### PR TITLE
feat(llm): add Ollama Cloud provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Read the full vision in [docs/spacedrive.md](docs/spacedrive.md).
 ### Prerequisites
 
 - **Rust** 1.85+ ([rustup](https://rustup.rs/))
-- An LLM API key from any supported provider (Anthropic, OpenAI, OpenRouter, Z.ai, Groq, Together, Fireworks, DeepSeek, xAI, Mistral, or OpenCode Zen)
+- An LLM API key from any supported provider (Anthropic, OpenAI, OpenRouter, Ollama Cloud, Z.ai, Groq, Together, Fireworks, DeepSeek, xAI, Mistral, or OpenCode Zen)
 
 ### Build and Run
 

--- a/interface/src/lib/providerIcons.tsx
+++ b/interface/src/lib/providerIcons.tsx
@@ -60,6 +60,7 @@ export function ProviderIcon({ provider, className = "text-ink-faint", size = 24
 		anthropic: Anthropic,
 		openai: OpenAI,
 		openrouter: OpenRouter,
+		ollama: OpenRouter,
 		groq: Groq,
 		mistral: Mistral,
 		deepseek: DeepSeek,

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -96,6 +96,13 @@ const PROVIDERS = [
 		envVar: "OPENAI_API_KEY",
 	},
 	{
+		id: "ollama",
+		name: "Ollama Cloud",
+		description: "Hosted Ollama models via OpenAI-compatible API",
+		placeholder: "ollama_...",
+		envVar: "OLLAMA_API_KEY",
+	},
+	{
 		id: "zhipu",
 		name: "Z.ai (GLM)",
 		description: "GLM models (GLM-4, GLM-4-Flash)",

--- a/src/llm/providers.rs
+++ b/src/llm/providers.rs
@@ -8,18 +8,26 @@ pub async fn init_providers(config: &LlmConfig) -> Result<()> {
     // Provider clients are initialized lazily through LlmManager
     // This module exists for any provider-specific setup that needs to happen
     // during system startup
-    
+
     if config.anthropic_key.is_some() {
         tracing::info!("Anthropic provider configured");
     }
-    
+
     if config.openai_key.is_some() {
         tracing::info!("OpenAI provider configured");
+    }
+
+    if config.openrouter_key.is_some() {
+        tracing::info!("OpenRouter provider configured");
+    }
+
+    if config.ollama_key.is_some() {
+        tracing::info!("Ollama provider configured");
     }
 
     if config.opencode_zen_key.is_some() {
         tracing::info!("OpenCode Zen provider configured");
     }
-    
+
     Ok(())
 }

--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -153,6 +153,20 @@ pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
                 rate_limit_cooldown_secs: 60,
             }
         }
+        "ollama" => {
+            let channel: String = "ollama/gpt-oss:120b".into();
+            let worker: String = "ollama/gpt-oss:20b".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+            }
+        }
         "zhipu" => {
             let channel: String = "zhipu/glm-4-plus".into();
             let worker: String = "zhipu/glm-4-flash".into();
@@ -277,6 +291,7 @@ pub fn provider_to_prefix(provider: &str) -> &str {
     match provider {
         "openrouter" => "openrouter/",
         "openai" => "openai/",
+        "ollama" => "ollama/",
         "anthropic" => "anthropic/",
         "zhipu" => "zhipu/",
         "groq" => "groq/",


### PR DESCRIPTION
Add Ollama Cloud provider support

- Add Ollama Cloud to README provider list
- Add provider config (key, env var, TOML support)
- Add Ollama option to onboarding CLI
- Add Ollama entry to Settings UI
- Add Ollama icon mapping (reuses OpenRouter icon)
- Add default model routing for Ollama (gpt-oss:120b/gpt-oss:20b)
- Add missing OpenRouter logging in provider init