### PR TITLE
feat: configurable base_url for all LLM providers

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -658,6 +658,7 @@ export interface ProviderStatus {
 export interface ProvidersResponse {
 	providers: ProviderStatus;
 	has_any: boolean;
+	base_urls?: Record<string, string>;
 }
 
 export interface ProviderActionResponse {
@@ -1010,11 +1011,13 @@ export const api = {
 
 	// Provider management
 	providers: () => fetchJson<ProvidersResponse>("/providers"),
-	updateProvider: async (provider: string, apiKey: string) => {
+	updateProvider: async (provider: string, apiKey: string, baseUrl?: string) => {
+		const body: Record<string, unknown> = { provider, api_key: apiKey };
+		if (baseUrl !== undefined) body.base_url = baseUrl;
 		const response = await fetch(`${API_BASE}/providers`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ provider, api_key: apiKey }),
+			body: JSON.stringify(body),
 		});
 		if (!response.ok) {
 			throw new Error(`API error: ${response.status}`);

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,24 +53,35 @@ impl Default for ApiConfig {
 #[derive(Debug, Clone)]
 pub struct LlmConfig {
     pub anthropic_key: Option<String>,
+    pub anthropic_base_url: Option<String>,
     pub openai_key: Option<String>,
+    pub openai_base_url: Option<String>,
     pub openrouter_key: Option<String>,
+    pub openrouter_base_url: Option<String>,
     pub zhipu_key: Option<String>,
+    pub zhipu_base_url: Option<String>,
     pub groq_key: Option<String>,
+    pub groq_base_url: Option<String>,
     pub together_key: Option<String>,
+    pub together_base_url: Option<String>,
     pub fireworks_key: Option<String>,
+    pub fireworks_base_url: Option<String>,
     pub deepseek_key: Option<String>,
+    pub deepseek_base_url: Option<String>,
     pub xai_key: Option<String>,
+    pub xai_base_url: Option<String>,
     pub mistral_key: Option<String>,
+    pub mistral_base_url: Option<String>,
     pub opencode_zen_key: Option<String>,
+    pub opencode_zen_base_url: Option<String>,
 }
 
 impl LlmConfig {
     /// Check if any provider key is configured.
     pub fn has_any_key(&self) -> bool {
-        self.anthropic_key.is_some() 
-            || self.openai_key.is_some() 
-            || self.openrouter_key.is_some() 
+        self.anthropic_key.is_some()
+            || self.openai_key.is_some()
+            || self.openrouter_key.is_some()
             || self.zhipu_key.is_some()
             || self.groq_key.is_some()
             || self.together_key.is_some()
@@ -867,16 +878,27 @@ fn default_api_bind() -> String {
 #[derive(Deserialize, Default)]
 struct TomlLlmConfig {
     anthropic_key: Option<String>,
+    anthropic_base_url: Option<String>,
     openai_key: Option<String>,
+    openai_base_url: Option<String>,
     openrouter_key: Option<String>,
+    openrouter_base_url: Option<String>,
     zhipu_key: Option<String>,
+    zhipu_base_url: Option<String>,
     groq_key: Option<String>,
+    groq_base_url: Option<String>,
     together_key: Option<String>,
+    together_base_url: Option<String>,
     fireworks_key: Option<String>,
+    fireworks_base_url: Option<String>,
     deepseek_key: Option<String>,
+    deepseek_base_url: Option<String>,
     xai_key: Option<String>,
+    xai_base_url: Option<String>,
     mistral_key: Option<String>,
+    mistral_base_url: Option<String>,
     opencode_zen_key: Option<String>,
+    opencode_zen_base_url: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1146,6 +1168,13 @@ impl Config {
         std::env::var("ANTHROPIC_API_KEY").is_err()
             && std::env::var("OPENAI_API_KEY").is_err()
             && std::env::var("OPENROUTER_API_KEY").is_err()
+            && std::env::var("ZHIPU_API_KEY").is_err()
+            && std::env::var("GROQ_API_KEY").is_err()
+            && std::env::var("TOGETHER_API_KEY").is_err()
+            && std::env::var("FIREWORKS_API_KEY").is_err()
+            && std::env::var("DEEPSEEK_API_KEY").is_err()
+            && std::env::var("XAI_API_KEY").is_err()
+            && std::env::var("MISTRAL_API_KEY").is_err()
             && std::env::var("OPENCODE_ZEN_API_KEY").is_err()
     }
 
@@ -1181,16 +1210,27 @@ impl Config {
     pub fn load_from_env(instance_dir: &Path) -> Result<Self> {
         let llm = LlmConfig {
             anthropic_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+            anthropic_base_url: std::env::var("ANTHROPIC_BASE_URL").ok(),
             openai_key: std::env::var("OPENAI_API_KEY").ok(),
+            openai_base_url: std::env::var("OPENAI_BASE_URL").ok(),
             openrouter_key: std::env::var("OPENROUTER_API_KEY").ok(),
+            openrouter_base_url: std::env::var("OPENROUTER_BASE_URL").ok(),
             zhipu_key: std::env::var("ZHIPU_API_KEY").ok(),
+            zhipu_base_url: std::env::var("ZHIPU_BASE_URL").ok(),
             groq_key: std::env::var("GROQ_API_KEY").ok(),
+            groq_base_url: std::env::var("GROQ_BASE_URL").ok(),
             together_key: std::env::var("TOGETHER_API_KEY").ok(),
+            together_base_url: std::env::var("TOGETHER_BASE_URL").ok(),
             fireworks_key: std::env::var("FIREWORKS_API_KEY").ok(),
+            fireworks_base_url: std::env::var("FIREWORKS_BASE_URL").ok(),
             deepseek_key: std::env::var("DEEPSEEK_API_KEY").ok(),
+            deepseek_base_url: std::env::var("DEEPSEEK_BASE_URL").ok(),
             xai_key: std::env::var("XAI_API_KEY").ok(),
+            xai_base_url: std::env::var("XAI_BASE_URL").ok(),
             mistral_key: std::env::var("MISTRAL_API_KEY").ok(),
+            mistral_base_url: std::env::var("MISTRAL_BASE_URL").ok(),
             opencode_zen_key: std::env::var("OPENCODE_ZEN_API_KEY").ok(),
+            opencode_zen_base_url: std::env::var("OPENCODE_ZEN_BASE_URL").ok(),
         };
 
         // Note: We allow boot without provider keys now. System starts in setup mode.
@@ -1255,66 +1295,110 @@ impl Config {
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok()),
+            anthropic_base_url: toml.llm.anthropic_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("ANTHROPIC_BASE_URL").ok()),
             openai_key: toml
                 .llm
                 .openai_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("OPENAI_API_KEY").ok()),
+            openai_base_url: toml.llm.openai_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("OPENAI_BASE_URL").ok()),
             openrouter_key: toml
                 .llm
                 .openrouter_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("OPENROUTER_API_KEY").ok()),
+            openrouter_base_url: toml.llm.openrouter_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("OPENROUTER_BASE_URL").ok()),
             zhipu_key: toml
                 .llm
                 .zhipu_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("ZHIPU_API_KEY").ok()),
+            zhipu_base_url: toml.llm.zhipu_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("ZHIPU_BASE_URL").ok()),
             groq_key: toml
                 .llm
                 .groq_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("GROQ_API_KEY").ok()),
+            groq_base_url: toml.llm.groq_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("GROQ_BASE_URL").ok()),
             together_key: toml
                 .llm
                 .together_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("TOGETHER_API_KEY").ok()),
