### PR TITLE
feat(messaging): add native Matrix adapter with E2EE support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "accessory"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87537f9ae7cfa78d5b8ebd1a1db25959f5e737126be4d8eb44a5452fc4b63cde"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +182,12 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "approx"
@@ -490,6 +508,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as_variant"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+
+[[package]]
+name = "assign"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +764,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +828,12 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitpacking"
@@ -843,6 +893,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -947,6 +1006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1140,30 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "chromiumoxide"
@@ -1156,6 +1263,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1336,6 +1444,15 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -1529,6 +1646,34 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2254,6 +2399,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "date_header"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656f14fc1ab819c65f332045ea7cb38841bbe551f3b2bc7e3abefb559af4155c"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
+name = "decancer"
+version = "3.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9244323129647178bf41ac861a2cdb9d9c81b9b09d3d0d1de9cd302b33b8a1d"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "deepsize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2473,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "delegate-display"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a85201f233142ac819bbf6226e36d0b5e129a47bd325084674261c82d4cd66"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2510,6 +2724,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2916,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyeball"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93bd0ebf93d61d6332d3c09a96e97975968a44e19a64c947bde06e6baff383f"
+dependencies = [
+ "futures-core",
+ "readlock",
+ "readlock-tokio",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "eyeball-im"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c02432230060cae0621e15803e073976d22974e0f013c9cb28a4ea1b484629"
+dependencies = [
+ "futures-core",
+ "imbl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy_constructor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b19d0e43eae2bfbafe4931b5e79c73fb1a849ca15cd41a761a7b8587f9a1a2"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,6 +3028,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -3216,6 +3512,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "growable-bloom-filter"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d174ccb4ba660d431329e7f0797870d0a4281e36353ec4b4a3c5eab6c2cfb6f1"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,6 +3620,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -3786,6 +4128,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "imbl"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3be8d8cd36f33a46b1849f31f837c44d9fa87223baee3b4bd96b8f11df81eb"
+dependencies = [
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.6.4",
+ "rand_xoshiro 0.6.0",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +4173,23 @@ checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "indexed_db_futures"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43315957678a70eb21fb0d2384fe86dde0d6c859a01e24ce127eb65a0143d28c"
+dependencies = [
+ "accessory",
+ "cfg-if",
+ "delegate-display",
+ "fancy_constructor",
+ "js-sys",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3881,6 +4263,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4030,6 +4413,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "js_int"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f95470b270ce8b8950207715d71aa8e153c0d44c6684d59397ed4949160a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "js_option"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "json5"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4459,26 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "konst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4381b9b00c55f251f2ebe9473aef7c117e96828def1a7cb3bd3f0f903c6894e9"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -4129,7 +4550,7 @@ dependencies = [
  "object_store",
  "permutation",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "rand 0.9.2",
  "roaring",
@@ -4203,7 +4624,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "rand 0.9.2",
  "roaring",
  "serde_json",
@@ -4242,7 +4663,7 @@ dependencies = [
  "lance-geo",
  "log",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "snafu",
  "tokio",
  "tracing",
@@ -4264,7 +4685,7 @@ dependencies = [
  "hex",
  "rand 0.9.2",
  "rand_distr 0.5.1",
- "rand_xoshiro",
+ "rand_xoshiro 0.7.0",
  "random_word",
 ]
 
@@ -4295,7 +4716,7 @@ dependencies = [
  "log",
  "lz4",
  "num-traits",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4333,7 +4754,7 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "snafu",
@@ -4406,7 +4827,7 @@ dependencies = [
  "ndarray",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4454,7 +4875,7 @@ dependencies = [
  "object_store",
  "path_abs",
  "pin-project",
- "prost",
+ "prost 0.14.3",
  "rand 0.9.2",
  "serde",
  "shellexpand",
@@ -4559,7 +4980,7 @@ dependencies = [
  "lance-io",
  "log",
  "object_store",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "rand 0.9.2",
@@ -4897,6 +5318,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "macroific"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05c00ac596022625d01047c421a0d97d7f09a18e429187b341c201cb631b9dd"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "macroific_macro",
+]
+
+[[package]]
+name = "macroific_attr_parse"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd94d5da95b30ae6e10621ad02340909346ad91661f3f8c0f2b62345e46a2f67"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "macroific_core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13198c120864097a565ccb3ff947672d969932b7975ebd4085732c9f09435e55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "macroific_macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c9853143cbed7f1e41dc39fee95f9b361bec65c8dc2a01bf609be01b61f5ae"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4910,6 +5384,245 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrix-pickle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c34e6db65145740459f2ca56623b40cd4e6000ffae2a7d91515fa82aa935dbf"
+dependencies = [
+ "matrix-pickle-derive",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "matrix-pickle-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a962fc9981f823f6555416dcb2ae9ae67ca412d767ee21ecab5150113ee6285b"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "matrix-sdk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a99e79362e6d806d5b0102b8c58dca1f013a50f2f4bc5ffad1cb8dd6fcf43"
+dependencies = [
+ "anymap2",
+ "aquamarine",
+ "as_variant",
+ "async-channel",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "bytes",
+ "bytesize",
+ "event-listener",
+ "eyeball",
+ "eyeball-im",
+ "futures-core",
+ "futures-util",
+ "gloo-timers",
+ "growable-bloom-filter",
+ "http",
+ "imbl",
+ "indexmap 2.13.0",
+ "js_int",
+ "matrix-sdk-base",
+ "matrix-sdk-common",
+ "matrix-sdk-indexeddb",
+ "matrix-sdk-sqlite",
+ "mime",
+ "mime2ext",
+ "once_cell",
+ "pin-project-lite",
+ "reqwest",
+ "ruma",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "urlencoding",
+ "vodozemac",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-base"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6720c7df74eb1d4804af9d402cf56ba43873ae62f19b81857e96da6532e12e1a"
+dependencies = [
+ "as_variant",
+ "async-trait",
+ "bitflags 2.10.0",
+ "decancer",
+ "eyeball",
+ "eyeball-im",
+ "futures-util",
+ "growable-bloom-filter",
+ "matrix-sdk-common",
+ "matrix-sdk-crypto",
+ "matrix-sdk-store-encryption",
+ "once_cell",
+ "regex",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "matrix-sdk-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee4c56343d78cef759a0398b35bb192e508f203b3d697abe5a09dfcf17ff440"
+dependencies = [
+ "async-trait",
+ "eyeball-im",
+ "futures-core",
+ "futures-util",
+ "gloo-timers",
+ "imbl",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "matrix-sdk-crypto"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7395a7ee99668e7ce63643f1cee8abc11a05c60ab953bd298e762c3356f9aef0"
+dependencies = [
+ "aes",
+ "aquamarine",
+ "as_variant",
+ "async-trait",
+ "bs58",
+ "byteorder",
+ "cfg-if",
+ "ctr",
+ "eyeball",
+ "futures-core",
+ "futures-util",
+ "hkdf",
+ "hmac",
+ "itertools 0.13.0",
+ "js_option",
+ "matrix-sdk-common",
+ "pbkdf2",
+ "rand 0.8.5",
+ "rmp-serde",
+ "ruma",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "ulid",
+ "url",
+ "vodozemac",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-indexeddb"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f86434be7e6256a5d6e7828b887a4e91a42cd66380f8b02e02eeb702819589"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "gloo-utils",
+ "hkdf",
+ "indexed_db_futures",
+ "js-sys",
+ "matrix-sdk-crypto",
+ "matrix-sdk-store-encryption",
+ "ruma",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec5d5bf5de2de1874caba8c97ca7c1e9c7b3b50aba22fac0067f03bfa2416bf"
+dependencies = [
+ "async-trait",
+ "deadpool-sqlite",
+ "itertools 0.13.0",
+ "matrix-sdk-base",
+ "matrix-sdk-crypto",
+ "matrix-sdk-store-encryption",
+ "rmp-serde",
+ "ruma",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vodozemac",
+]
+
+[[package]]
+name = "matrix-sdk-store-encryption"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d702add6a56f288bf2e1a4e45145529620bff2003e746d7f23fc736ea806dbc8"
+dependencies = [
+ "base64 0.22.1",
+ "blake3",
+ "chacha20poly1305",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "zeroize",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -4973,6 +5686,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf6f36070878c42c5233846cd3de24cf9016828fd47bc22957a687298bb21fc"
 
 [[package]]
 name = "mime_guess"
@@ -5637,6 +6356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,6 +6532,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5933,12 +6673,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -5953,11 +6703,24 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "regex",
  "syn 2.0.114",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5979,7 +6742,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -6184,6 +6947,15 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
@@ -6304,6 +7076,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
 dependencies = [
  "erasable",
+]
+
+[[package]]
+name = "readlock"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da6f291b23556edd9edaf655a0be2ad8ef8002ff5f1bca62b264f3f58b53f34"
+
+[[package]]
+name = "readlock-tokio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e264f9ec4f3d112e8e2f214e8e7cb5cf3b83278f3570b7e00bfe13d3bd8ff"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -6520,6 +7307,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6618,6 +7424,158 @@ dependencies = [
  "rustc_version",
  "syn 2.0.114",
  "unicode-ident",
+]
+
+[[package]]
+name = "ruma"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
+dependencies = [
+ "assign",
+ "js_int",
+ "js_option",
+ "ruma-client-api",
+ "ruma-common",
+ "ruma-events",
+ "ruma-federation-api",
+ "web-time",
+]
+
+[[package]]
+name = "ruma-client-api"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
+dependencies = [
+ "as_variant",
+ "assign",
+ "bytes",
+ "date_header",
+ "http",
+ "js_int",
+ "js_option",
+ "maplit",
+ "ruma-common",
+ "ruma-events",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387e1898e868d32ff7b205e7db327361d5dcf635c00a8ae5865068607595a9cf"
+dependencies = [
+ "as_variant",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "getrandom 0.2.17",
+ "http",
+ "indexmap 2.13.0",
+ "js-sys",
+ "js_int",
+ "konst",
+ "percent-encoding",
+ "rand 0.8.5",
+ "regex",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-events"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f141b37dcd3cfa1199d6a13929db59be529b2c69107edc9f1702b81015e970b2"
+dependencies = [
+ "as_variant",
+ "indexmap 2.13.0",
+ "js_int",
+ "js_option",
+ "percent-encoding",
+ "regex",
+ "ruma-common",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "web-time",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-federation-api"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2a705c3911870782e036a3a8b676d0166c6c93800b84f6b8b23c981f78ef08"
+dependencies = [
+ "http",
+ "js_int",
+ "mime",
+ "ruma-common",
+ "ruma-events",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+dependencies = [
+ "js_int",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff13fbd6045a7278533390826de316d6116d8582ed828352661337b0c422e1c"
+dependencies = [
+ "cfg-if",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation",
+ "serde",
+ "syn 2.0.114",
+ "toml 0.8.23",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6999,6 +7957,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7036,6 +8015,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]
@@ -7440,6 +8432,7 @@ dependencies = [
  "lance-index",
  "lancedb",
  "libc",
+ "matrix-sdk",
  "mime_guess",
  "minijinja",
  "notify",
@@ -7569,7 +8562,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.13.0",
  "log",
  "memchr",
@@ -8375,6 +9368,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -8780,10 +9774,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "typewit"
+version = "1.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+dependencies = [
+ "typewit_proc_macros",
+]
+
+[[package]]
+name = "typewit_proc_macros"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"
@@ -8901,6 +9920,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8964,6 +9989,36 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vodozemac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4b56780b7827dd72c3c6398c3048752bebf8d1d84ec19b606b15dbc3c850b8"
+dependencies = [
+ "aes",
+ "arrayvec",
+ "base64 0.22.1",
+ "base64ct",
+ "cbc",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hkdf",
+ "hmac",
+ "matrix-pickle",
+ "prost 0.13.5",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "walkdir"
@@ -9184,6 +10239,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi"
@@ -9705,6 +10766,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9734,7 +10807,7 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]
@@ -9806,6 +10879,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,9 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Telegram
 teloxide = { version = "0.17", default-features = false, features = ["rustls"] }
 
+# Matrix
+matrix-sdk = { version = "0.9", default-features = false, features = ["e2e-encryption", "sqlite", "rustls-tls"] }
+
 # Stream utilities
 tokio-stream = "0.1"
 

--- a/docs/content/docs/(messaging)/matrix-setup.mdx
+++ b/docs/content/docs/(messaging)/matrix-setup.mdx
@@ -1,0 +1,194 @@
+---
+title: Matrix Setup
+description: Step-by-step guide to connect Spacebot to Matrix.
+---
+
+# Matrix Setup Guide
+
+How to connect Spacebot to Matrix so it can receive and respond to messages in Matrix rooms and DMs. The adapter uses [matrix-sdk](https://crates.io/crates/matrix-sdk) (Apache-2.0), linked directly into the binary with no sidecar or Docker dependency. End-to-end encryption (E2EE) is supported out of the box.
+
+## Create a Bot Account
+
+### 1. Choose a Homeserver
+
+Matrix is a decentralized protocol — you can use any homeserver:
+
+- **matrix.org** — the largest public homeserver, good for testing
+- **Self-hosted Synapse or Conduit** — recommended for production (no rate limits, full control)
+
+### 2. Register a Dedicated Account
+
+Register a new account for your bot on the homeserver of your choice. Use [Element](https://app.element.io) or any Matrix client.
+
+- Pick a clear bot username like `@spacebot:matrix.org`
+- Use a strong, unique password
+- Do **not** use your personal account — the bot will have its own device and crypto keys
+
+### 3. Invite the Bot to Rooms
+
+From your personal account, create or open a room and invite the bot's user ID. If `auto_join` is enabled in the config, the bot will accept the invite automatically.
+
+## Spacebot Configuration
+
+Add the following to your `config.toml`:
+
+```toml
+[llm]
+openrouter_key = "env:OPENROUTER_API_KEY"
+
+[defaults.routing]
+channel = "openrouter/anthropic/claude-sonnet-4-20250514"
+worker = "openrouter/anthropic/claude-haiku-4.5-20250514"
+
+[messaging.matrix]
+enabled = true
+homeserver_url = "https://matrix.org"
+user_id = "@mybot:matrix.org"
+password = "env:MATRIX_PASSWORD"
+# access_token = "env:MATRIX_ACCESS_TOKEN"  # alternative to password
+dm_allowed_users = ["@yourname:matrix.org"]
+auto_join = true
+# data_dir = ""  # optional, defaults to {instance_dir}/matrix_store
+
+[[agents]]
+id = "main"
+default = true
+
+# Route a specific room to the "main" agent
+[[bindings]]
+agent_id = "main"
+channel = "matrix"
+chat_id = "!roomid:matrix.org"
+```
+
+Set the environment variables:
+
+```bash
+export MATRIX_PASSWORD="your-bot-account-password"
+export OPENROUTER_API_KEY="your-openrouter-key-here"
+```
+
+### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `enabled` | Yes | Set to `true` to activate the adapter |
+| `homeserver_url` | Yes | Full URL of the Matrix homeserver |
+| `user_id` | Yes | Bot's Matrix user ID (`@user:server`) |
+| `password` | One of | Account password (mutually exclusive with `access_token`) |
+| `access_token` | One of | Pre-existing access token (skips login) |
+| `dm_allowed_users` | No | List of user IDs allowed to DM the bot. Empty = all DMs accepted |
+| `data_dir` | No | Directory for SDK state/crypto keys. Defaults to `{instance_dir}/matrix_store` |
+| `auto_join` | No | Auto-accept room invites. Default: `false` |
+
+### Environment Variables
+
+All fields support `env:VAR_NAME` syntax, or you can set them directly:
+
+- `MATRIX_HOMESERVER_URL`
+- `MATRIX_USER_ID`
+- `MATRIX_PASSWORD`
+- `MATRIX_ACCESS_TOKEN`
+
+### Getting Room IDs
+
+Matrix room IDs look like `!abc123:matrix.org`. To find one:
+
+- **Element**: Open room Settings → Advanced → scroll to "Internal room ID"
+- **Other clients**: Check room info/details for the internal ID
+
+Room IDs always start with `!` and contain a colon.
+
+### Getting User IDs
+
+Matrix user IDs have the format `@username:homeserver.com`. You can see your own in your client's profile/settings.
+
+### Open Access (No Room Filter)
+
+To respond in any room the bot is a member of, omit `chat_id` from the binding:
+
+```toml
+[[bindings]]
+agent_id = "main"
+channel = "matrix"
+```
+
+### DM Access Control
+
+By default, DMs from anyone are accepted. To restrict DMs to specific users:
+
+```toml
+[messaging.matrix]
+enabled = true
+homeserver_url = "https://matrix.org"
+user_id = "@mybot:matrix.org"
+password = "env:MATRIX_PASSWORD"
+dm_allowed_users = ["@alice:matrix.org", "@bob:matrix.org"]
+```
+
+When `dm_allowed_users` is empty (the default), all DMs are accepted. When populated, only listed user IDs can DM the bot.
+
+### Multiple Rooms, Multiple Agents
+
+Route different Matrix rooms to different agents:
+
+```toml
+[[agents]]
+id = "community"
+default = true
+
+[[agents]]
+id = "team"
+
+[[bindings]]
+agent_id = "community"
+channel = "matrix"
+chat_id = "!community123:matrix.org"
+
+[[bindings]]
+agent_id = "team"
+channel = "matrix"
+chat_id = "!team456:matrix.org"
+```
+
+## End-to-End Encryption
+
+E2EE works automatically. The bot can participate in encrypted rooms without any extra configuration.
+
+- **Crypto keys** are persisted in the `data_dir` (default: `{instance_dir}/matrix_store`). Back up this directory if you need to preserve encryption state.
+- **First run** creates a new Matrix device. Other users in the room may see a "new device" notification and may need to verify it (or configure their client to trust cross-signed devices).
+- **Restarting** reuses the same device and session, so keys are preserved across restarts.
+
+## Platform Notes
+
+### Message Limits
+
+Matrix messages are capped at 4096 characters. Longer messages are automatically split at newlines, then spaces, then hard-cut.
+
+### Typing Indicators
+
+The bot sends typing notifications while processing. Matrix typing indicators expire after ~4 seconds, so the bot repeats them until a response is ready.
+
+### Streaming
+
+Responses stream via message edits — a `...` placeholder is sent immediately, then edited in-place as content arrives. Edits are throttled to every 300ms to avoid flooding the homeserver.
+
+### History Backfill
+
+Matrix is the first adapter to support history backfill. When a conversation starts, the bot can fetch previous messages from the room to build context. Configure `history_backfill_count` in the agent's tuning section.
+
+### Auto-Join
+
+When `auto_join = true`, the bot automatically accepts room invites. When disabled, you must manually accept invites from the bot account.
+
+### Rate Limits
+
+matrix.org enforces rate limits on message sending (~10 messages/sec). Self-hosted homeservers can be configured without limits. If you hit rate limits, you'll see errors in the logs — the bot will retry automatically.
+
+### Reactions
+
+The bot can send reaction events. Matrix supports arbitrary Unicode reactions (unlike Telegram which has a restricted set).
+
+### File Attachments
+
+The bot can receive file attachments (images, documents, audio, video). Received files are passed as attachment metadata with `mxc://` URLs resolved to HTTP download URLs.

--- a/docs/content/docs/(messaging)/meta.json
+++ b/docs/content/docs/(messaging)/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Messaging",
-  "pages": ["messaging", "discord-setup", "slack-setup", "telegram-setup"]
+  "pages": ["messaging", "discord-setup", "slack-setup", "telegram-setup", "matrix-setup"]
 }

--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -8,6 +8,11 @@
 			"name": "spacebot-interface",
 			"version": "0.1.0",
 			"dependencies": {
+				"@codemirror/language": "^6.12.1",
+				"@codemirror/legacy-modes": "^6.5.2",
+				"@codemirror/state": "^6.5.4",
+				"@codemirror/theme-one-dark": "^6.1.3",
+				"@codemirror/view": "^6.39.14",
 				"@fontsource/ibm-plex-sans": "^5.1.0",
 				"@fortawesome/fontawesome-svg-core": "^7.2.0",
 				"@fortawesome/free-brands-svg-icons": "^7.2.0",
@@ -16,6 +21,7 @@
 				"@hookform/resolvers": "^5.2.2",
 				"@hugeicons/core-free-icons": "^3.1.1",
 				"@hugeicons/react": "^1.1.5",
+				"@lobehub/icons": "^4.6.0",
 				"@radix-ui/react-checkbox": "^1.3.3",
 				"@radix-ui/react-dialog": "^1.1.15",
 				"@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -33,6 +39,7 @@
 				"@tanstack/router-devtools": "^1.159.5",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
+				"codemirror": "^6.0.2",
 				"framer-motion": "^12.34.0",
 				"graphology": "^0.26.0",
 				"graphology-layout-forceatlas2": "^0.10.1",
@@ -44,6 +51,7 @@
 				"recharts": "^3.7.0",
 				"remark-gfm": "^4.0.1",
 				"sigma": "^3.0.2",
+				"smol-toml": "^1.6.0",
 				"sonner": "^2.0.7",
 				"zod": "^4.3.6"
 			},
@@ -71,9 +79,121 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@ant-design/colors": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+			"integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/fast-color": "^3.0.0"
+			}
+		},
+		"node_modules/@ant-design/cssinjs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz",
+			"integrity": "sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@emotion/hash": "^0.8.0",
+				"@emotion/unitless": "^0.7.5",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1",
+				"csstype": "^3.1.3",
+				"stylis": "^4.3.4"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@ant-design/cssinjs-utils": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz",
+			"integrity": "sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.1.0",
+				"@babel/runtime": "^7.23.2",
+				"@rc-component/util": "^1.4.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@ant-design/fast-color": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+			"integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8.x"
+			}
+		},
+		"node_modules/@ant-design/icons": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
+			"integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/colors": "^8.0.0",
+				"@ant-design/icons-svg": "^4.4.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@ant-design/icons-svg": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+			"integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@ant-design/react-slick": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+			"integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"clsx": "^2.1.1",
+				"json2mq": "^0.2.0",
+				"throttle-debounce": "^5.0.0"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@antfu/install-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"package-manager-detector": "^1.3.0",
+				"tinyexec": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -123,7 +243,6 @@
 		},
 		"node_modules/@babel/generator": {
 			"version": "7.29.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
@@ -153,7 +272,6 @@
 		},
 		"node_modules/@babel/helper-globals": {
 			"version": "7.28.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -161,7 +279,6 @@
 		},
 		"node_modules/@babel/helper-module-imports": {
 			"version": "7.28.6",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.28.6",
@@ -197,7 +314,6 @@
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -205,7 +321,6 @@
 		},
 		"node_modules/@babel/helper-validator-identifier": {
 			"version": "7.28.5",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -233,7 +348,6 @@
 		},
 		"node_modules/@babel/parser": {
 			"version": "7.29.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.0"
@@ -273,9 +387,17 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/runtime": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/template": {
 			"version": "7.28.6",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
@@ -288,7 +410,6 @@
 		},
 		"node_modules/@babel/traverse": {
 			"version": "7.29.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
@@ -305,7 +426,6 @@
 		},
 		"node_modules/@babel/types": {
 			"version": "7.29.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -313,6 +433,567 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@base-ui/react": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.0.0.tgz",
+			"integrity": "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"@base-ui/utils": "0.2.3",
+				"@floating-ui/react-dom": "^2.1.6",
+				"@floating-ui/utils": "^0.2.10",
+				"reselect": "^5.1.1",
+				"tabbable": "^6.3.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.3.tgz",
+			"integrity": "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"@floating-ui/utils": "^0.2.10",
+				"reselect": "^5.1.1",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@chevrotain/cst-dts-gen": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.1.tgz",
+			"integrity": "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/gast": "11.1.1",
+				"@chevrotain/types": "11.1.1",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/@chevrotain/gast": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.1.tgz",
+			"integrity": "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/types": "11.1.1",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/@chevrotain/regexp-to-ast": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.1.tgz",
+			"integrity": "sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@chevrotain/types": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.1.tgz",
+			"integrity": "sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@chevrotain/utils": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.1.tgz",
+			"integrity": "sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.17.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+			"integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.4.0",
+				"@codemirror/view": "^6.27.0",
+				"@lezer/common": "^1.1.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.1.tgz",
+			"integrity": "sha512-Fa6xkSiuGKc8XC8Cn96T+TQHYj4ZZ7RdFmXA3i9xe/3hLHfwPZdM+dqfX0Cp0zQklBKhVD8Yzc8LS45rkqcwpQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.5.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/legacy-modes": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+			"integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0"
+			}
+		},
+		"node_modules/@codemirror/lint": {
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.4.tgz",
+			"integrity": "sha512-ABc9vJ8DEmvOWuH26P3i8FpMWPQkduD9Rvba5iwb6O3hxASgclm3T3krGo8NASXkHCidz6b++LWlzWIUfEPSWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.35.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+			"integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.37.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+			"integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+			"license": "MIT",
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/theme-one-dark": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+			"integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/highlight": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.39.14",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.14.tgz",
+			"integrity": "sha512-WJcvgHm/6Q7dvGT0YFv/6PSkoc36QlR0VCESS6x9tGsnF1lWLmmYxOgX3HH6v8fo6AvSLgpcs+H0Olre6MKXlg==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emoji-mart/data": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+			"integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@emoji-mart/react": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+			"integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"emoji-mart": "^5.2",
+				"react": "^16.8 || ^17 || ^18"
+			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.3.3",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/cache/node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/css": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+			"integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.13.5",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.2",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+			"license": "MIT"
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
@@ -325,6 +1006,363 @@
 			"optional": true,
 			"os": [
 				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -347,6 +1385,22 @@
 			"dependencies": {
 				"@floating-ui/core": "^1.7.4",
 				"@floating-ui/utils": "^0.2.10"
+			}
+		},
+		"node_modules/@floating-ui/react": {
+			"version": "0.27.18",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.18.tgz",
+			"integrity": "sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.1.7",
+				"@floating-ui/utils": "^0.2.10",
+				"tabbable": "^6.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=17.0.0",
+				"react-dom": ">=17.0.0"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
@@ -445,6 +1499,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@giscus/react": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+			"integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+			"peer": true,
+			"dependencies": {
+				"giscus": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16 || ^17 || ^18 || ^19",
+				"react-dom": "^16 || ^17 || ^18 || ^19"
+			}
+		},
 		"node_modules/@hookform/resolvers": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -472,9 +1539,27 @@
 				"react": ">=16.0.0"
 			}
 		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@iconify/utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+			"integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@antfu/install-pkg": "^1.1.0",
+				"@iconify/types": "^2.0.0",
+				"mlly": "^1.8.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -492,7 +1577,6 @@
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -500,16 +1584,307 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@lezer/common": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+			"integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.3.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lit-labs/ssr-dom-shim": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+			"integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@lit/reactive-element": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+			"integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0"
+			}
+		},
+		"node_modules/@lobehub/emojilib": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/emojilib/-/emojilib-1.0.0.tgz",
+			"integrity": "sha512-s9KnjaPjsEefaNv150G3aifvB+J3P4eEKG+epY9zDPS2BeB6+V2jELWqAZll+nkogMaVovjEE813z3V751QwGw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@lobehub/fluent-emoji": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/fluent-emoji/-/fluent-emoji-4.1.0.tgz",
+			"integrity": "sha512-R1MB2lfUkDvB7XAQdRzY75c1dx/tB7gEvBPaEEMarzKfCJWmXm7rheS6caVzmgwAlq5sfmTbxPL+un99sp//Yw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@lobehub/emojilib": "^1.0.0",
+				"antd-style": "^4.1.0",
+				"emoji-regex": "^10.6.0",
+				"es-toolkit": "^1.43.0",
+				"lucide-react": "^0.562.0",
+				"url-join": "^5.0.0"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/icons": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/icons/-/icons-4.6.0.tgz",
+			"integrity": "sha512-TuU0837kalurxQfGwfyd6UODwKtPluhvuT8XrgqHo/D0B/ggbYWrLF1pwIYG+p9ccA6oz6HeaEQhmNH2eQl2sw==",
+			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
+			"dependencies": {
+				"antd-style": "^4.1.0",
+				"lucide-react": "^0.469.0",
+				"polished": "^4.3.1"
+			},
+			"peerDependencies": {
+				"@lobehub/ui": "^4.3.3",
+				"antd": "^6.1.1",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/icons/node_modules/lucide-react": {
+			"version": "0.469.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+			"integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/ui": {
+			"version": "4.38.4",
+			"resolved": "https://registry.npmjs.org/@lobehub/ui/-/ui-4.38.4.tgz",
+			"integrity": "sha512-FYQeWkR0CoZCaPqEX9AUGrhaIfkYeuacW2KtV+1GS7eGVjREFNNOAgY5PLk20ZMYV/cRFsn9fNG0rqn9PxChxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.0.3",
+				"@base-ui/react": "1.0.0",
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
+				"@emoji-mart/data": "^1.2.1",
+				"@emoji-mart/react": "^1.1.1",
+				"@emotion/is-prop-valid": "^1.4.0",
+				"@floating-ui/react": "^0.27.17",
+				"@giscus/react": "^3.1.0",
+				"@mdx-js/mdx": "^3.1.1",
+				"@mdx-js/react": "^3.1.1",
+				"@pierre/diffs": "^1.0.10",
+				"@radix-ui/react-slot": "^1.2.4",
+				"@shikijs/core": "^3.22.0",
+				"@shikijs/transformers": "^3.22.0",
+				"@splinetool/runtime": "0.9.526",
+				"ahooks": "^3.9.6",
+				"antd-style": "^4.1.0",
+				"chroma-js": "^3.2.0",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"dayjs": "^1.11.19",
+				"emoji-mart": "^5.6.0",
+				"es-toolkit": "^1.44.0",
+				"fast-deep-equal": "^3.1.3",
+				"immer": "^11.1.3",
+				"katex": "^0.16.28",
+				"leva": "^0.10.1",
+				"lucide-react": "^0.563.0",
+				"marked": "^17.0.1",
+				"mermaid": "^11.12.2",
+				"motion": "^12.30.0",
+				"numeral": "^2.0.6",
+				"polished": "^4.3.1",
+				"query-string": "^9.3.1",
+				"rc-collapse": "^4.0.0",
+				"rc-footer": "^0.6.8",
+				"rc-image": "^7.12.0",
+				"rc-input-number": "^9.5.0",
+				"rc-menu": "^9.16.1",
+				"re-resizable": "^6.11.2",
+				"react-avatar-editor": "^14.0.0",
+				"react-error-boundary": "^6.1.0",
+				"react-hotkeys-hook": "^5.2.4",
+				"react-markdown": "^10.1.0",
+				"react-merge-refs": "^3.0.2",
+				"react-rnd": "^10.5.2",
+				"react-zoom-pan-pinch": "^3.7.0",
+				"rehype-github-alerts": "^4.2.0",
+				"rehype-katex": "^7.0.1",
+				"rehype-raw": "^7.0.0",
+				"remark-breaks": "^4.0.0",
+				"remark-cjk-friendly": "^1.2.3",
+				"remark-gfm": "^4.0.1",
+				"remark-github": "^12.0.0",
+				"remark-math": "^6.0.0",
+				"remend": "^1.2.0",
+				"shiki": "^3.22.0",
+				"shiki-stream": "^0.1.4",
+				"swr": "^2.4.0",
+				"ts-md5": "^2.0.1",
+				"unified": "^11.0.5",
+				"url-join": "^5.0.0",
+				"use-merge-value": "^1.2.0",
+				"uuid": "^13.0.0",
+				"virtua": "^0.48.5"
+			},
+			"peerDependencies": {
+				"@lobehub/fluent-emoji": "^4.0.0",
+				"@lobehub/icons": "^4.0.0",
+				"antd": "^6.1.1",
+				"motion": "^12.0.0",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/ui/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+			"integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@lobehub/ui/node_modules/immer": {
+			"version": "11.1.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+			"integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/@lobehub/ui/node_modules/lucide-react": {
+			"version": "0.563.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+			"integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"license": "MIT"
+		},
+		"node_modules/@mdx-js/mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+			"integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdx": "^2.0.0",
+				"acorn": "^8.0.0",
+				"collapse-white-space": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-util-scope": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"markdown-extensions": "^2.0.0",
+				"recma-build-jsx": "^1.0.0",
+				"recma-jsx": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"rehype-recma": "^1.0.0",
+				"remark-mdx": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"source-map": "^0.7.0",
+				"unified": "^11.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@mdx-js/react": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdx": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16",
+				"react": ">=16"
+			}
+		},
+		"node_modules/@mermaid-js/parser": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
+			"integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"langium": "^4.0.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -579,6 +1954,27 @@
 				"@parcel/watcher-win32-x64": "2.5.6"
 			}
 		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
 			"version": "2.5.6",
 			"cpu": [
@@ -596,6 +1992,267 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@pierre/diffs": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.0.11.tgz",
+			"integrity": "sha512-j6zIEoyImQy1HfcJqbrDwP0O5I7V2VNXAaw53FqQ+SykRfaNwABeZHs9uibXO4supaXPmTx6LEH9Lffr03e1Tw==",
+			"license": "apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "^3.0.0",
+				"@shikijs/engine-javascript": "^3.0.0",
+				"@shikijs/transformers": "^3.0.0",
+				"diff": "8.0.3",
+				"hast-util-to-html": "9.0.5",
+				"lru_map": "0.4.1",
+				"shiki": "^3.0.0"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1 || ^19.0.0",
+				"react-dom": "^18.3.1 || ^19.0.0"
+			}
+		},
+		"node_modules/@primer/octicons": {
+			"version": "19.22.0",
+			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.22.0.tgz",
+			"integrity": "sha512-nWoh9PlE6u7xbiZF3KcUm3ktLpN2rQPt11trwp/t4EsKuYRNVWVbBp1LkCBsvZq7ScckNKUURLigIU0wS1FQdw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"object-assign": "^4.1.1"
 			}
 		},
 		"node_modules/@radix-ui/number": {
@@ -1479,6 +3136,767 @@
 			"integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
 			"license": "MIT"
 		},
+		"node_modules/@rc-component/async-validator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
+			"integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.24.4"
+			},
+			"engines": {
+				"node": ">=14.x"
+			}
+		},
+		"node_modules/@rc-component/cascader": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
+			"integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/select": "~1.6.0",
+				"@rc-component/tree": "~1.2.0",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/checkbox": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+			"integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/collapse": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+			"integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/color-picker": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.0.tgz",
+			"integrity": "sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/fast-color": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/context": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
+			"integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/dialog": {
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
+			"integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.3",
+				"@rc-component/portal": "^2.1.0",
+				"@rc-component/util": "^1.9.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/drawer": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+			"integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.1.3",
+				"@rc-component/util": "^1.9.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/dropdown": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+			"integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.11.0",
+				"react-dom": ">=16.11.0"
+			}
+		},
+		"node_modules/@rc-component/form": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.6.2.tgz",
+			"integrity": "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/async-validator": "^5.1.0",
+				"@rc-component/util": "^1.6.2",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/image": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.6.0.tgz",
+			"integrity": "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.0.0",
+				"@rc-component/portal": "^2.1.2",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/input": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
+			"integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@rc-component/input-number": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+			"integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/mini-decimal": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mentions": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
+			"integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/input": "~1.1.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/textarea": "~1.1.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/menu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
+			"integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mini-decimal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
+			"integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			}
+		},
+		"node_modules/@rc-component/motion": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.1.6.tgz",
+			"integrity": "sha512-aEQobs/YA0kqRvHIPjQvOytdtdRVyhf/uXAal4chBjxDu6odHckExJzjn2D+Ju1aKK6hx3pAs6BXdV9+86xkgQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mutate-observer": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+			"integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/notification": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
+			"integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/overflow": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.0.tgz",
+			"integrity": "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/pagination": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
+			"integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/picker": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.0.tgz",
+			"integrity": "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/trigger": "^3.6.15",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"date-fns": ">= 2.x",
+				"dayjs": ">= 1.x",
+				"luxon": ">= 3.x",
+				"moment": ">= 2.x",
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			},
+			"peerDependenciesMeta": {
+				"date-fns": {
+					"optional": true
+				},
+				"dayjs": {
+					"optional": true
+				},
+				"luxon": {
+					"optional": true
+				},
+				"moment": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rc-component/portal": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
+			"integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/progress": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+			"integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/qrcode": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
+			"integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/rate": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+			"integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/resize-observer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.1.tgz",
+			"integrity": "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/segmented": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+			"integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@rc-component/select": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.10.tgz",
+			"integrity": "sha512-y4+2LnyGZrAorIBwflk78PmFVUWcSc9pcljiH72oHj7K1YY/BFUmj224pD7P4o7J+tbIFES45Z7LIpjVmvYlNA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/slider": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+			"integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/steps": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+			"integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/switch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+			"integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/table": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
+			"integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/context": "^2.0.1",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.1.0",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/tabs": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
+			"integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/dropdown": "~1.0.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/motion": "^1.1.3",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/textarea": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
+			"integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/input": "~1.1.0",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/tooltip": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+			"integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/trigger": "^3.7.1",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/tour": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
+			"integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/portal": "^2.2.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/tree": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz",
+			"integrity": "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.0.0",
+				"@rc-component/util": "^1.8.1",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=10.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/tree-select": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
+			"integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/select": "~1.6.0",
+				"@rc-component/tree": "~1.2.0",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/trigger": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
+			"integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.2.0",
+				"@rc-component/resize-observer": "^1.1.1",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/upload": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
+			"integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-mobile": "^5.0.0",
+				"react-is": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/util/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT"
+		},
+		"node_modules/@rc-component/virtual-list": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
+			"integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.0",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
 		"node_modules/@react-sigma/core": {
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/@react-sigma/core/-/core-5.0.6.tgz",
@@ -1527,6 +3945,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+			"integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+			"integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
 			"version": "4.57.1",
 			"cpu": [
@@ -1539,6 +3985,409 @@
 				"darwin"
 			]
 		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+			"integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+			"integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+			"integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+			"integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+			"integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+			"integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+			"integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+			"integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+			"integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+			"integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+			"integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+			"integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+			"integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+			"integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+			"integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+			"integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+			"integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+			"integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+			"integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@shikijs/core": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.22.0.tgz",
+			"integrity": "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.22.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.22.0.tgz",
+			"integrity": "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.22.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.4"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
+			"integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.22.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
+			"integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.22.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
+			"integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.22.0"
+			}
+		},
+		"node_modules/@shikijs/transformers": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.22.0.tgz",
+			"integrity": "sha512-E7eRV7mwDBjueLF6852n2oYeJYxBq3NSsDk+uyruYAXONv4U8holGmIrT+mPRJQ1J1SNOH6L8G19KRzmBawrFw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "3.22.0",
+				"@shikijs/types": "3.22.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
+			"integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@splinetool/runtime": {
+			"version": "0.9.526",
+			"resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-0.9.526.tgz",
+			"integrity": "sha512-qznHbXA5aKwDbCgESAothCNm1IeEZcmNWG145p5aXj4w5uoqR1TZ9qkTHTKLTsUbHeitCwdhzmRqan1kxboLgQ==",
+			"peer": true,
+			"dependencies": {
+				"on-change": "^4.0.0",
+				"semver-compare": "^1.0.0"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"license": "MIT"
@@ -1546,6 +4395,16 @@
 		"node_modules/@standard-schema/utils": {
 			"version": "0.3.0",
 			"license": "MIT"
+		},
+		"node_modules/@stitches/react": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+			"integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">= 16.3.0"
+			}
 		},
 		"node_modules/@tanstack/history": {
 			"version": "1.154.14",
@@ -1784,17 +4643,166 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/d3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/d3-axis": "*",
+				"@types/d3-brush": "*",
+				"@types/d3-chord": "*",
+				"@types/d3-color": "*",
+				"@types/d3-contour": "*",
+				"@types/d3-delaunay": "*",
+				"@types/d3-dispatch": "*",
+				"@types/d3-drag": "*",
+				"@types/d3-dsv": "*",
+				"@types/d3-ease": "*",
+				"@types/d3-fetch": "*",
+				"@types/d3-force": "*",
+				"@types/d3-format": "*",
+				"@types/d3-geo": "*",
+				"@types/d3-hierarchy": "*",
+				"@types/d3-interpolate": "*",
+				"@types/d3-path": "*",
+				"@types/d3-polygon": "*",
+				"@types/d3-quadtree": "*",
+				"@types/d3-random": "*",
+				"@types/d3-scale": "*",
+				"@types/d3-scale-chromatic": "*",
+				"@types/d3-selection": "*",
+				"@types/d3-shape": "*",
+				"@types/d3-time": "*",
+				"@types/d3-time-format": "*",
+				"@types/d3-timer": "*",
+				"@types/d3-transition": "*",
+				"@types/d3-zoom": "*"
+			}
+		},
 		"node_modules/@types/d3-array": {
 			"version": "3.2.2",
 			"license": "MIT"
+		},
+		"node_modules/@types/d3-axis": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-brush": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-chord": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/d3-color": {
 			"version": "3.1.3",
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-dispatch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-drag": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-dsv": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/d3-ease": {
 			"version": "3.0.2",
 			"license": "MIT"
+		},
+		"node_modules/@types/d3-fetch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-dsv": "*"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-format": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/d3-interpolate": {
 			"version": "3.0.4",
@@ -1807,12 +4815,47 @@
 			"version": "3.1.1",
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-polygon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-quadtree": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-random": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/d3-scale": {
 			"version": "4.0.9",
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-time": "*"
 			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-selection": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/d3-shape": {
 			"version": "3.1.8",
@@ -1825,9 +4868,37 @@
 			"version": "3.0.4",
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-time-format": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/d3-timer": {
 			"version": "3.0.2",
 			"license": "MIT"
+		},
+		"node_modules/@types/d3-transition": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-zoom": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-interpolate": "*",
+				"@types/d3-selection": "*"
+			}
 		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
@@ -1847,12 +4918,33 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "*"
 			}
+		},
+		"node_modules/@types/js-cookie": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+			"integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/mdast": {
 			"version": "4.0.4",
@@ -1861,8 +4953,21 @@
 				"@types/unist": "*"
 			}
 		},
