### PR TITLE
Add ARM64 multi-platform Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04
             platform: linux/amd64
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
@@ -83,7 +83,7 @@ jobs:
 
   merge:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary
- Add QEMU setup step for ARM emulation on GitHub runners
- Add `linux/arm64` platform to both `slim` and `full` image builds
- Tested locally on Apple Silicon — both targets build and run successfully
- Removed unnecessary write access in the build phase. It is only needed in the Github Release phase.

Let me know what you think. 

Tested the github action [here](https://github.com/andrasbacsai/spacebot/actions/runs/22129683504). I know it failed, because it could not push it to fly.io

- fixes #22 