+            together_base_url: toml.llm.together_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("TOGETHER_BASE_URL").ok()),
             fireworks_key: toml
                 .llm
                 .fireworks_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("FIREWORKS_API_KEY").ok()),
+            fireworks_base_url: toml.llm.fireworks_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("FIREWORKS_BASE_URL").ok()),
             deepseek_key: toml
                 .llm
                 .deepseek_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("DEEPSEEK_API_KEY").ok()),
+            deepseek_base_url: toml.llm.deepseek_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("DEEPSEEK_BASE_URL").ok()),
             xai_key: toml
                 .llm
                 .xai_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("XAI_API_KEY").ok()),
+            xai_base_url: toml.llm.xai_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("XAI_BASE_URL").ok()),
             mistral_key: toml
                 .llm
                 .mistral_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("MISTRAL_API_KEY").ok()),
+            mistral_base_url: toml.llm.mistral_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("MISTRAL_BASE_URL").ok()),
             opencode_zen_key: toml
                 .llm
                 .opencode_zen_key
                 .as_deref()
                 .and_then(resolve_env_value)
                 .or_else(|| std::env::var("OPENCODE_ZEN_API_KEY").ok()),
+            opencode_zen_base_url: toml.llm.opencode_zen_base_url
+                .as_deref()
+                .and_then(resolve_env_value)
+                .or_else(|| std::env::var("OPENCODE_ZEN_BASE_URL").ok()),
         };
 
         // Note: We allow boot without provider keys now. System starts in setup mode.