+		"node_modules/@types/mdx": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+			"integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/ms": {
 			"version": "2.1.0",
+			"license": "MIT"
+		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
@@ -1880,6 +4985,13 @@
 				"@types/react": "^19.2.0"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"license": "MIT"
@@ -1891,6 +5003,26 @@
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.3.0",
 			"license": "ISC"
+		},
+		"node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "4.7.0",
@@ -1909,6 +5041,137 @@
 			},
 			"peerDependencies": {
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/ahooks": {
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/ahooks/-/ahooks-3.9.6.tgz",
+			"integrity": "sha512-Mr7f05swd5SmKlR9SZo5U6M0LsL4ErweLzpdgXjA1JPmnZ78Vr6wzx0jUtvoxrcqGKYnX0Yjc02iEASVxHFPjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@types/js-cookie": "^3.0.6",
+				"dayjs": "^1.9.1",
+				"intersection-observer": "^0.12.0",
+				"js-cookie": "^3.0.5",
+				"lodash": "^4.17.21",
+				"react-fast-compare": "^3.2.2",
+				"resize-observer-polyfill": "^1.5.1",
+				"screenfull": "^5.0.0",
+				"tslib": "^2.4.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/antd": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/antd/-/antd-6.3.0.tgz",
+			"integrity": "sha512-bbHJcASrRHp02wTpr940KtUHlTT6tvmaD4OAjqgOJXNmTQ/+qBDdBVWY/yeDV41p/WbWjTLlaqRGVbL3UEVpNw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/colors": "^8.0.1",
+				"@ant-design/cssinjs": "^2.1.0",
+				"@ant-design/cssinjs-utils": "^2.1.1",
+				"@ant-design/fast-color": "^3.0.1",
+				"@ant-design/icons": "^6.1.0",
+				"@ant-design/react-slick": "~2.0.0",
+				"@babel/runtime": "^7.28.4",
+				"@rc-component/cascader": "~1.14.0",
+				"@rc-component/checkbox": "~2.0.0",
+				"@rc-component/collapse": "~1.2.0",
+				"@rc-component/color-picker": "~3.1.0",
+				"@rc-component/dialog": "~1.8.4",
+				"@rc-component/drawer": "~1.4.2",
+				"@rc-component/dropdown": "~1.0.2",
+				"@rc-component/form": "~1.6.2",
+				"@rc-component/image": "~1.6.0",
+				"@rc-component/input": "~1.1.2",
+				"@rc-component/input-number": "~1.6.2",
+				"@rc-component/mentions": "~1.6.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/motion": "~1.1.6",
+				"@rc-component/mutate-observer": "^2.0.1",
+				"@rc-component/notification": "~1.2.0",
+				"@rc-component/pagination": "~1.2.0",
+				"@rc-component/picker": "~1.9.0",
+				"@rc-component/progress": "~1.0.2",
+				"@rc-component/qrcode": "~1.1.1",
+				"@rc-component/rate": "~1.0.1",
+				"@rc-component/resize-observer": "^1.1.1",
+				"@rc-component/segmented": "~1.3.0",
+				"@rc-component/select": "~1.6.5",
+				"@rc-component/slider": "~1.0.1",
+				"@rc-component/steps": "~1.2.2",
+				"@rc-component/switch": "~1.0.3",
+				"@rc-component/table": "~1.9.1",
+				"@rc-component/tabs": "~1.7.0",
+				"@rc-component/textarea": "~1.1.2",
+				"@rc-component/tooltip": "~1.4.0",
+				"@rc-component/tour": "~2.3.0",
+				"@rc-component/tree": "~1.2.3",
+				"@rc-component/tree-select": "~1.8.0",
+				"@rc-component/trigger": "^3.9.0",
+				"@rc-component/upload": "~1.1.0",
+				"@rc-component/util": "^1.9.0",
+				"clsx": "^2.1.1",
+				"dayjs": "^1.11.11",
+				"scroll-into-view-if-needed": "^3.1.0",
+				"throttle-debounce": "^5.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ant-design"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/antd-style": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/antd-style/-/antd-style-4.1.0.tgz",
+			"integrity": "sha512-vnPBGg0OVlSz90KRYZhxd89aZiOImTiesF+9MQqN8jsLGZUQTjbP04X9jTdEfsztKUuMbBWg/RmB/wHTakbtMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.0.0",
+				"@babel/runtime": "^7.24.1",
+				"@emotion/cache": "^11.11.0",
+				"@emotion/css": "^11.11.2",
+				"@emotion/react": "^11.11.4",
+				"@emotion/serialize": "^1.1.3",
+				"@emotion/utils": "^1.2.1",
+				"use-merge-value": "^1.2.0"
+			},
+			"peerDependencies": {
+				"antd": ">=6.0.0",
+				"react": ">=18"
 			}
 		},
 		"node_modules/any-promise": {
@@ -1956,6 +5219,36 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/astring": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+			"integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"astring": "bin/astring"
+			}
+		},
+		"node_modules/attr-accept": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+			"integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.24",
 			"dev": true,
