### PR TITLE
fix: IPv6 socket address parsing for Docker deployments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,13 @@ async fn run(
     spacebot::update::spawn_update_checker(api_state.update_status.clone());
 
     let _http_handle = if config.api.enabled {
-        let bind: std::net::SocketAddr = format!("{}:{}", config.api.bind, config.api.port)
+        // IPv6 addresses need brackets when combined with port: [::]:19898
+        let bind_str = if config.api.bind.contains(':') {
+            format!("[{}]:{}", config.api.bind, config.api.port)
+        } else {
+            format!("{}:{}", config.api.bind, config.api.port)
+        };
+        let bind: std::net::SocketAddr = bind_str
             .parse()
             .context("invalid API bind address")?;
         let http_shutdown = shutdown_rx.clone();

--- a/src/messaging/webhook.rs
+++ b/src/messaging/webhook.rs
@@ -106,7 +106,11 @@ impl Messaging for WebhookAdapter {
             .route("/health", get(handle_health))
             .with_state(state);
 
-        let bind = format!("{}:{}", self.bind, self.port);
+        let bind = if self.bind.contains(':') {
+            format!("[{}]:{}", self.bind, self.port)
+        } else {
+            format!("{}:{}", self.bind, self.port)
+        };
         let listener = tokio::net::TcpListener::bind(&bind)
             .await
             .with_context(|| format!("failed to bind webhook server to {bind}"))?;


### PR DESCRIPTION
IPv6 addresses require brackets when combined with a port (e.g., [::]:19898 not :::19898). The docker-entrypoint.sh generates bind = :: for the API server, which caused a parse error when constructing the socket address.

Fixes #9
Fixes #12