--- a/src/llm/manager.rs
+++ b/src/llm/manager.rs
@@ -12,6 +12,19 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
 
+// Default API endpoints per provider (used when no base_url is configured).
+const DEFAULT_ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com/v1/messages";
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
+const DEFAULT_ZHIPU_BASE_URL: &str = "https://api.z.ai/api/paas/v4/chat/completions";
+const DEFAULT_GROQ_BASE_URL: &str = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_TOGETHER_BASE_URL: &str = "https://api.together.xyz/v1/chat/completions";
+const DEFAULT_FIREWORKS_BASE_URL: &str = "https://api.fireworks.ai/inference/v1/chat/completions";
+const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/v1/chat/completions";
+const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1/chat/completions";
+const DEFAULT_MISTRAL_BASE_URL: &str = "https://api.mistral.ai/v1/chat/completions";
+const DEFAULT_OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1/chat/completions";
+
 /// Manages LLM provider clients and tracks rate limit state.
 pub struct LlmManager {
     config: LlmConfig,
@@ -61,6 +74,38 @@ impl LlmManager {
             "opencode-zen" => self.config.opencode_zen_key.clone()
                 .ok_or_else(|| LlmError::MissingProviderKey("opencode-zen".into()).into()),
             _ => Err(LlmError::UnknownProvider(provider.into()).into()),
+        }
+    }
+
+    /// Get the base URL for a provider, falling back to the default.
+    ///
+    /// Panics if `provider` is not a known provider name — callers must
+    /// validate the provider string before reaching this point.
+    pub fn get_base_url(&self, provider: &str) -> &str {
+        match provider {
+            "anthropic" => self.config.anthropic_base_url.as_deref()
+                .unwrap_or(DEFAULT_ANTHROPIC_BASE_URL),
+            "openai" => self.config.openai_base_url.as_deref()
+                .unwrap_or(DEFAULT_OPENAI_BASE_URL),
+            "openrouter" => self.config.openrouter_base_url.as_deref()
+                .unwrap_or(DEFAULT_OPENROUTER_BASE_URL),
+            "zhipu" => self.config.zhipu_base_url.as_deref()
+                .unwrap_or(DEFAULT_ZHIPU_BASE_URL),
+            "groq" => self.config.groq_base_url.as_deref()
+                .unwrap_or(DEFAULT_GROQ_BASE_URL),
+            "together" => self.config.together_base_url.as_deref()
+                .unwrap_or(DEFAULT_TOGETHER_BASE_URL),
+            "fireworks" => self.config.fireworks_base_url.as_deref()
+                .unwrap_or(DEFAULT_FIREWORKS_BASE_URL),
+            "deepseek" => self.config.deepseek_base_url.as_deref()
+                .unwrap_or(DEFAULT_DEEPSEEK_BASE_URL),
+            "xai" => self.config.xai_base_url.as_deref()
+                .unwrap_or(DEFAULT_XAI_BASE_URL),
+            "mistral" => self.config.mistral_base_url.as_deref()
+                .unwrap_or(DEFAULT_MISTRAL_BASE_URL),
+            "opencode-zen" => self.config.opencode_zen_base_url.as_deref()
+                .unwrap_or(DEFAULT_OPENCODE_ZEN_BASE_URL),
+            _ => unreachable!("unknown provider: {provider}"),
         }
     }
 

--- a/src/llm/providers.rs
+++ b/src/llm/providers.rs
@@ -20,6 +20,6 @@ pub async fn init_providers(config: &LlmConfig) -> Result<()> {
     if config.opencode_zen_key.is_some() {
         tracing::info!("OpenCode Zen provider configured");
     }
-    
+
     Ok(())
 }