@@ -1989,6 +5282,21 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/bail": {
@@ -2061,6 +5369,15 @@
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
 			"dev": true,
@@ -2128,6 +5445,34 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/chevrotain": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
+			"integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/cst-dts-gen": "11.1.1",
+				"@chevrotain/gast": "11.1.1",
+				"@chevrotain/regexp-to-ast": "11.1.1",
+				"@chevrotain/types": "11.1.1",
+				"@chevrotain/utils": "11.1.1",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/chevrotain-allstar": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lodash-es": "^4.17.21"
+			},
+			"peerDependencies": {
+				"chevrotain": "^11.0.0"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"dev": true,
@@ -2142,6 +5487,13 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/chroma-js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+			"integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+			"license": "(BSD-3-Clause AND Apache-2.0)",
+			"peer": true
+		},
 		"node_modules/class-variance-authority": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -2154,12 +5506,52 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
+		"node_modules/classnames": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/codemirror": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+			"integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/commands": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/lint": "^6.0.0",
+				"@codemirror/search": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -2177,6 +5569,20 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/compute-scroll-into-view": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+			"integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"dev": true,
@@ -2184,6 +5590,47 @@
 		},
 		"node_modules/cookie-es": {
 			"version": "2.0.0",
+			"license": "MIT"
+		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
+		},
+		"node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"license": "MIT"
 		},
 		"node_modules/cssesc": {
@@ -2201,11 +5648,146 @@
 			"version": "3.2.3",
 			"license": "MIT"
 		},
+		"node_modules/cytoscape": {
+			"version": "3.33.1",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-array": {
 			"version": "3.2.4",
 			"license": "ISC",
 			"dependencies": {
 				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-path": "1 - 3"
 			},
 			"engines": {
 				"node": ">=12"
@@ -2218,6 +5800,92 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/d3-ease": {
 			"version": "3.0.1",
 			"license": "BSD-3-Clause",
@@ -2225,9 +5893,60 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-format": {
 			"version": "3.1.2",
 			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -2249,6 +5968,81 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"license": "ISC",
+			"peer": true
+		},
 		"node_modules/d3-scale": {
 			"version": "4.0.2",
 			"license": "ISC",
@@ -2259,6 +6053,30 @@
 				"d3-time": "2.1.1 - 3",
 				"d3-time-format": "2 - 4"
 			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -2300,6 +6118,61 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
+			"integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
+			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.19",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"license": "MIT",
@@ -2328,6 +6201,26 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/decode-uri-component": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+			"integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/delaunator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+			"integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
 			}
 		},
 		"node_modules/dequal": {
@@ -2368,15 +6261,71 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dompurify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"peer": true,
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.286",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/emoji-mart": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+			"integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
 		},
 		"node_modules/es-toolkit": {
 			"version": "1.44.0",
@@ -2385,6 +6334,40 @@
 				"docs",
 				"benchmarks"
 			]
+		},
+		"node_modules/esast-util-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+			"integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/esast-util-from-js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+			"integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"acorn": "^8.0.0",
+				"esast-util-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.12",
@@ -2444,12 +6427,99 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/estree-util-attach-comments": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+			"integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-build-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+			"integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-walker": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/estree-util-is-identifier-name": {
 			"version": "3.0.0",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-scope": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+			"integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-to-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+			"integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"astring": "^1.8.0",
+				"source-map": "^0.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-visit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+			"integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/eventemitter3": {
@@ -2468,6 +6538,36 @@
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"license": "MIT"
+		},
+		"node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend-shallow/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -2519,6 +6619,19 @@
 				}
 			}
 		},
+		"node_modules/file-selector": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.5.0.tgz",
+			"integrity": "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"dev": true,
@@ -2528,6 +6641,35 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/filter-obj": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+			"integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"license": "MIT"
+		},
+		"node_modules/for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/fraction.js": {
@@ -2543,10 +6685,12 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "12.34.0",
+			"version": "12.34.1",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.1.tgz",
+			"integrity": "sha512-kcZyNaYQfvE2LlH6+AyOaJAQV4rGp5XbzfhsZpiSZcwDMfZUHhuxLWeyRzf5I7jip3qKRpuimPA9pXXfr111kQ==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-dom": "^12.34.0",
+				"motion-dom": "^12.34.1",
 				"motion-utils": "^12.29.2",
 				"tslib": "^2.4.0"
 			},
@@ -2581,7 +6725,6 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2595,6 +6738,19 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-nonce": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -2602,6 +6758,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/giscus": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+			"integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lit": "^3.2.1"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2661,15 +6837,201 @@
 				"graphology-types": ">=0.23.0"
 			}
 		},