### PR DESCRIPTION
### Motivation

LLM providers increasingly offer multiple API surfaces — different endpoints, different formats, sometimes different credentials — for the same underlying models:

- **Z.ai (Zhipu)**: General API (`api.z.ai/api/paas/v4`) vs Coding Plan (`api.z.ai/api/coding/paas/v4`) — same key, different billing path
- **Moonshot/Kimi**: Standard Moonshot API (`api.moonshot.ai/v1`) vs Kimi Coding Plan (`api.kimi.com/coding/v1`) — same key, entirely different domain
- **MiniMax**: International (`api.minimax.io`) vs China mainland (`api.minimaxi.com`), OpenAI-compatible (`/v1`) vs Anthropic-compatible (`/anthropic`), standard API key vs Coding Plan key (`sk-cp-` prefix) — different keys, different domains, different API formats
- **OpenAI**: Direct API vs Azure OpenAI — different keys, different domains
- **Any provider**: Corporate proxies, observability wrappers (Helicone), self-hosted deployments, regional mirrors

Currently every provider hardcodes its URL. Users on alternate plans, behind proxies, or in different regions must fork the code to change an endpoint.

Huge thanks to @ZerGo0 for the research in #13 identifying the Z.ai, Kimi, and MiniMax coding plan endpoints and the need for this feature. This PR takes a complementary approach — making the base URL a configurable property of each existing provider rather than creating separate provider entries per endpoint variant. One provider = one API key field = one identity. The URL is a deployment choice, not a provider identity.

This also lays groundwork for future extensibility: custom provider instances, proxy routing, and arbitrary OpenAI/Anthropic-compatible endpoints can all be configured without code changes.

### Changes

**Backend**
- Consolidated 11 near-identical `call_*` methods into 2 generic helpers (`call_openai_compatible`, `call_anthropic_compatible`), removing ~260 lines of duplication
- Added `base_url` (`Option<String>`) for every provider in `LlmConfig`
- Env var support: `{PROVIDER}_BASE_URL` (e.g., `ZHIPU_BASE_URL`, `OPENAI_BASE_URL`)
- TOML support: `zhipu_base_url = "..."` in `[llm]` section
- `env:VAR_NAME` indirection works for base URLs, consistent with API keys
- URL validation on update (rejects non-http(s) strings)
- `delete_provider` cleans up `base_url` alongside the key
- `GET /providers` returns `base_urls` map so the frontend can display current state

**Frontend**
- New `EndpointSelector` component with declarative presets per provider + custom URL fallback
- Presets for Z.ai (General / Coding Plan)
- Providers without alternate endpoints show no selector (unchanged UX)
- Adding a new preset for any provider is one line in `ENDPOINT_PRESETS`

**Bug fixes discovered during refactor**
- `opencode-zen` vs `opencode_zen` key mismatch in frontend `isConfigured` — was always returning `false`
- `is_needs_setup` only checked 3 of 12 providers — users with only Groq/Together/etc. configured were stuck in setup mode

### Breaking Changes

None. All existing config, env vars, and defaults are preserved. Providers without a `base_url` configured behave identically to before.

### How to Test

```bash
# Build
cargo build

# Set a custom base URL via env
ZHIPU_BASE_URL="https://api.z.ai/api/coding/paas/v4/chat/completions" cargo run

# Or via TOML
# [llm]
# zhipu_base_url = "https://api.z.ai/api/coding/paas/v4/chat/completions"

# Or via the web UI → Settings → Providers → Z.ai → Endpoint dropdown
```

### Verified

Tested end-to-end with a Z.ai Coding Plan subscription. Set `ZHIPU_BASE_URL` to the Coding Plan endpoint — chat completions return successfully. Without the override, the same key against the general endpoint returns 429 "Insufficient balance" (no pay-per-token credits loaded). With the Coding Plan endpoint, the subscription billing kicks in and requests succeed. This is exactly the user experience the `base_url` feature is designed to solve: same key, different endpoint, works without touching code.

### Diff stats
```
7 files changed, 367 insertions(+), 390 deletions(-)
```

Net reduction of 23 lines while adding the feature.