+		"node_modules/hachure-fill": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hast-util-from-dom": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+			"integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hastscript": "^9.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"devlop": "^1.1.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"parse5": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html-isomorphic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+			"integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-from-dom": "^5.0.0",
+				"hast-util-from-html": "^2.0.0",
+				"unist-util-remove-position": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-parse5": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+			"integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"property-information": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-location": "^5.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-is-element": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+			"integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+			"integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"hast-util-to-parse5": "^8.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"parse5": "^7.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-estree": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+			"integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-attach-comments": "^3.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/hast-util-to-jsx-runtime": {
@@ -2697,6 +7059,43 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hast-util-to-parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+			"integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-text": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+			"integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"unist-util-find-after": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-whitespace": {
 			"version": "3.0.0",
 			"license": "MIT",
@@ -2708,12 +7107,69 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hastscript": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+			"integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT"
+		},
 		"node_modules/html-url-attributes": {
 			"version": "3.0.1",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/immer": {
@@ -2729,6 +7185,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/import-fresh": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/inline-style-parser": {
 			"version": "0.2.7",
 			"license": "MIT"
@@ -2739,6 +7211,14 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/intersection-observer": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+			"integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+			"deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/is-alphabetical": {
 			"version": "2.0.1",
@@ -2760,6 +7240,12 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"license": "MIT"
+		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"dev": true,
@@ -2773,7 +7259,6 @@
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -2791,6 +7276,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-extendable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -2820,6 +7318,12 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/is-mobile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+			"integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"dev": true,
@@ -2838,11 +7342,34 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/isbot": {
 			"version": "5.1.35",
 			"license": "Unlicense",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jiti": {
@@ -2853,20 +7380,44 @@
 				"jiti": "bin/jiti.js"
 			}
 		},
+		"node_modules/js-cookie": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"license": "MIT"
+		},
+		"node_modules/json2mq": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+			"integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"string-convert": "^0.2.0"
 			}
 		},
 		"node_modules/json5": {
@@ -2878,6 +7429,88 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/katex": {
+			"version": "0.16.28",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+			"integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+			"peer": true
+		},
+		"node_modules/langium": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+			"integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"chevrotain": "~11.1.1",
+				"chevrotain-allstar": "~0.3.1",
+				"vscode-languageserver": "~9.0.1",
+				"vscode-languageserver-textdocument": "~1.0.11",
+				"vscode-uri": "~3.1.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/leva": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
+			"integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@radix-ui/react-portal": "^1.1.4",
+				"@radix-ui/react-tooltip": "^1.1.8",
+				"@stitches/react": "^1.2.8",
+				"@use-gesture/react": "^10.2.5",
+				"colord": "^2.9.2",
+				"dequal": "^2.0.2",
+				"merge-value": "^1.0.0",
+				"react-colorful": "^5.5.1",
+				"react-dropzone": "^12.0.0",
+				"v8n": "^1.3.3",
+				"zustand": "^3.6.9"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -2893,8 +7526,55 @@
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/lit": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit/reactive-element": "^2.1.0",
+				"lit-element": "^4.2.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-element": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+			"integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0",
+				"@lit/reactive-element": "^2.1.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-html": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+			"integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash-es": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/longest-streak": {
 			"version": "3.1.0",
@@ -2904,6 +7584,26 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru_map": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+			"integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"dev": true,
@@ -2912,12 +7612,48 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/lucide-react": {
+			"version": "0.562.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+			"integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/markdown-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+			"integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/markdown-table": {
 			"version": "3.0.4",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/marked": {
+			"version": "17.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
+			"integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/mdast-util-find-and-replace": {
@@ -3045,6 +7781,44 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/mdast-util-math": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+			"integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.1.0",
+				"unist-util-remove-position": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+			"integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/mdast-util-mdx-expression": {
 			"version": "2.0.1",
 			"license": "MIT",
@@ -3093,6 +7867,21 @@
 				"devlop": "^1.0.0",
 				"mdast-util-from-markdown": "^2.0.0",
 				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-newline-to-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+			"integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3160,12 +7949,84 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/merge-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+			"integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"get-value": "^2.0.6",
+				"is-extendable": "^1.0.0",
+				"mixin-deep": "^1.2.0",
+				"set-value": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/mermaid": {
+			"version": "11.12.3",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
+			"integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@braintree/sanitize-url": "^7.1.1",
+				"@iconify/utils": "^3.0.1",
+				"@mermaid-js/parser": "^1.0.0",
+				"@types/d3": "^7.4.3",
+				"cytoscape": "^3.29.3",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"cytoscape-fcose": "^2.2.0",
+				"d3": "^7.9.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.13",
+				"dayjs": "^1.11.18",
+				"dompurify": "^3.2.5",
+				"katex": "^0.16.22",
+				"khroma": "^2.1.0",
+				"lodash-es": "^4.17.23",
+				"marked": "^16.2.1",
+				"roughjs": "^4.6.6",
+				"stylis": "^4.3.6",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^11.1.0"
+			}
+		},
+		"node_modules/mermaid/node_modules/marked": {
+			"version": "16.4.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/mermaid/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/micromark": {
@@ -3231,6 +8092,52 @@
 				"micromark-util-subtokenize": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-cjk-friendly": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
+			"integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"devlop": "^1.1.0",
+				"micromark-extension-cjk-friendly-util": "2.1.1",
+				"micromark-util-chunked": "^2.0.1",
+				"micromark-util-resolve-all": "^2.0.1",
+				"micromark-util-symbol": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"micromark": "^4.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"micromark-util-types": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/micromark-extension-cjk-friendly-util": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-2.1.1.tgz",
+			"integrity": "sha512-egs6+12JU2yutskHY55FyR48ZiEcFOJFyk9rsiyIhcJ6IvWB6ABBqVrBw8IobqJTDZ/wdSr9eoXDPb5S2nW1bg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"get-east-asian-width": "^1.3.0",
+				"micromark-util-character": "^2.1.1",
+				"micromark-util-symbol": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependenciesMeta": {
+				"micromark-util-types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/micromark-extension-gfm": {
@@ -3340,6 +8247,133 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/micromark-extension-math": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+			"integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/katex": "^0.16.0",
+				"devlop": "^1.0.0",
+				"katex": "^0.16.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-expression": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+			"integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-mdx-jsx": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+			"integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-md": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+			"integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+			"integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.0.0",
+				"acorn-jsx": "^5.0.0",
+				"micromark-extension-mdx-expression": "^3.0.0",
+				"micromark-extension-mdx-jsx": "^3.0.0",
+				"micromark-extension-mdx-md": "^2.0.0",
+				"micromark-extension-mdxjs-esm": "^3.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs-esm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+			"integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/micromark-factory-destination": {
 			"version": "2.0.1",
 			"funding": [
@@ -3377,6 +8411,34 @@
 				"micromark-util-character": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-mdx-expression": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+			"integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
 			}
 		},
 		"node_modules/micromark-factory-space": {
@@ -3560,6 +8622,32 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/micromark-util-events-to-acorn": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+			"integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
 		"node_modules/micromark-util-html-tag-name": {
 			"version": "2.0.1",
 			"funding": [
@@ -3698,8 +8786,64 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/motion": {
+			"version": "12.34.1",
+			"resolved": "https://registry.npmjs.org/motion/-/motion-12.34.1.tgz",
+			"integrity": "sha512-N9RVNGn/NSo85OgHX1wGaUWHvReuQ7dZUwuQRhHyzY2wfVOvY3cEgn0Mw4NXOsXMHL/y7EYuzA+b59PYI6EejA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"framer-motion": "^12.34.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/motion-dom": {
-			"version": "12.34.0",
+			"version": "12.34.1",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.1.tgz",
+			"integrity": "sha512-SC7ZC5dRcGwku2g7EsPvI4q/EzHumUbqsDNumBmZTLFg+goBO5LTJvDu9MAxx+0mtX4IA78B2be/A3aRjY0jnw==",
 			"license": "MIT",
 			"dependencies": {
 				"motion-utils": "^12.29.2"
@@ -3707,6 +8851,8 @@
 		},
 		"node_modules/motion-utils": {
 			"version": "12.29.2",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+			"integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
 			"license": "MIT"
 		},
 		"node_modules/ms": {
@@ -3759,9 +8905,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -3773,6 +8928,57 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/on-change": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz",
+			"integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/on-change?sponsor=1"
+			}
+		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+			"integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+			"integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"oniguruma-parser": "^0.12.1",
+				"regex": "^6.0.1",
+				"regex-recursion": "^6.0.2"
+			}
+		},
+		"node_modules/package-manager-detector": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/parse-entities": {
@@ -3796,14 +9002,66 @@
 			"version": "2.0.11",
 			"license": "MIT"
 		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/path-data-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -3831,6 +9089,48 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/points-on-curve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/points-on-path": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-data-parser": "0.1.0",
+				"points-on-curve": "0.2.0"
+			}
+		},
+		"node_modules/polished": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+			"integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.17.8"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/postcss": {
@@ -3982,12 +9282,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/property-information": {
 			"version": "7.1.0",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
+			"integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"decode-uri-component": "^0.4.1",
+				"filter-obj": "^5.1.0",
+				"split-on-first": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/queue-microtask": {
@@ -4009,11 +9346,317 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/rc-collapse": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-4.0.0.tgz",
+			"integrity": "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"classnames": "2.x",
+				"rc-motion": "^2.3.4",
+				"rc-util": "^5.27.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-dialog": {
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+			"integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/portal": "^1.0.0-8",
+				"classnames": "^2.2.6",
+				"rc-motion": "^2.3.0",
+				"rc-util": "^5.21.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-dialog/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-footer": {
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/rc-footer/-/rc-footer-0.6.8.tgz",
+			"integrity": "sha512-JBZ+xcb6kkex8XnBd4VHw1ZxjV6kmcwUumSHaIFdka2qzMCo7Klcy4sI6G0XtUpG/vtpislQCc+S9Bc+NLHYMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/rc-image": {
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+			"integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.2",
+				"@rc-component/portal": "^1.0.2",
+				"classnames": "^2.2.6",
+				"rc-dialog": "~9.6.0",
+				"rc-motion": "^2.6.2",
+				"rc-util": "^5.34.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-image/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-input": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+			"integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.18.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/rc-input-number": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+			"integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/mini-decimal": "^1.0.1",
+				"classnames": "^2.2.5",
+				"rc-input": "~1.8.0",
+				"rc-util": "^5.40.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu": {
+			"version": "9.16.1",
+			"resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+			"integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/trigger": "^2.0.0",
+				"classnames": "2.x",
+				"rc-motion": "^2.4.3",
+				"rc-overflow": "^1.3.1",
+				"rc-util": "^5.27.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu/node_modules/@rc-component/trigger": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
+			"integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.23.2",
+				"@rc-component/portal": "^1.1.0",
+				"classnames": "^2.3.2",
+				"rc-motion": "^2.0.0",
+				"rc-resize-observer": "^1.3.1",
+				"rc-util": "^5.44.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-motion": {
+			"version": "2.9.5",
+			"resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+			"integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.44.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-overflow": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
+			"integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-resize-observer": "^1.0.0",
+				"rc-util": "^5.37.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-resize-observer": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+			"integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.7",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.44.1",
+				"resize-observer-polyfill": "^1.5.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-util": {
+			"version": "5.44.4",
+			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+			"integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"react-is": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-util/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/re-resizable": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+			"integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "19.2.4",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-avatar-editor": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-14.0.0.tgz",
+			"integrity": "sha512-NaQM3oo4u0a1/Njjutc2FjwKX35vQV+t6S8hovsbAlMpBN1ntIwP/g+Yr9eDIIfaNtRXL0AqboTnPmRxhD/i8A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-colorful": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -4025,6 +9668,66 @@
 			"peerDependencies": {
 				"react": "^19.2.4"
 			}
+		},
+		"node_modules/react-draggable": {
+			"version": "4.4.6",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+			"integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"clsx": "^1.1.1",
+				"prop-types": "^15.8.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.3.0",
+				"react-dom": ">= 16.3.0"
+			}
+		},
+		"node_modules/react-draggable/node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/react-dropzone": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-12.1.0.tgz",
+			"integrity": "sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"attr-accept": "^2.2.2",
+				"file-selector": "^0.5.0",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">= 10.13"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8"
+			}
+		},
+		"node_modules/react-error-boundary": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+			"integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-fast-compare": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/react-hook-form": {
 			"version": "7.71.1",
@@ -4040,6 +9743,17 @@
 			},
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17 || ^18 || ^19"
+			}
+		},
+		"node_modules/react-hotkeys-hook": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
+			"integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/react-is": {
@@ -4070,6 +9784,25 @@
 			"peerDependencies": {
 				"@types/react": ">=18",
 				"react": ">=18"
+			}
+		},
+		"node_modules/react-merge-refs": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-3.0.2.tgz",
+			"integrity": "sha512-MSZAfwFfdbEvwkKWP5EI5chuLYnNUxNS7vyS0i1Jp+wtd8J4Ga2ddzhaE68aMol2Z4vCnRM/oGOo1a3V75UPlw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-redux": {
@@ -4148,6 +9881,29 @@
 				}
 			}
 		},
+		"node_modules/react-rnd": {
+			"version": "10.5.2",
+			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+			"integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"re-resizable": "6.11.2",
+				"react-draggable": "4.4.6",
+				"tslib": "2.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.3.0",
+				"react-dom": ">=16.3.0"
+			}
+		},
+		"node_modules/react-rnd/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"license": "0BSD",
+			"peer": true
+		},
 		"node_modules/react-style-singleton": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -4168,6 +9924,21 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/react-zoom-pan-pinch": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+			"integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8",
+				"npm": ">=5"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
 			}
 		},
 		"node_modules/read-cache": {
@@ -4218,6 +9989,77 @@
 				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/recma-build-jsx": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+			"integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-build-jsx": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-jsx": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+			"integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn-jsx": "^5.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"recma-parse": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/recma-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+			"integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"esast-util-from-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-stringify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+			"integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/redux": {
 			"version": "5.0.1",
 			"license": "MIT"
@@ -4227,6 +10069,139 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"redux": "^5.0.0"
+			}
+		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/rehype-github-alerts": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/rehype-github-alerts/-/rehype-github-alerts-4.2.0.tgz",
+			"integrity": "sha512-6di6kEu9WUHKLKrkKG2xX6AOuaCMGghg0Wq7MEuM/jBYUPVIq6PJpMe00dxMfU+/YSBtDXhffpDimgDi+BObIQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@primer/octicons": "^19.20.0",
+				"hast-util-from-html": "^2.0.3",
+				"hast-util-is-element": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/chrisweb"
+			}
+		},
+		"node_modules/rehype-katex": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+			"integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/katex": "^0.16.0",
+				"hast-util-from-html-isomorphic": "^2.0.0",
+				"hast-util-to-text": "^4.0.0",
+				"katex": "^0.16.0",
+				"unist-util-visit-parents": "^6.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-raw": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+			"integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-raw": "^9.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-recma": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+			"integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"hast-util-to-estree": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-breaks": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+			"integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-newline-to-break": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-cjk-friendly": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
+			"integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"micromark-extension-cjk-friendly": "1.2.3"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"@types/mdast": "^4.0.0",
+				"unified": "^11.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/mdast": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/remark-gfm": {
@@ -4239,6 +10214,57 @@
 				"remark-parse": "^11.0.0",
 				"remark-stringify": "^11.0.0",
 				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-github": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/remark-github/-/remark-github-12.0.0.tgz",
+			"integrity": "sha512-ByefQKFN184LeiGRCabfl7zUJsdlMYWEhiLX1gpmQ11yFg6xSuOTW7LVCv0oc1x+YvUMJW23NU36sJX2RWGgvg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"to-vfile": "^8.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-math": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+			"integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-math": "^3.0.0",
+				"micromark-extension-math": "^3.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+			"integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mdast-util-mdx": "^3.0.0",
+				"micromark-extension-mdxjs": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4287,13 +10313,26 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/remend/-/remend-1.2.0.tgz",
+			"integrity": "sha512-NbKrdWweTRuByPYErzQCNpNtsR9M1QQ0hK2UzmnmlSaEqHnkQ5Korlyi8KpdbOJ0rImJfRy4EAY0uDxYnL9Plw==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
 		"node_modules/reselect": {
 			"version": "5.1.1",
 			"license": "MIT"
 		},
+		"node_modules/resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/resolve": {
 			"version": "1.22.11",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.16.1",
@@ -4310,6 +10349,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
 			"dev": true,
@@ -4318,6 +10366,13 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+			"integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+			"license": "Unlicense",
+			"peer": true
 		},
 		"node_modules/rollup": {
 			"version": "4.57.1",
@@ -4362,6 +10417,19 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/roughjs": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hachure-fill": "^0.5.2",
+				"path-data-parser": "^0.1.0",
+				"points-on-curve": "^0.2.0",
+				"points-on-path": "^0.2.1"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"dev": true,
@@ -4383,6 +10451,20 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
+		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/sass": {
 			"version": "1.97.3",
@@ -4407,6 +10489,29 @@
 			"version": "0.27.0",
 			"license": "MIT"
 		},
+		"node_modules/screenfull": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+			"integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/scroll-into-view-if-needed": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+			"integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"compute-scroll-into-view": "^3.0.2"
+			}
+		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"dev": true,
@@ -4414,6 +10519,13 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/seroval": {
 			"version": "1.5.0",
@@ -4432,6 +10544,78 @@
 				"seroval": "^1.0"
 			}
 		},
+		"node_modules/set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz",
+			"integrity": "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "3.22.0",
+				"@shikijs/engine-javascript": "3.22.0",
+				"@shikijs/engine-oniguruma": "3.22.0",
+				"@shikijs/langs": "3.22.0",
+				"@shikijs/themes": "3.22.0",
+				"@shikijs/types": "3.22.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/shiki-stream": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/shiki-stream/-/shiki-stream-0.1.4.tgz",
+			"integrity": "sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"solid-js": "^1.9.0",
+				"vue": "^3.2.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/sigma": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.2.tgz",
@@ -4442,6 +10626,18 @@
 				"graphology-utils": "^2.5.2"
 			}
 		},
+		"node_modules/smol-toml": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+			"integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
 		"node_modules/sonner": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -4450,6 +10646,16 @@
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
 				"react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -4468,6 +10674,53 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/split-on-first": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+			"integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"extend-shallow": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split-string/node_modules/extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string-convert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+			"integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/stringify-entities": {
 			"version": "4.0.4",
 			"license": "MIT",
@@ -4479,6 +10732,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"license": "MIT"
 		},
 		"node_modules/style-to-js": {
 			"version": "1.1.21",
@@ -4493,6 +10752,12 @@
 			"dependencies": {
 				"inline-style-parser": "0.2.7"
 			}
+		},
+		"node_modules/stylis": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+			"license": "MIT"
 		},
 		"node_modules/sucrase": {
 			"version": "3.35.1",
@@ -4517,7 +10782,6 @@
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4525,6 +10789,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/swr": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+			"integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tailwindcss": {
 			"version": "3.4.19",
@@ -4657,6 +10942,16 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/throttle-debounce": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+			"integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.22"
+			}
+		},
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"license": "MIT"
@@ -4664,6 +10959,16 @@
 		"node_modules/tiny-warning": {
 			"version": "1.0.3",
 			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
@@ -4691,6 +10996,20 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/to-vfile": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-8.0.0.tgz",
+			"integrity": "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/trim-lines": {
 			"version": "3.0.1",
 			"license": "MIT",
@@ -4707,10 +11026,30 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/ts-md5": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
+			"integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
@@ -4728,6 +11067,13 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/ufo": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/unified": {
 			"version": "11.0.5",
 			"license": "MIT",
@@ -4739,6 +11085,21 @@
 				"is-plain-obj": "^4.0.0",
 				"trough": "^2.0.0",
 				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-find-after": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+			"integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4761,6 +11122,35 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+			"integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+			"integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4832,6 +11222,16 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
 		"node_modules/use-callback-ref": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -4851,6 +11251,15 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/use-merge-value": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-merge-value/-/use-merge-value-1.2.0.tgz",
+			"integrity": "sha512-DXgG0kkgJN45TcyoXL49vJnn55LehnrmoHc7MbKi+QDBvr8dsesqws8UlyIWGHMR+JXgxc1nvY+jDGMlycsUcw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">= 16.x"
 			}
 		},
 		"node_modules/use-sidecar": {
@@ -4887,12 +11296,48 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/v8n": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/v8n/-/v8n-1.5.1.tgz",
+			"integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/vfile": {
 			"version": "6.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
 				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-location": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+			"integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile": "^6.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4929,6 +11374,37 @@
 				"d3-shape": "^3.1.0",
 				"d3-time": "^3.0.0",
 				"d3-timer": "^3.0.1"
+			}
+		},
+		"node_modules/virtua": {
+			"version": "0.48.6",
+			"resolved": "https://registry.npmjs.org/virtua/-/virtua-0.48.6.tgz",
+			"integrity": "sha512-Cl4uMvMV5c9RuOy9zhkFMYwx/V4YLBMYLRSWkO8J46opQZ3P7KMq0CqCVOOAKUckjl/r//D2jWTBGYWzmgtzrQ==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.14.0",
+				"react-dom": ">=16.14.0",
+				"solid-js": ">=1.0",
+				"svelte": ">=5.0",
+				"vue": ">=3.2"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vite": {
@@ -5004,6 +11480,78 @@
 				}
 			}
 		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"license": "MIT"
+		},
+		"node_modules/web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "3.1.1",
 			"dev": true,
@@ -5016,6 +11564,24 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zustand": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+			"integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/zwitch": {

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -715,6 +715,7 @@ export interface MessagingStatusResponse {
 	discord: PlatformStatus;
 	slack: PlatformStatus;
 	telegram: PlatformStatus;
+	matrix: PlatformStatus;
 	webhook: PlatformStatus;
 }
 
@@ -744,6 +745,11 @@ export interface CreateBindingRequest {
 		discord_token?: string;
 		slack_bot_token?: string;
 		slack_app_token?: string;
+		telegram_token?: string;
+		matrix_homeserver_url?: string;
+		matrix_user_id?: string;
+		matrix_password?: string;
+		matrix_access_token?: string;
 	};
 }
 

--- a/interface/src/lib/platformIcons.tsx
+++ b/interface/src/lib/platformIcons.tsx
@@ -1,6 +1,21 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDiscord, faSlack, faTelegram, faWhatsapp } from "@fortawesome/free-brands-svg-icons";
 import { faLink, faEnvelope, faComments, faComment } from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+// Fork Awesome matrix-org icon (SIL OFL 1.1 license)
+// Source: https://forkaweso.me/Fork-Awesome/icon/matrix-org/
+const faMatrixOrg: IconDefinition = {
+	prefix: "fab" as IconDefinition["prefix"],
+	iconName: "matrix-org" as IconDefinition["iconName"],
+	icon: [
+		1536,
+		1792,
+		[],
+		"f313",
+		"M40.467 163.152v1465.696H145.92V1664H0V128h145.92v35.152zm450.757 464.64v74.14h2.069c19.79-28.356 43.717-50.215 71.483-65.575 27.765-15.656 59.963-23.336 96-23.336 34.56 0 66.165 6.795 94.818 20.086 28.652 13.293 50.216 37.22 65.28 70.893 16.246-23.926 38.4-45.194 66.166-63.507 27.766-18.314 60.848-27.472 98.954-27.472 28.948 0 55.828 3.545 80.64 10.635 24.812 7.088 45.785 18.314 63.508 33.968 17.722 15.656 31.31 35.742 41.354 60.85 9.747 25.107 14.768 55.236 14.768 90.683v366.573h-150.35V865.28c0-18.314-.59-35.741-2.068-51.987-1.476-16.247-5.316-30.426-11.52-42.24-6.499-12.112-15.656-21.563-28.062-28.653-12.405-7.088-29.242-10.634-50.214-10.634-21.268 0-38.4 4.135-51.397 12.112-12.997 8.27-23.336 18.608-30.72 31.901-7.386 12.997-12.407 27.765-14.77 44.602-2.363 16.542-3.84 33.379-3.84 50.216v305.133H692.971v-307.2c0-16.247-.294-32.197-1.18-48.149-.591-15.95-3.84-30.424-9.157-44.011-5.317-13.293-14.178-24.223-26.585-32.197-12.406-7.976-30.425-12.112-54.646-12.112-7.088 0-16.542 1.478-28.062 4.726-11.52 3.25-23.04 9.157-33.968 18.02-10.93 8.86-20.383 21.563-28.063 38.103-7.68 16.543-11.52 38.4-11.52 65.28v317.834H349.44V627.792zm1004.309 1001.056V163.152H1390.08V128H1536v1536h-145.92v-35.152z",
+	],
+};
 
 interface PlatformIconProps {
 	platform: string;
@@ -16,7 +31,7 @@ export function PlatformIcon({ platform, className = "text-ink-faint", size = "1
 		webhook: faLink,
 		email: faEnvelope,
 		whatsapp: faWhatsapp,
-		matrix: faComments,
+		matrix: faMatrixOrg,
 		imessage: faComment,
 		irc: faComments,
 		lark: faComment,

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,8 +1,9 @@
-//! Messaging adapters (Discord, Slack, Telegram, Webhook).
+//! Messaging adapters (Discord, Matrix, Slack, Telegram, Webhook).
 
 pub mod traits;
 pub mod manager;
 pub mod discord;
+pub mod matrix;
 pub mod slack;
 pub mod telegram;
 pub mod webhook;

--- a/src/messaging/matrix.rs
+++ b/src/messaging/matrix.rs
@@ -1,0 +1,796 @@
+//! Matrix messaging adapter using matrix-sdk.
+
+use crate::config::MatrixPermissions;
+use crate::messaging::traits::{HistoryMessage, InboundStream, Messaging};
+use crate::{Attachment, InboundMessage, MessageContent, OutboundResponse, StatusUpdate};
+
+use anyhow::Context as _;
+use arc_swap::ArcSwap;
+use matrix_sdk::config::SyncSettings;
+use matrix_sdk::matrix_auth::{MatrixSession, MatrixSessionTokens};
+use matrix_sdk::room::edit::EditedContent;
+use matrix_sdk::ruma::events::reaction::ReactionEventContent;
+use matrix_sdk::ruma::events::relation::Annotation;
+use matrix_sdk::ruma::events::room::member::StrippedRoomMemberEvent;
+use matrix_sdk::ruma::events::room::message::{
+    RoomMessageEventContent, RoomMessageEventContentWithoutRelation, SyncRoomMessageEvent,
+};
+use matrix_sdk::ruma::{OwnedEventId, OwnedRoomId, RoomId};
+use matrix_sdk::{Client, SessionMeta};
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{RwLock, mpsc};
+use tokio::task::JoinHandle;
+
+/// Matrix adapter state.
+pub struct MatrixAdapter {
+    user_id: String,
+    client: Client,
+    permissions: Arc<ArcSwap<MatrixPermissions>>,
+    auto_join: bool,
+    /// Tracks in-progress streaming message edits per conversation_id.
+    active_streams: Arc<RwLock<HashMap<String, ActiveStream>>>,
+    /// Repeating typing indicator tasks per conversation_id.
+    typing_tasks: Arc<RwLock<HashMap<String, JoinHandle<()>>>>,
+    /// Shutdown signal for the sync loop.
+    shutdown_tx: Arc<RwLock<Option<mpsc::Sender<()>>>>,
+}
+
+/// Tracks an in-progress streaming message edit.
+struct ActiveStream {
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+    accumulated_text: String,
+    last_edit: Instant,
+}
+
+/// Matrix's recommended per-message character limit.
+const MAX_MESSAGE_LENGTH: usize = 4096;
+
+/// Minimum interval between streaming edits.
+const STREAM_EDIT_INTERVAL: Duration = Duration::from_millis(300);
+
+impl MatrixAdapter {
+    /// Create a new Matrix adapter. Logs in or restores session as appropriate.
+    pub async fn new(
+        config: &crate::config::MatrixConfig,
+        data_dir: PathBuf,
+        permissions: Arc<ArcSwap<MatrixPermissions>>,
+    ) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(&data_dir)
+            .with_context(|| format!("failed to create matrix data dir: {}", data_dir.display()))?;
+
+        let client = Client::builder()
+            .homeserver_url(&config.homeserver_url)
+            .sqlite_store(&data_dir, None)
+            .build()
+            .await
+            .context("failed to build matrix client")?;
+
+        let session_path = data_dir.join("session.json");
+
+        if session_path.exists() {
+            // Preserves device ID and E2EE keys across restarts
+            let session_data = std::fs::read_to_string(&session_path)
+                .context("failed to read matrix session.json")?;
+            let session: MatrixSession = serde_json::from_str(&session_data)
+                .context("failed to parse matrix session.json")?;
+            client.restore_session(session).await
+                .context("failed to restore matrix session")?;
+            tracing::info!("matrix session restored from disk");
+        } else if let Some(access_token) = &config.access_token {
+            let user_id = matrix_sdk::ruma::UserId::parse(&config.user_id)
+                .context("invalid matrix user_id")?;
+            let device_id = matrix_sdk::ruma::device_id!("SPACEBOT").to_owned();
+            let session = MatrixSession {
+                meta: SessionMeta {
+                    user_id: user_id.to_owned(),
+                    device_id,
+                },
+                tokens: MatrixSessionTokens {
+                    access_token: access_token.clone(),
+                    refresh_token: None,
+                },
+            };
+            client.restore_session(session).await
+                .context("failed to restore matrix session from access token")?;
+            tracing::info!("matrix session restored from access token");
+        } else if let Some(password) = &config.password {
+            client
+                .matrix_auth()
+                .login_username(&config.user_id, password)
+                .initial_device_display_name("spacebot")
+                .await
+                .context("matrix password login failed")?;
+            tracing::info!("matrix logged in with password");
+        } else {
+            anyhow::bail!("matrix: no session file, access_token, or password configured");
+        }
+
+        // Future restarts can skip login by restoring the session from disk
+        if let Some(session) = client.session()
+            && let matrix_sdk::AuthSession::Matrix(matrix_session) = session
+        {
+            let json = serde_json::to_string_pretty(&matrix_session)
+                .context("failed to serialize matrix session")?;
+            std::fs::write(&session_path, json)
+                .context("failed to write matrix session.json")?;
+        }
+
+        Ok(Self {
+            user_id: config.user_id.clone(),
+            client,
+            permissions,
+            auto_join: config.auto_join,
+            active_streams: Arc::new(RwLock::new(HashMap::new())),
+            typing_tasks: Arc::new(RwLock::new(HashMap::new())),
+            shutdown_tx: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    fn extract_room_id(&self, message: &InboundMessage) -> anyhow::Result<OwnedRoomId> {
+        let id_str = message
+            .metadata
+            .get("matrix_room_id")
+            .and_then(|v| v.as_str())
+            .context("missing matrix_room_id in metadata")?;
+        let room_id = <&RoomId>::try_from(id_str)
+            .context("invalid matrix_room_id")?;
+        Ok(room_id.to_owned())
+    }
+
+    fn extract_event_id(&self, message: &InboundMessage) -> anyhow::Result<OwnedEventId> {
+        let id_str = message
+            .metadata
+            .get("matrix_event_id")
+            .and_then(|v| v.as_str())
+            .context("missing matrix_event_id in metadata")?;
+        let event_id = OwnedEventId::try_from(id_str.to_string())
+            .context("invalid matrix_event_id")?;
+        Ok(event_id)
+    }
+
+    fn get_room(&self, room_id: &RoomId) -> anyhow::Result<matrix_sdk::Room> {
+        self.client
+            .get_room(room_id)
+            .context("room not found (not joined?)")
+    }
+
+    async fn stop_typing(&self, conversation_id: &str) {
+        if let Some(handle) = self.typing_tasks.write().await.remove(conversation_id) {
+            handle.abort();
+        }
+    }
+}
+
+impl Messaging for MatrixAdapter {
+    fn name(&self) -> &str {
+        "matrix"
+    }
+
+    async fn start(&self) -> crate::Result<InboundStream> {
+        let (inbound_tx, inbound_rx) = mpsc::channel(256);
+        let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
+
+        *self.shutdown_tx.write().await = Some(shutdown_tx);
+
+        let our_user_id = self.user_id.clone();
+        let permissions = self.permissions.clone();
+
+        // Register message event handler
+        let tx = inbound_tx.clone();
+        let our_user_id_clone = our_user_id.clone();
+        let permissions_clone = permissions.clone();
+        let homeserver = self
+            .client
+            .homeserver()
+            .to_string();
+
+        self.client.add_event_handler(
+            move |event: SyncRoomMessageEvent, room: matrix_sdk::Room| {
+                let tx = tx.clone();
+                let our_user_id = our_user_id_clone.clone();
+                let permissions = permissions_clone.clone();
+                let homeserver = homeserver.clone();
+                async move {
+                    let original = match event {
+                        SyncRoomMessageEvent::Original(o) => o,
+                        SyncRoomMessageEvent::Redacted(_) => return,
+                    };
+
+                    // Skip own messages
+                    if original.sender.as_str() == our_user_id {
+                        return;
+                    }
+
+                    let room_id = room.room_id().to_string();
+                    let permissions = permissions.load();
+
+                    // Room filter
+                    if let Some(ref filter) = permissions.room_filter
+                        && !filter.iter().any(|id| id == &room_id)
+                    {
+                        return;
+                    }
+
+                    // DM detection and filter
+                    let is_dm = room.is_direct().await.unwrap_or(false);
+                    if is_dm
+                        && !permissions.dm_allowed_users.is_empty()
+                        && !permissions.dm_allowed_users.iter().any(|u| u == original.sender.as_str())
+                    {
+                        return;
+                    }
+
+                    let conversation_id = if is_dm {
+                        format!("matrix:dm:{}", original.sender)
+                    } else {
+                        format!("matrix:{room_id}")
+                    };
+
+                    // Extract text content and attachments
+                    let (text, attachments) = extract_content(&original.content, &homeserver);
+
+                    if text.is_none() && attachments.is_empty() {
+                        return;
+                    }
+
+                    let content = if attachments.is_empty() {
+                        MessageContent::Text(text.unwrap_or_default())
+                    } else {
+                        MessageContent::Media {
+                            text,
+                            attachments,
+                        }
+                    };
+
+                    let mut metadata = HashMap::new();
+                    metadata.insert("matrix_room_id".into(), serde_json::Value::String(room_id));
+                    metadata.insert(
+                        "matrix_event_id".into(),
+                        serde_json::Value::String(original.event_id.to_string()),
+                    );
+                    metadata.insert(
+                        "matrix_sender".into(),
+                        serde_json::Value::String(original.sender.to_string()),
+                    );
+                    metadata.insert(
+                        "display_name".into(),
+                        serde_json::Value::String(original.sender.localpart().to_string()),
+                    );
+                    if is_dm {
+                        metadata.insert(
+                            "matrix_is_dm".into(),
+                            serde_json::Value::Bool(true),
+                        );
+                    }
+                    if let Some(name) = room.cached_display_name() {
+                        metadata.insert(
+                            "matrix_room_name".into(),
+                            serde_json::Value::String(name.to_string()),
+                        );
+                    }
+
+                    let timestamp = chrono::DateTime::from_timestamp_millis(
+                        original.origin_server_ts.0.into(),
+                    )
+                    .unwrap_or_else(chrono::Utc::now);
+
+                    let inbound = InboundMessage {
+                        id: original.event_id.to_string(),
+                        source: "matrix".into(),
+                        conversation_id,
+                        sender_id: original.sender.to_string(),
+                        agent_id: None,
+                        content,
+                        timestamp,
+                        metadata,
+                    };
+
+                    if let Err(error) = tx.send(inbound).await {
+                        tracing::warn!(
+                            %error,
+                            "failed to send inbound message from Matrix (receiver dropped)"
+                        );
+                    }
+                }
+            },
+        );
+
+        if self.auto_join {
+            self.client.add_event_handler(
+                |event: StrippedRoomMemberEvent, client: Client, room: matrix_sdk::Room| async move {
+                    // Only act on invites for ourselves
+                    if let Some(user_id) = client.user_id()
+                        && event.state_key != *user_id
+                    {
+                        return;
+                    }
+                    if room.state() == matrix_sdk::RoomState::Invited {
+                        tracing::info!(room_id = %room.room_id(), "auto-joining invited room");
+                        // Retry join a few times in case of federation lag
+                        for attempt in 0..3 {
+                            match room.join().await {
+                                Ok(_) => {
+                                    tracing::info!(room_id = %room.room_id(), "joined room");
+                                    return;
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        %error,
+                                        attempt,
+                                        room_id = %room.room_id(),
+                                        "failed to join room, retrying"
+                                    );
+                                    tokio::time::sleep(Duration::from_secs(1)).await;
+                                }
+                            }
+                        }
+                    }
+                },
+            );
+        }
+
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            let settings = SyncSettings::default();
+            tokio::select! {
+                _ = shutdown_rx.recv() => {
+                    tracing::info!("matrix sync loop shutting down");
+                }
+                _ = client.sync(settings) => {
+                    tracing::warn!("matrix sync loop ended unexpectedly");
+                }
+            }
+        });
+
+        tracing::info!(user_id = %self.user_id, "matrix connected");
+        let stream = tokio_stream::wrappers::ReceiverStream::new(inbound_rx);
+        Ok(Box::pin(stream))
+    }
+
+    async fn respond(
+        &self,
+        message: &InboundMessage,
+        response: OutboundResponse,
+    ) -> crate::Result<()> {
+        match response {
+            OutboundResponse::Text(text) => {
+                self.stop_typing(&message.conversation_id).await;
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+
+                for chunk in split_message(&text, MAX_MESSAGE_LENGTH) {
+                    let content = RoomMessageEventContent::text_plain(&chunk);
+                    room.send(content).await
+                        .context("failed to send matrix message")?;
+                }
+            }
+            OutboundResponse::ThreadReply { thread_name: _, text } => {
+                self.stop_typing(&message.conversation_id).await;
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+
+                for chunk in split_message(&text, MAX_MESSAGE_LENGTH) {
+                    let content = RoomMessageEventContent::text_plain(&chunk);
+                    // Matrix doesn't have named threads like Slack. Send as reply.
+                    room.send(content).await
+                        .context("failed to send matrix thread reply")?;
+                }
+            }
+            OutboundResponse::File {
+                filename,
+                data,
+                mime_type,
+                caption,
+            } => {
+                self.stop_typing(&message.conversation_id).await;
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+
+                let content_type: mime_guess::mime::Mime = mime_type
+                    .parse()
+                    .unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM);
+
+                let config = matrix_sdk::attachment::AttachmentConfig::new();
+                room.send_attachment(&filename, &content_type, data, config)
+                    .await
+                    .context("failed to send matrix file attachment")?;
+
+                // Send caption as a follow-up message if provided
+                if let Some(caption_text) = caption
+                    && !caption_text.is_empty()
+                {
+                    let caption_content = RoomMessageEventContent::text_plain(&caption_text);
+                    room.send(caption_content).await
+                        .context("failed to send matrix file caption")?;
+                }
+            }
+            OutboundResponse::Reaction(emoji) => {
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+                let event_id = self.extract_event_id(message)?;
+
+                let annotation = Annotation::new(event_id, emoji.clone());
+                let content = ReactionEventContent::new(annotation);
+                if let Err(error) = room.send(content).await {
+                    tracing::debug!(
+                        %error,
+                        emoji = %emoji,
+                        "failed to send matrix reaction"
+                    );
+                }
+            }
+            OutboundResponse::StreamStart => {
+                self.stop_typing(&message.conversation_id).await;
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+
+                let placeholder = RoomMessageEventContent::text_plain("...");
+                let response = room.send(placeholder).await
+                    .context("failed to send matrix stream placeholder")?;
+
+                self.active_streams.write().await.insert(
+                    message.conversation_id.clone(),
+                    ActiveStream {
+                        room_id,
+                        event_id: response.event_id,
+                        accumulated_text: String::new(),
+                        last_edit: Instant::now(),
+                    },
+                );
+            }
+            OutboundResponse::StreamChunk(text) => {
+                let mut active = self.active_streams.write().await;
+                if let Some(stream) = active.get_mut(&message.conversation_id) {
+                    stream.accumulated_text = text;
+
+                    // Rate-limit edits
+                    if stream.last_edit.elapsed() < STREAM_EDIT_INTERVAL {
+                        return Ok(());
+                    }
+
+                    let display_text = if stream.accumulated_text.len() > MAX_MESSAGE_LENGTH {
+                        let end = stream.accumulated_text
+                            .floor_char_boundary(MAX_MESSAGE_LENGTH - 3);
+                        format!("{}...", &stream.accumulated_text[..end])
+                    } else {
+                        stream.accumulated_text.clone()
+                    };
+
+                    let room = self.get_room(&stream.room_id)?;
+                    let edited = EditedContent::RoomMessage(
+                        RoomMessageEventContentWithoutRelation::text_plain(&display_text),
+                    );
+                    match room.make_edit_event(&stream.event_id, edited).await {
+                        Ok(edit_event) => {
+                            if let Err(error) = room.send(edit_event).await {
+                                tracing::debug!(%error, "failed to edit streaming matrix message");
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(%error, "failed to create matrix edit event");
+                        }
+                    }
+                    stream.last_edit = Instant::now();
+                }
+            }
+            OutboundResponse::StreamEnd => {
+                let stream = self
+                    .active_streams
+                    .write()
+                    .await
+                    .remove(&message.conversation_id);
+                if let Some(stream) = stream
+                    && !stream.accumulated_text.is_empty()
+                {
+                    let room = self.get_room(&stream.room_id)?;
+                    for (i, chunk) in split_message(&stream.accumulated_text, MAX_MESSAGE_LENGTH)
+                        .iter()
+                        .enumerate()
+                    {
+                        if i == 0 {
+                            let edited = EditedContent::RoomMessage(
+                                RoomMessageEventContentWithoutRelation::text_plain(chunk),
+                            );
+                            match room.make_edit_event(&stream.event_id, edited).await {
+                                Ok(edit_event) => {
+                                    if let Err(error) = room.send(edit_event).await {
+                                        tracing::debug!(%error, "failed to send final matrix stream edit");
+                                    }
+                                }
+                                Err(error) => {
+                                    tracing::debug!(%error, "failed to create final matrix edit event");
+                                }
+                            }
+                        } else {
+                            let content = RoomMessageEventContent::text_plain(chunk);
+                            if let Err(error) = room.send(content).await {
+                                tracing::debug!(%error, "failed to send matrix overflow chunk");
+                            }
+                        }
+                    }
+                }
+            }
+            OutboundResponse::Status(status) => {
+                self.send_status(message, status).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn send_status(
+        &self,
+        message: &InboundMessage,
+        status: StatusUpdate,
+    ) -> crate::Result<()> {
+        match status {
+            StatusUpdate::Thinking => {
+                let room_id = self.extract_room_id(message)?;
+                let room = self.get_room(&room_id)?;
+                let conversation_id = message.conversation_id.clone();
+
+                // Matrix typing indicators expire after ~4 seconds.
+                // Send one immediately, then repeat every 4 seconds.
+                let handle = tokio::spawn(async move {
+                    loop {
+                        if let Err(error) = room.typing_notice(true).await {
+                            tracing::debug!(%error, "failed to send matrix typing indicator");
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_secs(4)).await;
+                    }
+                });
+
+                self.typing_tasks
+                    .write()
+                    .await
+                    .insert(conversation_id, handle);
+            }
+            StatusUpdate::StopTyping
+            | StatusUpdate::ToolStarted { .. }
+            | StatusUpdate::ToolCompleted { .. }
+            | StatusUpdate::BranchStarted { .. }
+            | StatusUpdate::WorkerStarted { .. }
+            | StatusUpdate::WorkerCompleted { .. } => {
+                self.stop_typing(&message.conversation_id).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn broadcast(
+        &self,
+        target: &str,
+        response: OutboundResponse,
+    ) -> crate::Result<()> {
+        let room_id = <&RoomId>::try_from(target)
+            .context("invalid matrix room ID for broadcast")?;
+        let room = self.get_room(room_id)?;
+
+        match response {
+            OutboundResponse::Text(text) => {
+                for chunk in split_message(&text, MAX_MESSAGE_LENGTH) {
+                    let content = RoomMessageEventContent::text_plain(&chunk);
+                    room.send(content).await
+                        .context("failed to broadcast matrix message")?;
+                }
+            }
+            OutboundResponse::ThreadReply { .. }
+            | OutboundResponse::File { .. }
+            | OutboundResponse::Reaction(_)
+            | OutboundResponse::StreamStart
+            | OutboundResponse::StreamChunk(_)
+            | OutboundResponse::StreamEnd
+            | OutboundResponse::Status(_) => {
+                tracing::debug!("unsupported broadcast response type for matrix");
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn fetch_history(
+        &self,
+        message: &InboundMessage,
+        limit: usize,
+    ) -> crate::Result<Vec<HistoryMessage>> {
+        let room_id = self.extract_room_id(message)?;
+        let room = self.get_room(&room_id)?;
+
+        let our_user_id = self.user_id.clone();
+
+        let options = matrix_sdk::room::MessagesOptions::backward()
+            .from(None::<&str>);
+        let messages = room.messages(options).await
+            .context("failed to fetch matrix message history")?;
+
+        let mut history = Vec::new();
+        for event in messages.chunk.into_iter().rev() {
+            let event = match event.raw().deserialize() {
+                Ok(ev) => ev,
+                Err(error) => {
+                    tracing::debug!(%error, "failed to deserialize matrix timeline event");
+                    continue;
+                }
+            };
+
+            if let matrix_sdk::ruma::events::AnySyncTimelineEvent::MessageLike(
+                matrix_sdk::ruma::events::AnySyncMessageLikeEvent::RoomMessage(msg_event),
+            ) = event
+            {
+                let sender = msg_event.sender().to_string();
+                let is_bot = sender == our_user_id;
+                if let Some(original) = msg_event.as_original() {
+                    let body = original.content.body().to_string();
+                    history.push(HistoryMessage {
+                        author: sender,
+                        content: body,
+                        is_bot,
+                    });
+                }
+            }
+
+            if history.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(history)
+    }
+
+    async fn health_check(&self) -> crate::Result<()> {
+        self.client
+            .whoami()
+            .await
+            .context("matrix health check failed")?;
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> crate::Result<()> {
+        let mut tasks = self.typing_tasks.write().await;
+        for (_, handle) in tasks.drain() {
+            handle.abort();
+        }
+
+        if let Some(tx) = self.shutdown_tx.read().await.as_ref() {
+            tx.send(()).await.ok();
+        }
+
+        tracing::info!("matrix adapter shut down");
+        Ok(())
+    }
+}
+
+/// Extract text content and attachments from a Matrix message.
+fn extract_content(
+    content: &RoomMessageEventContent,
+    homeserver: &str,
+) -> (Option<String>, Vec<Attachment>) {
+    use matrix_sdk::ruma::events::room::message::MessageType;
+
+    let mut attachments = Vec::new();
+
+    match &content.msgtype {
+        MessageType::Text(text) => {
+            return (Some(text.body.clone()), attachments);
+        }
+        MessageType::Notice(notice) => {
+            return (Some(notice.body.clone()), attachments);
+        }
+        MessageType::Emote(emote) => {
+            return (Some(format!("* {}", emote.body)), attachments);
+        }
+        MessageType::Image(image) => {
+            let url = media_source_url(&image.source, homeserver);
+            attachments.push(Attachment {
+                filename: image.body.clone(),
+                mime_type: image
+                    .info
+                    .as_ref()
+                    .and_then(|i| i.mimetype.clone())
+                    .unwrap_or_else(|| "image/png".to_string()),
+                url,
+                size_bytes: image.info.as_ref().and_then(|i| i.size).map(|s| s.into()),
+            });
+        }
+        MessageType::File(file) => {
+            let url = media_source_url(&file.source, homeserver);
+            attachments.push(Attachment {
+                filename: file.body.clone(),
+                mime_type: file
+                    .info
+                    .as_ref()
+                    .and_then(|i| i.mimetype.clone())
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+                url,
+                size_bytes: file.info.as_ref().and_then(|i| i.size).map(|s| s.into()),
+            });
+        }
+        MessageType::Audio(audio) => {
+            let url = media_source_url(&audio.source, homeserver);
+            attachments.push(Attachment {
+                filename: audio.body.clone(),
+                mime_type: audio
+                    .info
+                    .as_ref()
+                    .and_then(|i| i.mimetype.clone())
+                    .unwrap_or_else(|| "audio/mpeg".to_string()),
+                url,
+                size_bytes: audio.info.as_ref().and_then(|i| i.size).map(|s| s.into()),
+            });
+        }
+        MessageType::Video(video) => {
+            let url = media_source_url(&video.source, homeserver);
+            attachments.push(Attachment {
+                filename: video.body.clone(),
+                mime_type: video
+                    .info
+                    .as_ref()
+                    .and_then(|i| i.mimetype.clone())
+                    .unwrap_or_else(|| "video/mp4".to_string()),
+                url,
+                size_bytes: video.info.as_ref().and_then(|i| i.size).map(|s| s.into()),
+            });
+        }
+        _ => {
+            return (None, attachments);
+        }
+    }
+
+    (None, attachments)
+}
+
+/// Extract a download URL from a MediaSource.
+fn media_source_url(source: &matrix_sdk::ruma::events::room::MediaSource, homeserver: &str) -> String {
+    match source {
+        matrix_sdk::ruma::events::room::MediaSource::Plain(mxc_uri) => {
+            resolve_mxc_url(homeserver, mxc_uri.as_str())
+        }
+        matrix_sdk::ruma::events::room::MediaSource::Encrypted(info) => {
+            resolve_mxc_url(homeserver, info.url.as_str())
+        }
+    }
+}
+
+/// Convert an `mxc://` URL to an HTTP download URL.
+fn resolve_mxc_url(homeserver: &str, mxc_url: &str) -> String {
+    if let Some(stripped) = mxc_url.strip_prefix("mxc://") {
+        let hs = homeserver.trim_end_matches('/');
+        format!("{hs}/_matrix/media/v3/download/{stripped}")
+    } else {
+        mxc_url.to_string()
+    }
+}
+
+/// Split a message into chunks that fit within Matrix's character limit.
+fn split_message(text: &str, max_len: usize) -> Vec<String> {
+    if text.len() <= max_len {
+        return vec![text.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        if remaining.len() <= max_len {
+            chunks.push(remaining.to_string());
+            break;
+        }
+
+        let split_at = remaining[..max_len]
+            .rfind('\n')
+            .or_else(|| remaining[..max_len].rfind(' '))
+            .unwrap_or(max_len);
+
+        chunks.push(remaining[..split_at].to_string());
+        remaining = remaining[split_at..].trim_start();
+    }
+
+    chunks
+}


### PR DESCRIPTION
Add a full Matrix messaging adapter with end-to-end encryption, streaming responses, and frontend UI support.

**Backend (`src/messaging/matrix.rs`)**
- Password login, access token restore, and persistent session via `session.json`
- E2EE out of the box via matrix-sdk's `e2e-encryption` + `sqlite` store
- Streaming responses via message edits (300ms throttle)
- Typing indicators with auto-repeat
- Auto-join on room invite
- File attachment support (images, documents, audio, video via `mxc://` URLs)
- DM access control (`dm_allowed_users` allowlist)
- History backfill for conversation context
- Message splitting at 4096-char Matrix limit

**Config (`src/config.rs`)**
- `MatrixConfig` and `MatrixPermissions` structs with hot-reload support
- Binding matching via `matrix_room_id` metadata key

**API (`src/api/server.rs`)**
- Matrix status in `/api/messaging/status` endpoint
- `create_binding` support with Matrix credentials
- Fix: add missing `telegram` field to `MessagingStatusResponse`

**Frontend (`interface/`)**
- Matrix platform card, setup dialog (homeserver URL, user ID, password/access token)
- Matrix binding support with optional Room ID filter
- API types for Matrix credentials and status

**Docs**
- `matrix-setup.mdx` setup guide covering account creation, TOML config, E2EE, DM access control, and platform notes

Tested:
- [x] Password login to matrix.org
- [x] E2EE message receive/send in encrypted rooms
- [x] Streaming response edits
- [x] History backfill
- [x] Auto-join
- [x] Frontend settings UI renders Matrix card and setup dialog
- [x] Bindings section shows Matrix with Room ID field