### PR TITLE
Add support for Claude Code Token

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -462,6 +462,11 @@ export interface RoutingSection {
 	compactor: string;
 	cortex: string;
 	rate_limit_cooldown_secs: number;
+	channel_thinking_effort: string;
+	branch_thinking_effort: string;
+	worker_thinking_effort: string;
+	compactor_thinking_effort: string;
+	cortex_thinking_effort: string;
 }
 
 export interface TuningSection {
@@ -532,6 +537,11 @@ export interface RoutingUpdate {
 	compactor?: string;
 	cortex?: string;
 	rate_limit_cooldown_secs?: number;
+	channel_thinking_effort?: string;
+	branch_thinking_effort?: string;
+	worker_thinking_effort?: string;
+	compactor_thinking_effort?: string;
+	cortex_thinking_effort?: string;
 }
 
 export interface TuningUpdate {

--- a/interface/src/routes/AgentConfig.tsx
+++ b/interface/src/routes/AgentConfig.tsx
@@ -8,6 +8,12 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useSearch, useNavigate } from "@tanstack/react-router";
 
 
+function supportsAdaptiveThinking(modelId: string): boolean {
+	const id = modelId.toLowerCase();
+	return id.includes("opus-4-6") || id.includes("opus-4.6")
+		|| id.includes("sonnet-4-6") || id.includes("sonnet-4.6");
+}
+
 type SectionId = "soul" | "identity" | "user" | "routing" | "tuning" | "compaction" | "cortex" | "coalesce" | "memory" | "browser";
 
 const SECTIONS: {
@@ -485,39 +491,42 @@ function ConfigSectionEditor({ sectionId, label, description, detail, config, on
 
 	const renderFields = () => {
 		switch (sectionId) {
-			case "routing":
+			case "routing": {
+				const modelSlots = [
+					{ key: "channel", label: "Channel Model", description: "Model for user-facing channels" },
+					{ key: "branch", label: "Branch Model", description: "Model for thinking branches" },
+					{ key: "worker", label: "Worker Model", description: "Model for task workers" },
+					{ key: "compactor", label: "Compactor Model", description: "Model for summarization" },
+					{ key: "cortex", label: "Cortex Model", description: "Model for system observation" },
+				];
 				return (
 					<div className="grid gap-4">
-						<ModelSelect
-							label="Channel Model"
-							description="Model for user-facing channels"
-							value={localValues.channel as string}
-							onChange={(v) => handleChange("channel", v)}
-						/>
-						<ModelSelect
-							label="Branch Model"
-							description="Model for thinking branches"
-							value={localValues.branch as string}
-							onChange={(v) => handleChange("branch", v)}
-						/>
-						<ModelSelect
-							label="Worker Model"
-							description="Model for task workers"
-							value={localValues.worker as string}
-							onChange={(v) => handleChange("worker", v)}
-						/>
-						<ModelSelect
-							label="Compactor Model"
-							description="Model for summarization"
-							value={localValues.compactor as string}
-							onChange={(v) => handleChange("compactor", v)}
-						/>
-						<ModelSelect
-							label="Cortex Model"
-							description="Model for system observation"
-							value={localValues.cortex as string}
-							onChange={(v) => handleChange("cortex", v)}
-						/>
+						{modelSlots.map(({ key, label, description }) => (
+							<div key={key} className="flex flex-col gap-2">
+								<ModelSelect
+									label={label}
+									description={description}
+									value={localValues[key] as string}
+									onChange={(v) => handleChange(key, v)}
+								/>
+								{supportsAdaptiveThinking(localValues[key] as string) && (
+									<div className="ml-4 flex flex-col gap-1">
+										<label className="text-xs font-medium text-ink-dull">Thinking Effort</label>
+										<select
+											value={(localValues[`${key}_thinking_effort`] as string) || "auto"}
+											onChange={(e) => handleChange(`${key}_thinking_effort`, e.target.value)}
+											className="w-full rounded-md border border-app-line/50 bg-app-darkBox/30 px-3 py-1.5 text-sm text-ink focus:outline-none focus:ring-1 focus:ring-accent"
+										>
+											<option value="auto">Auto</option>
+											<option value="max">Max</option>
+											<option value="high">High</option>
+											<option value="medium">Medium</option>
+											<option value="low">Low</option>
+										</select>
+									</div>
+								)}
+							</div>
+						))}
 						<NumberStepper
 							label="Rate Limit Cooldown"
 							description="Seconds to deprioritize rate-limited models"
@@ -528,6 +537,7 @@ function ConfigSectionEditor({ sectionId, label, description, detail, config, on
 						/>
 					</div>
 				);
+			}
 			case "tuning":
 				return (
 					<div className="grid gap-4">

--- a/src/agent/cortex.rs
+++ b/src/agent/cortex.rs
@@ -462,8 +462,8 @@ pub async fn generate_bulletin(deps: &AgentDeps, logger: &CortexLogger) -> bool 
 
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Branch, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_routing((**routing).clone());
 
     // No tools needed — the LLM just synthesizes the pre-gathered data
     let agent = AgentBuilder::new(model).preamble(&bulletin_prompt).build();
@@ -621,8 +621,8 @@ async fn generate_profile(deps: &AgentDeps, logger: &CortexLogger) {
 
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Branch, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_routing((**routing).clone());
 
     let agent = AgentBuilder::new(model).preamble(&profile_prompt).build();
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -10,9 +10,12 @@ use axum::Router;
 use axum::http::{StatusCode, Uri, header};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{delete, get, post, put};
+use axum::{Json, State};
 use rust_embed::Embed;
+use serde::Serialize;
 use tower_http::cors::{Any, CorsLayer};
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -21,6 +24,480 @@ use std::sync::Arc;
 #[folder = "interface/dist/"]
 #[allow(unused)]
 struct InterfaceAssets;
+
+// -- Response types --
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+}
+
+#[derive(Serialize)]
+struct IdleResponse {
+    idle: bool,
+    active_workers: usize,
+    active_branches: usize,
+}
+
+#[derive(Serialize)]
+struct StatusResponse {
+    status: &'static str,
+    version: &'static str,
+    pid: u32,
+    uptime_seconds: u64,
+}
+
+#[derive(Serialize)]
+struct ChannelResponse {
+    agent_id: String,
+    id: String,
+    platform: String,
+    display_name: Option<String>,
+    is_active: bool,
+    last_activity_at: String,
+    created_at: String,
+}
+
+#[derive(Serialize)]
+struct ChannelsResponse {
+    channels: Vec<ChannelResponse>,
+}
+
+#[derive(Serialize)]
+struct MessagesResponse {
+    items: Vec<TimelineItem>,
+    has_more: bool,
+}
+
+#[derive(Serialize)]
+struct AgentsResponse {
+    agents: Vec<AgentInfo>,
+}
+
+#[derive(Serialize)]
+struct AgentOverviewResponse {
+    /// Memory count by type.
+    memory_counts: HashMap<String, i64>,
+    /// Total memory count.
+    memory_total: i64,
+    /// Active channel count for this agent.
+    channel_count: usize,
+    /// Cron jobs (all, not just enabled).
+    cron_jobs: Vec<CronJobInfo>,
+    /// Last cortex bulletin event time, if any.
+    last_bulletin_at: Option<String>,
+    /// Recent cortex events (last 5).
+    recent_cortex_events: Vec<CortexEvent>,
+    /// Daily memory creation counts for the last 30 days.
+    memory_daily: Vec<DayCount>,
+    /// Daily activity counts (branches, workers) for the last 30 days.
+    activity_daily: Vec<ActivityDayCount>,
+    /// Activity heatmap: messages per day-of-week/hour.
+    activity_heatmap: Vec<HeatmapCell>,
+    /// Latest cortex bulletin text, if any.
+    latest_bulletin: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DayCount {
+    date: String,
+    count: i64,
+}
+
+#[derive(Serialize)]
+struct ActivityDayCount {
+    date: String,
+    branches: i64,
+    workers: i64,
+}
+
+#[derive(Serialize)]
+struct HeatmapCell {
+    day: i64,
+    hour: i64,
+    count: i64,
+}
+
+#[derive(Serialize)]
+struct CronJobInfo {
+    id: String,
+    prompt: String,
+    interval_secs: u64,
+    delivery_target: String,
+    enabled: bool,
+    active_hours: Option<(u8, u8)>,
+}
+
+/// Instance-wide overview response for the main dashboard.
+#[derive(Serialize)]
+struct InstanceOverviewResponse {
+    version: &'static str,
+    uptime_seconds: u64,
+    pid: u32,
+    agents: Vec<AgentSummary>,
+}
+
+/// Summary of a single agent for the dashboard.
+#[derive(Serialize)]
+struct AgentSummary {
+    id: String,
+    /// Number of active channels.
+    channel_count: usize,
+    /// Total memory count.
+    memory_total: i64,
+    /// Number of cron jobs.
+    cron_job_count: usize,
+    /// 14-day activity sparkline (messages per day).
+    activity_sparkline: Vec<i64>,
+    /// Most recent activity across all channels.
+    last_activity_at: Option<String>,
+    /// Last bulletin generation time.
+    last_bulletin_at: Option<String>,
+    /// Cortex-generated agent profile (display name, status, bio).
+    profile: Option<crate::agent::cortex::AgentProfile>,
+}
+
+#[derive(Serialize)]
+struct MemoriesListResponse {
+    memories: Vec<Memory>,
+    total: usize,
+}
+
+#[derive(Serialize)]
+struct MemoriesSearchResponse {
+    results: Vec<MemorySearchResult>,
+}
+
+#[derive(Serialize)]
+struct MemoryGraphResponse {
+    nodes: Vec<Memory>,
+    edges: Vec<Association>,
+    total: usize,
+}
+
+#[derive(Serialize)]
+struct MemoryGraphNeighborsResponse {
+    nodes: Vec<Memory>,
+    edges: Vec<Association>,
+}
+
+#[derive(Serialize)]
+struct CortexEventsResponse {
+    events: Vec<CortexEvent>,
+    total: i64,
+}
+
+#[derive(Serialize)]
+struct CortexChatMessagesResponse {
+    messages: Vec<CortexChatMessage>,
+    thread_id: String,
+}
+
+#[derive(Serialize)]
+struct IdentityResponse {
+    soul: Option<String>,
+    identity: Option<String>,
+    user: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IdentityQuery {
+    agent_id: String,
+}
+
+#[derive(Deserialize)]
+struct IdentityUpdateRequest {
+    agent_id: String,
+    soul: Option<String>,
+    identity: Option<String>,
+    user: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CortexChatSendRequest {
+    agent_id: String,
+    thread_id: String,
+    message: String,
+    channel_id: Option<String>,
+}
+
+// -- Ingest Types --
+
+#[derive(Serialize)]
+struct IngestFileInfo {
+    content_hash: String,
+    filename: String,
+    file_size: i64,
+    total_chunks: i64,
+    chunks_completed: i64,
+    status: String,
+    started_at: String,
+    completed_at: Option<String>,
+}
+
+#[derive(Serialize)]
+struct IngestFilesResponse {
+    files: Vec<IngestFileInfo>,
+}
+
+#[derive(Serialize)]
+struct IngestUploadResponse {
+    uploaded: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct IngestDeleteResponse {
+    success: bool,
+}
+
+// -- Skill Types --
+
+#[derive(Serialize)]
+struct SkillInfo {
+    name: String,
+    description: String,
+    file_path: String,
+    base_dir: String,
+    source: String,
+}
+
+#[derive(Serialize)]
+struct SkillsListResponse {
+    skills: Vec<SkillInfo>,
+}
+
+#[derive(Deserialize)]
+struct InstallSkillRequest {
+    agent_id: String,
+    spec: String,
+    #[serde(default)]
+    instance: bool,
+}
+
+#[derive(Serialize)]
+struct InstallSkillResponse {
+    installed: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct RemoveSkillRequest {
+    agent_id: String,
+    name: String,
+}
+
+#[derive(Serialize)]
+struct RemoveSkillResponse {
+    success: bool,
+    path: Option<String>,
+}
+
+// -- Skills Registry Types (skills.sh proxy) --
+
+#[derive(Serialize, Deserialize, Clone)]
+struct RegistrySkill {
+    source: String,
+    #[serde(rename = "skillId")]
+    skill_id: String,
+    name: String,
+    installs: u64,
+    /// Only present in search results
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RegistryBrowseResponse {
+    skills: Vec<RegistrySkill>,
+    has_more: bool,
+}
+
+#[derive(Serialize)]
+struct RegistrySearchResponse {
+    skills: Vec<RegistrySkill>,
+    query: String,
+    count: usize,
+}
+
+// -- Agent Config Types --
+
+#[derive(Serialize, Debug)]
+struct RoutingSection {
+    channel: String,
+    branch: String,
+    worker: String,
+    compactor: String,
+    cortex: String,
+    rate_limit_cooldown_secs: u64,
+    channel_thinking_effort: String,
+    branch_thinking_effort: String,
+    worker_thinking_effort: String,
+    compactor_thinking_effort: String,
+    cortex_thinking_effort: String,
+}
+
+#[derive(Serialize, Debug)]
+struct TuningSection {
+    max_concurrent_branches: usize,
+    max_concurrent_workers: usize,
+    max_turns: usize,
+    branch_max_turns: usize,
+    context_window: usize,
+    history_backfill_count: usize,
+}
+
+#[derive(Serialize, Debug)]
+struct CompactionSection {
+    background_threshold: f32,
+    aggressive_threshold: f32,
+    emergency_threshold: f32,
+}
+
+#[derive(Serialize, Debug)]
+struct CortexSection {
+    tick_interval_secs: u64,
+    worker_timeout_secs: u64,
+    branch_timeout_secs: u64,
+    circuit_breaker_threshold: u8,
+    bulletin_interval_secs: u64,
+    bulletin_max_words: usize,
+    bulletin_max_turns: usize,
+}
+
+#[derive(Serialize, Debug)]
+struct CoalesceSection {
+    enabled: bool,
+    debounce_ms: u64,
+    max_wait_ms: u64,
+    min_messages: usize,
+    multi_user_only: bool,
+}
+
+#[derive(Serialize, Debug)]
+struct MemoryPersistenceSection {
+    enabled: bool,
+    message_interval: usize,
+}
+
+#[derive(Serialize, Debug)]
+struct BrowserSection {
+    enabled: bool,
+    headless: bool,
+    evaluate_enabled: bool,
+}
+
+#[derive(Serialize, Debug)]
+struct DiscordSection {
+    enabled: bool,
+    allow_bot_messages: bool,
+}
+
+#[derive(Serialize, Debug)]
+struct AgentConfigResponse {
+    routing: RoutingSection,
+    tuning: TuningSection,
+    compaction: CompactionSection,
+    cortex: CortexSection,
+    coalesce: CoalesceSection,
+    memory_persistence: MemoryPersistenceSection,
+    browser: BrowserSection,
+    discord: DiscordSection,
+}
+
+#[derive(Deserialize)]
+struct AgentConfigQuery {
+    agent_id: String,
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct AgentConfigUpdateRequest {
+    agent_id: String,
+    #[serde(default)]
+    routing: Option<RoutingUpdate>,
+    #[serde(default)]
+    tuning: Option<TuningUpdate>,
+    #[serde(default)]
+    compaction: Option<CompactionUpdate>,
+    #[serde(default)]
+    cortex: Option<CortexUpdate>,
+    #[serde(default)]
+    coalesce: Option<CoalesceUpdate>,
+    #[serde(default)]
+    memory_persistence: Option<MemoryPersistenceUpdate>,
+    #[serde(default)]
+    browser: Option<BrowserUpdate>,
+    #[serde(default)]
+    discord: Option<DiscordUpdate>,
+}
+
+#[derive(Deserialize, Debug)]
+struct RoutingUpdate {
+    channel: Option<String>,
+    branch: Option<String>,
+    worker: Option<String>,
+    compactor: Option<String>,
+    cortex: Option<String>,
+    rate_limit_cooldown_secs: Option<u64>,
+    channel_thinking_effort: Option<String>,
+    branch_thinking_effort: Option<String>,
+    worker_thinking_effort: Option<String>,
+    compactor_thinking_effort: Option<String>,
+    cortex_thinking_effort: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TuningUpdate {
+    max_concurrent_branches: Option<usize>,
+    max_concurrent_workers: Option<usize>,
+    max_turns: Option<usize>,
+    branch_max_turns: Option<usize>,
+    context_window: Option<usize>,
+    history_backfill_count: Option<usize>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CompactionUpdate {
+    background_threshold: Option<f32>,
+    aggressive_threshold: Option<f32>,
+    emergency_threshold: Option<f32>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CortexUpdate {
+    tick_interval_secs: Option<u64>,
+    worker_timeout_secs: Option<u64>,
+    branch_timeout_secs: Option<u64>,
+    circuit_breaker_threshold: Option<u8>,
+    bulletin_interval_secs: Option<u64>,
+    bulletin_max_words: Option<usize>,
+    bulletin_max_turns: Option<usize>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CoalesceUpdate {
+    enabled: Option<bool>,
+    debounce_ms: Option<u64>,
+    max_wait_ms: Option<u64>,
+    min_messages: Option<usize>,
+    multi_user_only: Option<bool>,
+}
+
+#[derive(Deserialize, Debug)]
+struct MemoryPersistenceUpdate {
+    enabled: Option<bool>,
+    message_interval: Option<usize>,
+}
+
+#[derive(Deserialize, Debug)]
+struct BrowserUpdate {
+    enabled: Option<bool>,
+    headless: Option<bool>,
+    evaluate_enabled: Option<bool>,
+}
+
+#[derive(Deserialize, Debug)]
+struct DiscordUpdate {
+    allow_bot_messages: Option<bool>,
+}
 
 /// Start the HTTP server on the given address.
 ///
@@ -151,6 +628,4740 @@ pub async fn start_http_server(
 
     Ok(handle)
 }
+
+// -- API handlers --
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok" })
+}
+
+/// Reports whether the instance is idle (no active workers or branches).
+/// Used by the platform to gate rolling updates.
+async fn idle(State(state): State<Arc<ApiState>>) -> Json<IdleResponse> {
+    let blocks = state.channel_status_blocks.read().await;
+    let mut total_workers = 0;
+    let mut total_branches = 0;
+
+    for status_block in blocks.values() {
+        let block = status_block.read().await;
+        total_workers += block.active_workers.len();
+        total_branches += block.active_branches.len();
+    }
+
+    Json(IdleResponse {
+        idle: total_workers == 0 && total_branches == 0,
+        active_workers: total_workers,
+        active_branches: total_branches,
+    })
+}
+
+async fn status(State(state): State<Arc<ApiState>>) -> Json<StatusResponse> {
+    let uptime = state.started_at.elapsed();
+    Json(StatusResponse {
+        status: "running",
+        version: env!("CARGO_PKG_VERSION"),
+        pid: std::process::id(),
+        uptime_seconds: uptime.as_secs(),
+    })
+}
+
+/// List all configured agents with their config summaries.
+async fn list_agents(State(state): State<Arc<ApiState>>) -> Json<AgentsResponse> {
+    let agents = state.agent_configs.load();
+    Json(AgentsResponse { agents: agents.as_ref().clone() })
+}
+
+/// Create a new agent and initialize it live (directories, databases, memory, identity, cron, cortex).
+async fn create_agent(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<CreateAgentRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let agent_id = request.agent_id.trim().to_string();
+    if agent_id.is_empty() {
+        return Ok(Json(serde_json::json!({
+            "success": false,
+            "message": "Agent ID cannot be empty"
+        })));
+    }
+
+    // Check if agent already exists
+    {
+        let existing = state.agent_configs.load();
+        if existing.iter().any(|a| a.id == agent_id) {
+            return Ok(Json(serde_json::json!({
+                "success": false,
+                "message": format!("Agent '{agent_id}' already exists")
+            })));
+        }
+    }
+
+    let config_path = state.config_path.read().await.clone();
+    let instance_dir = (**state.instance_dir.load()).clone();
+
+    // Write agent entry to config.toml
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+            tracing::warn!(%error, "failed to read config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+    } else {
+        String::new()
+    };
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    if doc.get("agents").is_none() {
+        doc["agents"] = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+    }
+    let agents_array = doc["agents"]
+        .as_array_of_tables_mut()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut new_table = toml_edit::Table::new();
+    new_table["id"] = toml_edit::value(&agent_id);
+    agents_array.push(new_table);
+
+    tokio::fs::write(&config_path, doc.to_string()).await.map_err(|error| {
+        tracing::warn!(%error, "failed to write config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Resolve the agent config using instance defaults
+    let defaults = state.defaults_config.read().await;
+    let defaults = defaults.as_ref().ok_or_else(|| {
+        tracing::error!("defaults config not available");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let raw_config = crate::config::AgentConfig {
+        id: agent_id.clone(),
+        default: false,
+        workspace: None,
+        routing: None,
+        max_concurrent_branches: None,
+        max_concurrent_workers: None,
+        max_turns: None,
+        branch_max_turns: None,
+        context_window: None,
+        compaction: None,
+        memory_persistence: None,
+        coalesce: None,
+        ingestion: None,
+        cortex: None,
+        browser: None,
+        brave_search_key: None,
+        cron: Vec::new(),
+    };
+    let agent_config = raw_config.resolve(&instance_dir, defaults);
+    drop(defaults);
+
+    // Create directories
+    for dir in [
+        &agent_config.workspace,
+        &agent_config.data_dir,
+        &agent_config.archives_dir,
+        &agent_config.ingest_dir(),
+        &agent_config.logs_dir(),
+    ] {
+        std::fs::create_dir_all(dir).map_err(|error| {
+            tracing::error!(%error, dir = %dir.display(), "failed to create agent directory");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    }
+
+    // Connect databases
+    let db = crate::db::Db::connect(&agent_config.data_dir).await.map_err(|error| {
+        tracing::error!(%error, agent_id = %agent_id, "failed to connect agent databases");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Settings store
+    let settings_path = agent_config.data_dir.join("settings.redb");
+    let settings_store = std::sync::Arc::new(
+        crate::settings::SettingsStore::new(&settings_path).map_err(|error| {
+            tracing::error!(%error, agent_id = %agent_id, "failed to init settings store");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+    );
+
+    // Memory system
+    let embedding_model = {
+        let guard = state.embedding_model.read().await;
+        guard.as_ref().ok_or_else(|| {
+            tracing::error!("embedding model not available");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?.clone()
+    };
+
+    let memory_store = crate::memory::MemoryStore::new(db.sqlite.clone());
+    let embedding_table = crate::memory::EmbeddingTable::open_or_create(&db.lance)
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, agent_id = %agent_id, "failed to init embeddings");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if let Err(error) = embedding_table.ensure_fts_index().await {
+        tracing::warn!(%error, agent_id = %agent_id, "failed to create FTS index");
+    }
+
+    let memory_search = std::sync::Arc::new(crate::memory::MemorySearch::new(
+        memory_store,
+        embedding_table,
+        embedding_model,
+    ));
+
+    // Event bus
+    let (event_tx, _) = tokio::sync::broadcast::channel(256);
+    let arc_agent_id: crate::AgentId = std::sync::Arc::from(agent_id.as_str());
+
+    // Identity scaffolding
+    crate::identity::scaffold_identity_files(&agent_config.workspace)
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, agent_id = %agent_id, "failed to scaffold identity files");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let identity = crate::identity::Identity::load(&agent_config.workspace).await;
+
+    // Skills
+    let skills = crate::skills::SkillSet::load(
+        &instance_dir.join("skills"),
+        &agent_config.skills_dir(),
+    ).await;
+
+    // Prompt engine
+    let prompt_engine = {
+        let guard = state.prompt_engine.read().await;
+        guard.as_ref().ok_or_else(|| {
+            tracing::error!("prompt engine not available");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?.clone()
+    };
+
+    // Defaults for RuntimeConfig
+    let defaults_for_runtime = {
+        let guard = state.defaults_config.read().await;
+        guard.as_ref().ok_or_else(|| {
+            tracing::error!("defaults config not available");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?.clone()
+    };
+
+    // RuntimeConfig
+    let runtime_config = std::sync::Arc::new(crate::config::RuntimeConfig::new(
+        &instance_dir,
+        &agent_config,
+        &defaults_for_runtime,
+        prompt_engine,
+        identity,
+        skills,
+    ));
+    runtime_config.set_settings(settings_store.clone());
+
+    // LLM manager
+    let llm_manager = {
+        let guard = state.llm_manager.read().await;
+        guard.as_ref().ok_or_else(|| {
+            tracing::error!("LLM manager not available");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?.clone()
+    };
+
+    // Build deps
+    let deps = crate::AgentDeps {
+        agent_id: arc_agent_id.clone(),
+        memory_search: memory_search.clone(),
+        llm_manager,
+        cron_tool: None,
+        runtime_config: runtime_config.clone(),
+        event_tx: event_tx.clone(),
+        sqlite_pool: db.sqlite.clone(),
+    };
+
+    // Register event stream with API
+    let event_rx = event_tx.subscribe();
+    state.register_agent_events(agent_id.clone(), event_rx);
+
+    // Cron setup
+    let cron_store = std::sync::Arc::new(crate::cron::CronStore::new(db.sqlite.clone()));
+    let cron_context = crate::cron::CronContext {
+        deps: deps.clone(),
+        screenshot_dir: agent_config.screenshot_dir(),
+        logs_dir: agent_config.logs_dir(),
+        messaging_manager: {
+            let guard = state.messaging_manager.read().await;
+            guard.as_ref().cloned().unwrap_or_else(|| std::sync::Arc::new(crate::messaging::MessagingManager::new()))
+        },
+        store: cron_store.clone(),
+    };
+    let scheduler = std::sync::Arc::new(crate::cron::Scheduler::new(cron_context));
+    runtime_config.set_cron(cron_store.clone(), scheduler.clone());
+
+    let cron_tool = crate::tools::CronTool::new(cron_store.clone(), scheduler.clone());
+
+    // Cortex chat session
+    let browser_config = (**runtime_config.browser_config.load()).clone();
+    let brave_search_key = (**runtime_config.brave_search_key.load()).clone();
+    let conversation_logger = crate::conversation::history::ConversationLogger::new(db.sqlite.clone());
+    let channel_store = crate::conversation::ChannelStore::new(db.sqlite.clone());
+    let cortex_tool_server = crate::tools::create_cortex_chat_tool_server(
+        memory_search.clone(),
+        conversation_logger,
+        channel_store,
+        browser_config,
+        agent_config.screenshot_dir(),
+        brave_search_key,
+        runtime_config.workspace_dir.clone(),
+        runtime_config.instance_dir.clone(),
+    );
+    let cortex_store = crate::agent::cortex_chat::CortexChatStore::new(db.sqlite.clone());
+    let cortex_session = crate::agent::cortex_chat::CortexChatSession::new(
+        deps.clone(),
+        cortex_tool_server,
+        cortex_store,
+    );
+
+    // Spawn cortex loops
+    let cortex_logger = crate::agent::cortex::CortexLogger::new(db.sqlite.clone());
+    tokio::spawn({
+        let deps = deps.clone();
+        let logger = cortex_logger.clone();
+        async move {
+            crate::agent::cortex::spawn_bulletin_loop(deps, logger).await;
+        }
+    });
+    tokio::spawn({
+        let deps = deps.clone();
+        async move {
+            crate::agent::cortex::spawn_association_loop(deps, cortex_logger).await;
+        }
+    });
+
+    // Spawn ingestion if enabled
+    let ingestion_config = **runtime_config.ingestion.load();
+    if ingestion_config.enabled {
+        crate::agent::ingestion::spawn_ingestion_loop(
+            agent_config.ingest_dir(),
+            deps.clone(),
+        );
+    }
+
+    // Build the Agent and send to main loop so it can receive messages
+    let sqlite_pool = db.sqlite.clone();
+    let mut deps_with_cron = deps.clone();
+    deps_with_cron.cron_tool = Some(cron_tool);
+    let agent = crate::Agent {
+        id: arc_agent_id.clone(),
+        config: agent_config.clone(),
+        db,
+        deps: deps_with_cron,
+    };
+    if let Err(error) = state.agent_tx.send(agent).await {
+        tracing::error!(%error, "failed to send new agent to main loop");
+    }
+
+    // Update all ArcSwap-based API state maps
+    {
+        // Agent pools
+        let mut pools = (**state.agent_pools.load()).clone();
+        pools.insert(agent_id.clone(), sqlite_pool);
+        state.agent_pools.store(std::sync::Arc::new(pools));
+
+        // Memory searches
+        let mut searches = (**state.memory_searches.load()).clone();
+        searches.insert(agent_id.clone(), memory_search);
+        state.memory_searches.store(std::sync::Arc::new(searches));
+
+        // Agent workspaces
+        let mut workspaces = (**state.agent_workspaces.load()).clone();
+        workspaces.insert(agent_id.clone(), agent_config.workspace.clone());
+        state.agent_workspaces.store(std::sync::Arc::new(workspaces));
+
+        // Runtime configs
+        let mut configs = (**state.runtime_configs.load()).clone();
+        configs.insert(agent_id.clone(), runtime_config);
+        state.runtime_configs.store(std::sync::Arc::new(configs));
+
+        // Agent config summaries
+        let mut agent_infos = (**state.agent_configs.load()).clone();
+        agent_infos.push(AgentInfo {
+            id: agent_config.id.clone(),
+            workspace: agent_config.workspace.clone(),
+            context_window: agent_config.context_window,
+            max_turns: agent_config.max_turns,
+            max_concurrent_branches: agent_config.max_concurrent_branches,
+            max_concurrent_workers: agent_config.max_concurrent_workers,
+        });
+        state.agent_configs.store(std::sync::Arc::new(agent_infos));
+
+        // Cron stores and schedulers
+        let mut cron_stores = (**state.cron_stores.load()).clone();
+        cron_stores.insert(agent_id.clone(), cron_store);
+        state.cron_stores.store(std::sync::Arc::new(cron_stores));
+
+        let mut cron_schedulers = (**state.cron_schedulers.load()).clone();
+        cron_schedulers.insert(agent_id.clone(), scheduler);
+        state.cron_schedulers.store(std::sync::Arc::new(cron_schedulers));
+
+        // Cortex chat sessions
+        let mut sessions = (**state.cortex_chat_sessions.load()).clone();
+        sessions.insert(agent_id.clone(), std::sync::Arc::new(cortex_session));
+        state.cortex_chat_sessions.store(std::sync::Arc::new(sessions));
+    }
+
+    tracing::info!(agent_id = %agent_id, "agent created and initialized via API");
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "agent_id": agent_id,
+        "message": format!("Agent '{agent_id}' created and running")
+    })))
+}
+
+#[derive(Deserialize)]
+struct CreateAgentRequest {
+    agent_id: String,
+}
+
+/// Get overview stats for an agent: memory breakdown, channels, cron, cortex.
+async fn agent_overview(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<AgentOverviewQuery>,
+) -> Result<Json<AgentOverviewResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    // Memory counts by type
+    let memory_rows = sqlx::query(
+        "SELECT memory_type, COUNT(*) as count FROM memories WHERE forgotten = 0 GROUP BY memory_type",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| {
+        tracing::warn!(%error, agent_id = %query.agent_id, "failed to count memories");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut memory_counts: HashMap<String, i64> = HashMap::new();
+    let mut memory_total: i64 = 0;
+    for row in &memory_rows {
+        let memory_type: String = row.get("memory_type");
+        let count: i64 = row.get("count");
+        memory_total += count;
+        memory_counts.insert(memory_type, count);
+    }
+
+    // Channel count
+    let channel_store = ChannelStore::new(pool.clone());
+    let channels = channel_store.list_active().await.unwrap_or_default();
+    let channel_count = channels.len();
+
+    // Cron jobs
+    let cron_rows = sqlx::query(
+        "SELECT id, prompt, interval_secs, delivery_target, active_start_hour, active_end_hour, enabled FROM cron_jobs ORDER BY created_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let cron_jobs: Vec<CronJobInfo> = cron_rows
+        .into_iter()
+        .map(|row| {
+            let active_start: Option<i64> = row.try_get("active_start_hour").ok();
+            let active_end: Option<i64> = row.try_get("active_end_hour").ok();
+            CronJobInfo {
+                id: row.get("id"),
+                prompt: row.get("prompt"),
+                interval_secs: row.get::<i64, _>("interval_secs") as u64,
+                delivery_target: row.get("delivery_target"),
+                enabled: row.get::<i64, _>("enabled") != 0,
+                active_hours: match (active_start, active_end) {
+                    (Some(s), Some(e)) => Some((s as u8, e as u8)),
+                    _ => None,
+                },
+            }
+        })
+        .collect();
+
+    // Last bulletin time
+    let cortex_logger = CortexLogger::new(pool.clone());
+    let bulletin_events = cortex_logger
+        .load_events(1, 0, Some("bulletin_generated"))
+        .await
+        .unwrap_or_default();
+    let last_bulletin_at = bulletin_events.first().map(|e| e.created_at.clone());
+
+    // Recent cortex events
+    let recent_cortex_events = cortex_logger
+        .load_events(5, 0, None)
+        .await
+        .unwrap_or_default();
+
+    // Latest bulletin text
+    let latest_bulletin = bulletin_events.first().and_then(|e| {
+        e.details.as_ref().and_then(|d| {
+            d.get("bulletin_text").and_then(|v| v.as_str().map(|s| s.to_string()))
+        })
+    });
+
+    // Memory daily counts for last 30 days
+    let memory_daily_rows = sqlx::query(
+        "SELECT date(created_at) as date, COUNT(*) as count FROM memories WHERE forgotten = 0 AND created_at > date('now', '-30 days') GROUP BY date ORDER BY date",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let memory_daily: Vec<DayCount> = memory_daily_rows
+        .into_iter()
+        .map(|row| DayCount {
+            date: row.get("date"),
+            count: row.get("count"),
+        })
+        .collect();
+
+    // Activity daily counts (branches + workers) for last 30 days
+    let activity_window = chrono::Utc::now() - chrono::Duration::days(30);
+
+    let branch_activity = sqlx::query(
+        "SELECT date(started_at) as date, COUNT(*) as count FROM branch_runs WHERE started_at > ? GROUP BY date ORDER BY date",
+    )
+    .bind(activity_window.to_rfc3339())
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let worker_activity = sqlx::query(
+        "SELECT date(started_at) as date, COUNT(*) as count FROM worker_runs WHERE started_at > ? GROUP BY date ORDER BY date",
+    )
+    .bind(activity_window.to_rfc3339())
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let activity_daily: Vec<ActivityDayCount> = {
+        let mut map: HashMap<String, ActivityDayCount> = HashMap::new();
+        for row in branch_activity {
+            let date: String = row.get("date");
+            let count: i64 = row.get("count");
+            map.entry(date.clone()).or_insert_with(|| ActivityDayCount { date, branches: 0, workers: 0 }).branches = count;
+        }
+        for row in worker_activity {
+            let date: String = row.get("date");
+            let count: i64 = row.get("count");
+            map.entry(date.clone()).or_insert_with(|| ActivityDayCount { date, branches: 0, workers: 0 }).workers = count;
+        }
+        let mut days: Vec<_> = map.into_values().collect();
+        days.sort_by(|a, b| a.date.cmp(&b.date));
+        days
+    };
+
+    // Activity heatmap: messages per day-of-week/hour
+    let heatmap_rows = sqlx::query(
+        "SELECT CAST(strftime('%w', created_at) AS INTEGER) as day, CAST(strftime('%H', created_at) AS INTEGER) as hour, COUNT(*) as count FROM conversation_messages WHERE created_at > date('now', '-90 days') GROUP BY day, hour",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    let activity_heatmap: Vec<HeatmapCell> = heatmap_rows
+        .into_iter()
+        .map(|row| HeatmapCell {
+            day: row.get("day"),
+            hour: row.get("hour"),
+            count: row.get("count"),
+        })
+        .collect();
+
+    Ok(Json(AgentOverviewResponse {
+        memory_counts,
+        memory_total,
+        channel_count,
+        cron_jobs,
+        last_bulletin_at,
+        recent_cortex_events,
+        memory_daily,
+        activity_daily,
+        activity_heatmap,
+        latest_bulletin,
+    }))
+}
+
+#[derive(Deserialize)]
+struct AgentOverviewQuery {
+    agent_id: String,
+}
+
+/// Get instance-wide overview for the main dashboard.
+async fn instance_overview(State(state): State<Arc<ApiState>>) -> Result<Json<InstanceOverviewResponse>, StatusCode> {
+    let uptime = state.started_at.elapsed();
+    let pools = state.agent_pools.load();
+    let configs = state.agent_configs.load();
+
+    let mut agents: Vec<AgentSummary> = Vec::new();
+
+    for agent_config in configs.iter() {
+        let agent_id = agent_config.id.clone();
+        
+        let Some(pool) = pools.get(&agent_id) else {
+            continue;
+        };
+
+        // Channel count
+        let channel_store = ChannelStore::new(pool.clone());
+        let channels = channel_store.list_active().await.unwrap_or_default();
+        let channel_count = channels.len();
+
+        // Last activity from channels
+        let last_activity_at = channels.iter()
+            .map(|c| &c.last_activity_at)
+            .max()
+            .map(|dt| dt.to_rfc3339());
+
+        // Memory count
+        let memory_total: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM memories WHERE forgotten = 0",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+
+        // Cron job count
+        let cron_job_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM cron_jobs",
+        )
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+
+        // 14-day activity sparkline
+        let activity_window = chrono::Utc::now() - chrono::Duration::days(14);
+        let activity_rows = sqlx::query(
+            "SELECT date(created_at) as date, COUNT(*) as count FROM conversation_messages WHERE created_at > ? GROUP BY date ORDER BY date",
+        )
+        .bind(activity_window.to_rfc3339())
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+
+        // Build sparkline (14 values, one per day, 0 for missing days)
+        let mut activity_map: HashMap<String, i64> = HashMap::new();
+        for row in &activity_rows {
+            let date: String = row.get("date");
+            let count: i64 = row.get("count");
+            activity_map.insert(date, count);
+        }
+
+        let mut activity_sparkline: Vec<i64> = Vec::with_capacity(14);
+        for i in 0..14 {
+            let date = (chrono::Utc::now() - chrono::Duration::days(13 - i as i64)).format("%Y-%m-%d").to_string();
+            activity_sparkline.push(*activity_map.get(&date).unwrap_or(&0));
+        }
+
+        // Last bulletin time
+        let cortex_logger = CortexLogger::new(pool.clone());
+        let bulletin_events = cortex_logger
+            .load_events(1, 0, Some("bulletin_generated"))
+            .await
+            .unwrap_or_default();
+        let last_bulletin_at = bulletin_events.first().map(|e| e.created_at.clone());
+
+        // Agent profile
+        let profile = crate::agent::cortex::load_profile(pool, &agent_id).await;
+
+        agents.push(AgentSummary {
+            id: agent_id,
+            channel_count,
+            memory_total,
+            cron_job_count: cron_job_count as usize,
+            activity_sparkline,
+            last_activity_at,
+            last_bulletin_at,
+            profile,
+        });
+    }
+
+    Ok(Json(InstanceOverviewResponse {
+        version: env!("CARGO_PKG_VERSION"),
+        uptime_seconds: uptime.as_secs(),
+        pid: std::process::id(),
+        agents,
+    }))
+}
+
+/// SSE endpoint streaming all agent events to connected clients.
+async fn events_sse(
+    State(state): State<Arc<ApiState>>,
+) -> Sse<impl Stream<Item = Result<axum::response::sse::Event, Infallible>>> {
+    let mut rx = state.event_tx.subscribe();
+
+    let stream = async_stream::stream! {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if let Ok(json) = serde_json::to_string(&event) {
+                        let event_type = match &event {
+                            ApiEvent::InboundMessage { .. } => "inbound_message",
+                            ApiEvent::OutboundMessage { .. } => "outbound_message",
+                            ApiEvent::TypingState { .. } => "typing_state",
+                            ApiEvent::WorkerStarted { .. } => "worker_started",
+                            ApiEvent::WorkerStatusUpdate { .. } => "worker_status",
+                            ApiEvent::WorkerCompleted { .. } => "worker_completed",
+                            ApiEvent::BranchStarted { .. } => "branch_started",
+                            ApiEvent::BranchCompleted { .. } => "branch_completed",
+                            ApiEvent::ToolStarted { .. } => "tool_started",
+                            ApiEvent::ToolCompleted { .. } => "tool_completed",
+                            ApiEvent::ConfigReloaded => "config_reloaded",
+                        };
+                        yield Ok(axum::response::sse::Event::default()
+                            .event(event_type)
+                            .data(json));
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                    tracing::debug!(count, "SSE client lagged");
+                    yield Ok(axum::response::sse::Event::default()
+                        .event("lagged")
+                        .data(format!("{{\"skipped\":{count}}}")));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text("ping"),
+    )
+}
+
+/// List active channels across all agents.
+async fn list_channels(State(state): State<Arc<ApiState>>) -> Json<ChannelsResponse> {
+    let pools = state.agent_pools.load();
+    let mut all_channels = Vec::new();
+
+    for (agent_id, pool) in pools.iter() {
+        let store = ChannelStore::new(pool.clone());
+        match store.list_active().await {
+            Ok(channels) => {
+                for channel in channels {
+                    all_channels.push(ChannelResponse {
+                        agent_id: agent_id.clone(),
+                        id: channel.id,
+                        platform: channel.platform,
+                        display_name: channel.display_name,
+                        is_active: channel.is_active,
+                        last_activity_at: channel.last_activity_at.to_rfc3339(),
+                        created_at: channel.created_at.to_rfc3339(),
+                    });
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, agent_id, "failed to list channels");
+            }
+        }
+    }
+
+    Json(ChannelsResponse { channels: all_channels })
+}
+
+#[derive(Deserialize)]
+struct MessagesQuery {
+    channel_id: String,
+    #[serde(default = "default_message_limit")]
+    limit: i64,
+    before: Option<String>,
+}
+
+fn default_message_limit() -> i64 {
+    20
+}
+
+/// Get the unified timeline for a channel: messages, branch runs, and worker runs
+/// interleaved chronologically.
+async fn channel_messages(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<MessagesQuery>,
+) -> Json<MessagesResponse> {
+    let pools = state.agent_pools.load();
+    let limit = query.limit.min(100);
+    // Fetch one extra to determine if there are more pages
+    let fetch_limit = limit + 1;
+
+    for (_agent_id, pool) in pools.iter() {
+        let logger = ProcessRunLogger::new(pool.clone());
+        match logger.load_channel_timeline(&query.channel_id, fetch_limit, query.before.as_deref()).await {
+            Ok(items) if !items.is_empty() => {
+                let has_more = items.len() as i64 > limit;
+                let items = if has_more { items[items.len() - limit as usize..].to_vec() } else { items };
+                return Json(MessagesResponse { items, has_more });
+            }
+            Ok(_) => continue,
+            Err(error) => {
+                tracing::warn!(%error, channel_id = %query.channel_id, "failed to load timeline");
+                continue;
+            }
+        }
+    }
+
+    Json(MessagesResponse { items: vec![], has_more: false })
+}
+
+/// Get live status (active workers, branches, completed items) for all channels.
+///
+/// Returns the StatusBlock directly -- it already derives Serialize.
+async fn channel_status(
+    State(state): State<Arc<ApiState>>,
+) -> Json<HashMap<String, serde_json::Value>> {
+    // Snapshot the map under the outer lock, then release it so
+    // register/unregister calls aren't blocked during serialization.
+    let snapshot: Vec<_> = {
+        let blocks = state.channel_status_blocks.read().await;
+        blocks.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    };
+
+    let mut result = HashMap::new();
+    for (channel_id, status_block) in snapshot {
+        let block = status_block.read().await;
+        if let Ok(value) = serde_json::to_value(&*block) {
+            result.insert(channel_id, value);
+        }
+    }
+
+    Json(result)
+}
+
+#[derive(Deserialize)]
+struct MemoriesListQuery {
+    agent_id: String,
+    #[serde(default = "default_memories_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: usize,
+    #[serde(default)]
+    memory_type: Option<String>,
+    #[serde(default = "default_memories_sort")]
+    sort: String,
+}
+
+fn default_memories_limit() -> i64 {
+    50
+}
+
+fn default_memories_sort() -> String {
+    "recent".into()
+}
+
+fn parse_sort(sort: &str) -> SearchSort {
+    match sort {
+        "importance" => SearchSort::Importance,
+        "most_accessed" => SearchSort::MostAccessed,
+        _ => SearchSort::Recent,
+    }
+}
+
+fn parse_memory_type(type_str: &str) -> Option<MemoryType> {
+    match type_str {
+        "fact" => Some(MemoryType::Fact),
+        "preference" => Some(MemoryType::Preference),
+        "decision" => Some(MemoryType::Decision),
+        "identity" => Some(MemoryType::Identity),
+        "event" => Some(MemoryType::Event),
+        "observation" => Some(MemoryType::Observation),
+        "goal" => Some(MemoryType::Goal),
+        "todo" => Some(MemoryType::Todo),
+        _ => None,
+    }
+}
+
+/// List memories for an agent with sorting, filtering, and pagination.
+async fn list_memories(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<MemoriesListQuery>,
+) -> Result<Json<MemoriesListResponse>, StatusCode> {
+    let searches = state.memory_searches.load();
+    let memory_search = searches.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let store = memory_search.store();
+
+    let limit = query.limit.min(200);
+    let sort = parse_sort(&query.sort);
+    let memory_type = query.memory_type.as_deref().and_then(parse_memory_type);
+
+    // Fetch limit + offset so we can paginate, then slice
+    let fetch_limit = limit + query.offset as i64;
+    let all = store.get_sorted(sort, fetch_limit, memory_type)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to list memories");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let total = all.len();
+    let memories = all.into_iter().skip(query.offset).collect();
+
+    Ok(Json(MemoriesListResponse { memories, total }))
+}
+
+#[derive(Deserialize)]
+struct MemoriesSearchQuery {
+    agent_id: String,
+    q: String,
+    #[serde(default = "default_search_limit")]
+    limit: usize,
+    #[serde(default)]
+    memory_type: Option<String>,
+}
+
+fn default_search_limit() -> usize {
+    20
+}
+
+/// Search memories using hybrid search (vector + FTS + graph).
+async fn search_memories(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<MemoriesSearchQuery>,
+) -> Result<Json<MemoriesSearchResponse>, StatusCode> {
+    let searches = state.memory_searches.load();
+    let memory_search = searches.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let config = SearchConfig {
+        mode: SearchMode::Hybrid,
+        memory_type: query.memory_type.as_deref().and_then(parse_memory_type),
+        max_results: query.limit.min(100),
+        ..SearchConfig::default()
+    };
+
+    let results = memory_search.search(&query.q, &config)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, query = %query.q, "memory search failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(MemoriesSearchResponse { results }))
+}
+
+// -- Memory graph handlers --
+
+#[derive(Deserialize)]
+struct MemoryGraphQuery {
+    agent_id: String,
+    #[serde(default = "default_graph_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: usize,
+    #[serde(default)]
+    memory_type: Option<String>,
+    #[serde(default = "default_memories_sort")]
+    sort: String,
+}
+
+fn default_graph_limit() -> i64 {
+    200
+}
+
+/// Get a subgraph of memories: nodes + all edges between them.
+/// Uses the same sort/filter params as the list endpoint, then fetches
+/// all associations that connect the returned nodes.
+async fn memory_graph(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<MemoryGraphQuery>,
+) -> Result<Json<MemoryGraphResponse>, StatusCode> {
+    let searches = state.memory_searches.load();
+    let memory_search = searches.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let store = memory_search.store();
+
+    let limit = query.limit.min(500);
+    let sort = parse_sort(&query.sort);
+    let memory_type = query.memory_type.as_deref().and_then(parse_memory_type);
+
+    let fetch_limit = limit + query.offset as i64;
+    let all = store.get_sorted(sort, fetch_limit, memory_type)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to load graph nodes");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let total = all.len();
+    let nodes: Vec<Memory> = all.into_iter().skip(query.offset).collect();
+    let node_ids: Vec<String> = nodes.iter().map(|m| m.id.clone()).collect();
+
+    let edges = store.get_associations_between(&node_ids)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to load graph edges");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(MemoryGraphResponse { nodes, edges, total }))
+}
+
+#[derive(Deserialize)]
+struct MemoryGraphNeighborsQuery {
+    agent_id: String,
+    memory_id: String,
+    #[serde(default = "default_neighbor_depth")]
+    depth: u32,
+    /// Comma-separated list of memory IDs the client already has.
+    #[serde(default)]
+    exclude: Option<String>,
+}
+
+fn default_neighbor_depth() -> u32 {
+    1
+}
+
+/// Get the neighbors of a specific memory node. Returns new nodes
+/// and edges not already present in the client's graph.
+async fn memory_graph_neighbors(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<MemoryGraphNeighborsQuery>,
+) -> Result<Json<MemoryGraphNeighborsResponse>, StatusCode> {
+    let searches = state.memory_searches.load();
+    let memory_search = searches.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let store = memory_search.store();
+
+    let depth = query.depth.min(3);
+    let exclude_ids: Vec<String> = query.exclude
+        .as_deref()
+        .unwrap_or("")
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
+    let (nodes, edges) = store.get_neighbors(&query.memory_id, depth, &exclude_ids)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, memory_id = %query.memory_id, "failed to load neighbors");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(MemoryGraphNeighborsResponse { nodes, edges }))
+}
+
+// -- Cortex chat handlers --
+
+#[derive(Deserialize)]
+struct CortexChatMessagesQuery {
+    agent_id: String,
+    /// If omitted, loads the latest thread.
+    thread_id: Option<String>,
+    #[serde(default = "default_cortex_chat_limit")]
+    limit: i64,
+}
+
+fn default_cortex_chat_limit() -> i64 {
+    50
+}
+
+/// Load persisted cortex chat history for a thread.
+/// If no thread_id is provided, loads the latest thread.
+/// If no threads exist, returns an empty list with a fresh thread_id.
+async fn cortex_chat_messages(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<CortexChatMessagesQuery>,
+) -> Result<Json<CortexChatMessagesResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let store = CortexChatStore::new(pool.clone());
+
+    // Resolve thread_id: explicit > latest > generate new
+    let thread_id = if let Some(tid) = query.thread_id {
+        tid
+    } else {
+        store
+            .latest_thread_id()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+    };
+
+    let messages = store
+        .load_history(&thread_id, query.limit.min(200))
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to load cortex chat history");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(CortexChatMessagesResponse { messages, thread_id }))
+}
+
+/// Send a message to cortex chat. Returns an SSE stream with activity events.
+///
+/// Send a message to cortex chat. Returns an SSE stream with activity events.
+///
+/// The stream emits:
+/// - `thinking` — cortex is processing
+/// - `tool_started` — a tool call began
+/// - `tool_completed` — a tool call finished (with result preview)
+/// - `done` — full response text
+/// - `error` — if something went wrong
+async fn cortex_chat_send(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<CortexChatSendRequest>,
+) -> Result<Sse<impl Stream<Item = Result<axum::response::sse::Event, Infallible>>>, StatusCode> {
+    let sessions = state.cortex_chat_sessions.load();
+    let session = sessions
+        .get(&request.agent_id)
+        .cloned()
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let thread_id = request.thread_id;
+    let message = request.message;
+    let channel_id = request.channel_id;
+
+    // Start the agent and get an event receiver
+    let channel_ref = channel_id.as_deref();
+    let mut event_rx = session
+        .send_message_with_events(&thread_id, &message, channel_ref)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to start cortex chat send");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let stream = async_stream::stream! {
+        // Send thinking event
+        yield Ok(axum::response::sse::Event::default()
+            .event("thinking")
+            .data("{}"));
+
+        // Forward events from the agent task
+        while let Some(event) = event_rx.recv().await {
+            let event_name = match &event {
+                CortexChatEvent::Thinking => "thinking",
+                CortexChatEvent::ToolStarted { .. } => "tool_started",
+                CortexChatEvent::ToolCompleted { .. } => "tool_completed",
+                CortexChatEvent::Done { .. } => "done",
+                CortexChatEvent::Error { .. } => "error",
+            };
+            if let Ok(json) = serde_json::to_string(&event) {
+                yield Ok(axum::response::sse::Event::default()
+                    .event(event_name)
+                    .data(json));
+            }
+        }
+    };
+
+    Ok(Sse::new(stream))
+}
+
+// -- Agent profile handler --
+
+/// Get the cortex-generated profile for an agent.
+async fn get_agent_profile(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<AgentOverviewQuery>,
+) -> Result<Json<AgentProfileResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let profile = crate::agent::cortex::load_profile(pool, &query.agent_id).await;
+
+    Ok(Json(AgentProfileResponse { profile }))
+}
+
+#[derive(Serialize)]
+struct AgentProfileResponse {
+    profile: Option<crate::agent::cortex::AgentProfile>,
+}
+
+// -- Identity file handlers --
+
+/// Get identity files (SOUL.md, IDENTITY.md, USER.md) for an agent.
+async fn get_identity(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<IdentityQuery>,
+) -> Result<Json<IdentityResponse>, StatusCode> {
+    let workspaces = state.agent_workspaces.load();
+    let workspace = workspaces.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let identity = crate::identity::Identity::load(workspace).await;
+
+    Ok(Json(IdentityResponse {
+        soul: identity.soul,
+        identity: identity.identity,
+        user: identity.user,
+    }))
+}
+
+/// Update identity files for an agent. Only writes files for fields that are present.
+/// The file watcher will pick up changes and hot-reload identity into RuntimeConfig.
+async fn update_identity(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<IdentityUpdateRequest>,
+) -> Result<Json<IdentityResponse>, StatusCode> {
+    let workspaces = state.agent_workspaces.load();
+    let workspace = workspaces.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    if let Some(soul) = &request.soul {
+        tokio::fs::write(workspace.join("SOUL.md"), soul)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to write SOUL.md");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    if let Some(identity) = &request.identity {
+        tokio::fs::write(workspace.join("IDENTITY.md"), identity)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to write IDENTITY.md");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    if let Some(user) = &request.user {
+        tokio::fs::write(workspace.join("USER.md"), user)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to write USER.md");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Read back the current state after writes
+    let updated = crate::identity::Identity::load(workspace).await;
+
+    Ok(Json(IdentityResponse {
+        soul: updated.soul,
+        identity: updated.identity,
+        user: updated.user,
+    }))
+}
+
+// -- Agent config handlers --
+
+/// Get the resolved configuration for an agent.
+/// Reads live values from the agent's RuntimeConfig (hot-reloaded via ArcSwap).
+async fn get_agent_config(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<AgentConfigQuery>,
+) -> Result<Json<AgentConfigResponse>, StatusCode> {
+    let runtime_configs = state.runtime_configs.load();
+    let rc = runtime_configs
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let routing = rc.routing.load();
+    let compaction = rc.compaction.load();
+    let cortex = rc.cortex.load();
+    let coalesce = rc.coalesce.load();
+    let memory_persistence = rc.memory_persistence.load();
+    let browser = rc.browser_config.load();
+
+    let response = AgentConfigResponse {
+        routing: RoutingSection {
+            channel: routing.channel.clone(),
+            branch: routing.branch.clone(),
+            worker: routing.worker.clone(),
+            compactor: routing.compactor.clone(),
+            cortex: routing.cortex.clone(),
+            rate_limit_cooldown_secs: routing.rate_limit_cooldown_secs,
+            channel_thinking_effort: routing.channel_thinking_effort.clone(),
+            branch_thinking_effort: routing.branch_thinking_effort.clone(),
+            worker_thinking_effort: routing.worker_thinking_effort.clone(),
+            compactor_thinking_effort: routing.compactor_thinking_effort.clone(),
+            cortex_thinking_effort: routing.cortex_thinking_effort.clone(),
+        },
+        tuning: TuningSection {
+            max_concurrent_branches: **rc.max_concurrent_branches.load(),
+            max_concurrent_workers: **rc.max_concurrent_workers.load(),
+            max_turns: **rc.max_turns.load(),
+            branch_max_turns: **rc.branch_max_turns.load(),
+            context_window: **rc.context_window.load(),
+            history_backfill_count: **rc.history_backfill_count.load(),
+        },
+        compaction: CompactionSection {
+            background_threshold: compaction.background_threshold,
+            aggressive_threshold: compaction.aggressive_threshold,
+            emergency_threshold: compaction.emergency_threshold,
+        },
+        cortex: CortexSection {
+            tick_interval_secs: cortex.tick_interval_secs,
+            worker_timeout_secs: cortex.worker_timeout_secs,
+            branch_timeout_secs: cortex.branch_timeout_secs,
+            circuit_breaker_threshold: cortex.circuit_breaker_threshold,
+            bulletin_interval_secs: cortex.bulletin_interval_secs,
+            bulletin_max_words: cortex.bulletin_max_words,
+            bulletin_max_turns: cortex.bulletin_max_turns,
+        },
+        coalesce: CoalesceSection {
+            enabled: coalesce.enabled,
+            debounce_ms: coalesce.debounce_ms,
+            max_wait_ms: coalesce.max_wait_ms,
+            min_messages: coalesce.min_messages,
+            multi_user_only: coalesce.multi_user_only,
+        },
+        memory_persistence: MemoryPersistenceSection {
+            enabled: memory_persistence.enabled,
+            message_interval: memory_persistence.message_interval,
+        },
+        browser: BrowserSection {
+            enabled: browser.enabled,
+            headless: browser.headless,
+            evaluate_enabled: browser.evaluate_enabled,
+        },
+        discord: {
+            let perms = state.discord_permissions.read().await;
+            match perms.as_ref() {
+                Some(arc_swap) => {
+                    let snapshot = arc_swap.load();
+                    DiscordSection {
+                        enabled: true,
+                        allow_bot_messages: snapshot.allow_bot_messages,
+                    }
+                }
+                None => DiscordSection {
+                    enabled: false,
+                    allow_bot_messages: false,
+                },
+            }
+        },
+    };
+
+    Ok(Json(response))
+}
+
+/// Update agent configuration by editing config.toml with toml_edit.
+/// This preserves formatting and comments while writing the new values.
+async fn update_agent_config(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<AgentConfigUpdateRequest>,
+) -> Result<Json<AgentConfigResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        tracing::error!("config_path not set in ApiState");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // Read the config file
+    let config_content = tokio::fs::read_to_string(&config_path)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to read config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Parse with toml_edit to preserve formatting
+    let mut doc = config_content.parse::<toml_edit::DocumentMut>()
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to parse config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Find or create the agent table
+    let agent_idx = find_or_create_agent_table(&mut doc, &request.agent_id)?;
+
+    // Apply updates to the correct agent entry
+    if let Some(routing) = &request.routing {
+        update_routing_table(&mut doc, agent_idx, routing)?;
+    }
+    if let Some(tuning) = &request.tuning {
+        update_tuning_table(&mut doc, agent_idx, tuning)?;
+    }
+    if let Some(compaction) = &request.compaction {
+        update_compaction_table(&mut doc, agent_idx, compaction)?;
+    }
+    if let Some(cortex) = &request.cortex {
+        update_cortex_table(&mut doc, agent_idx, cortex)?;
+    }
+    if let Some(coalesce) = &request.coalesce {
+        update_coalesce_table(&mut doc, agent_idx, coalesce)?;
+    }
+    if let Some(memory_persistence) = &request.memory_persistence {
+        update_memory_persistence_table(&mut doc, agent_idx, memory_persistence)?;
+    }
+    if let Some(browser) = &request.browser {
+        update_browser_table(&mut doc, agent_idx, browser)?;
+    }
+    if let Some(discord) = &request.discord {
+        update_discord_table(&mut doc, discord)?;
+    }
+
+    // Write the updated config back
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!(agent_id = %request.agent_id, "config.toml updated via API");
+
+    // Immediately reload RuntimeConfig and DiscordPermissions so the response
+    // reflects the new values (the file watcher will also pick this up, but has a 2s debounce)
+    match crate::config::Config::load_from_path(&config_path) {
+        Ok(new_config) => {
+            let runtime_configs = state.runtime_configs.load();
+            if let Some(rc) = runtime_configs.get(&request.agent_id) {
+                rc.reload_config(&new_config, &request.agent_id);
+            }
+            if request.discord.is_some() {
+                if let Some(discord_config) = &new_config.messaging.discord {
+                    let new_perms = crate::config::DiscordPermissions::from_config(
+                        discord_config,
+                        &new_config.bindings,
+                    );
+                    let perms = state.discord_permissions.read().await;
+                    if let Some(arc_swap) = perms.as_ref() {
+                        arc_swap.store(std::sync::Arc::new(new_perms));
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            tracing::warn!(%error, "config.toml written but failed to reload immediately");
+        }
+    }
+
+    get_agent_config(State(state), Query(AgentConfigQuery { agent_id: request.agent_id })).await
+}
+
+/// Find the index of an agent table in the [[agents]] array, or create a new one.
+fn find_or_create_agent_table(doc: &mut toml_edit::DocumentMut, agent_id: &str) -> Result<usize, StatusCode> {
+    // Create agents array if it doesn't exist
+    if doc.get("agents").is_none() {
+        doc["agents"] = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+    }
+
+    // Get the agents array
+    let agents = doc.get_mut("agents")
+        .and_then(|a| a.as_array_of_tables_mut())
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Find existing agent
+    for (idx, table) in agents.iter().enumerate() {
+        if let Some(id) = table.get("id").and_then(|v| v.as_str()) {
+            if id == agent_id {
+                return Ok(idx);
+            }
+        }
+    }
+
+    // Create new agent table
+    let mut new_agent = toml_edit::Table::new();
+    new_agent["id"] = toml_edit::value(agent_id);
+    agents.push(new_agent);
+
+    Ok(agents.len() - 1)
+}
+
+/// Get a mutable reference to an agent's table in the [[agents]] array.
+fn get_agent_table_mut(doc: &mut toml_edit::DocumentMut, agent_idx: usize) -> Result<&mut toml_edit::Table, StatusCode> {
+    doc.get_mut("agents")
+        .and_then(|a| a.as_array_of_tables_mut())
+        .and_then(|arr| arr.get_mut(agent_idx))
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Get or create a subtable within an agent's config (e.g., [agents.routing]).
+fn get_or_create_subtable<'a>(agent: &'a mut toml_edit::Table, key: &str) -> &'a mut toml_edit::Table {
+    if !agent.contains_key(key) {
+        agent[key] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    agent[key].as_table_mut().expect("just created as table")
+}
+
+fn update_routing_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, routing: &RoutingUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "routing");
+    if let Some(ref v) = routing.channel { table["channel"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.branch { table["branch"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.worker { table["worker"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.compactor { table["compactor"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.cortex { table["cortex"] = toml_edit::value(v.as_str()); }
+    if let Some(v) = routing.rate_limit_cooldown_secs { table["rate_limit_cooldown_secs"] = toml_edit::value(v as i64); }
+    if let Some(ref v) = routing.channel_thinking_effort { table["channel_thinking_effort"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.branch_thinking_effort { table["branch_thinking_effort"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.worker_thinking_effort { table["worker_thinking_effort"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.compactor_thinking_effort { table["compactor_thinking_effort"] = toml_edit::value(v.as_str()); }
+    if let Some(ref v) = routing.cortex_thinking_effort { table["cortex_thinking_effort"] = toml_edit::value(v.as_str()); }
+    Ok(())
+}
+
+fn update_tuning_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, tuning: &TuningUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    if let Some(v) = tuning.max_concurrent_branches { agent["max_concurrent_branches"] = toml_edit::value(v as i64); }
+    if let Some(v) = tuning.max_concurrent_workers { agent["max_concurrent_workers"] = toml_edit::value(v as i64); }
+    if let Some(v) = tuning.max_turns { agent["max_turns"] = toml_edit::value(v as i64); }
+    if let Some(v) = tuning.branch_max_turns { agent["branch_max_turns"] = toml_edit::value(v as i64); }
+    if let Some(v) = tuning.context_window { agent["context_window"] = toml_edit::value(v as i64); }
+    if let Some(v) = tuning.history_backfill_count { agent["history_backfill_count"] = toml_edit::value(v as i64); }
+    Ok(())
+}
+
+fn update_compaction_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, compaction: &CompactionUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "compaction");
+    if let Some(v) = compaction.background_threshold { table["background_threshold"] = toml_edit::value(v as f64); }
+    if let Some(v) = compaction.aggressive_threshold { table["aggressive_threshold"] = toml_edit::value(v as f64); }
+    if let Some(v) = compaction.emergency_threshold { table["emergency_threshold"] = toml_edit::value(v as f64); }
+    Ok(())
+}
+
+fn update_cortex_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, cortex: &CortexUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "cortex");
+    if let Some(v) = cortex.tick_interval_secs { table["tick_interval_secs"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.worker_timeout_secs { table["worker_timeout_secs"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.branch_timeout_secs { table["branch_timeout_secs"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.circuit_breaker_threshold { table["circuit_breaker_threshold"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.bulletin_interval_secs { table["bulletin_interval_secs"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.bulletin_max_words { table["bulletin_max_words"] = toml_edit::value(v as i64); }
+    if let Some(v) = cortex.bulletin_max_turns { table["bulletin_max_turns"] = toml_edit::value(v as i64); }
+    Ok(())
+}
+
+fn update_coalesce_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, coalesce: &CoalesceUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "coalesce");
+    if let Some(v) = coalesce.enabled { table["enabled"] = toml_edit::value(v); }
+    if let Some(v) = coalesce.debounce_ms { table["debounce_ms"] = toml_edit::value(v as i64); }
+    if let Some(v) = coalesce.max_wait_ms { table["max_wait_ms"] = toml_edit::value(v as i64); }
+    if let Some(v) = coalesce.min_messages { table["min_messages"] = toml_edit::value(v as i64); }
+    if let Some(v) = coalesce.multi_user_only { table["multi_user_only"] = toml_edit::value(v); }
+    Ok(())
+}
+
+fn update_memory_persistence_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, memory_persistence: &MemoryPersistenceUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "memory_persistence");
+    if let Some(v) = memory_persistence.enabled { table["enabled"] = toml_edit::value(v); }
+    if let Some(v) = memory_persistence.message_interval { table["message_interval"] = toml_edit::value(v as i64); }
+    Ok(())
+}
+
+fn update_browser_table(doc: &mut toml_edit::DocumentMut, agent_idx: usize, browser: &BrowserUpdate) -> Result<(), StatusCode> {
+    let agent = get_agent_table_mut(doc, agent_idx)?;
+    let table = get_or_create_subtable(agent, "browser");
+    if let Some(v) = browser.enabled { table["enabled"] = toml_edit::value(v); }
+    if let Some(v) = browser.headless { table["headless"] = toml_edit::value(v); }
+    if let Some(v) = browser.evaluate_enabled { table["evaluate_enabled"] = toml_edit::value(v); }
+    Ok(())
+}
+
+/// Update instance-level Discord config at [messaging.discord].
+fn update_discord_table(doc: &mut toml_edit::DocumentMut, discord: &DiscordUpdate) -> Result<(), StatusCode> {
+    let messaging = doc.get_mut("messaging")
+        .and_then(|m| m.as_table_mut())
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let discord_table = messaging.get_mut("discord")
+        .and_then(|d| d.as_table_mut())
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if let Some(allow_bot_messages) = discord.allow_bot_messages {
+        discord_table["allow_bot_messages"] = toml_edit::value(allow_bot_messages);
+    }
+
+    Ok(())
+}
+
+// -- Cortex events handlers --
+
+#[derive(Deserialize)]
+struct CortexEventsQuery {
+    agent_id: String,
+    #[serde(default = "default_cortex_events_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: i64,
+    #[serde(default)]
+    event_type: Option<String>,
+}
+
+fn default_cortex_events_limit() -> i64 {
+    50
+}
+
+/// List cortex events for an agent with optional type filter, newest first.
+async fn cortex_events(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<CortexEventsQuery>,
+) -> Result<Json<CortexEventsResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let logger = CortexLogger::new(pool.clone());
+
+    let limit = query.limit.min(200);
+    let event_type_ref = query.event_type.as_deref();
+
+    let events = logger
+        .load_events(limit, query.offset, event_type_ref)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to load cortex events");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let total = logger
+        .count_events(event_type_ref)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to count cortex events");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(CortexEventsResponse { events, total }))
+}
+
+// -- Cron handlers --
+
+#[derive(Deserialize)]
+struct CronQuery {
+    agent_id: String,
+}
+
+#[derive(Deserialize)]
+struct CronExecutionsQuery {
+    agent_id: String,
+    #[serde(default)]
+    cron_id: Option<String>,
+    #[serde(default = "default_cron_executions_limit")]
+    limit: i64,
+}
+
+fn default_cron_executions_limit() -> i64 {
+    50
+}
+
+#[derive(Deserialize, Debug)]
+struct CreateCronRequest {
+    agent_id: String,
+    id: String,
+    prompt: String,
+    #[serde(default = "default_interval")]
+    interval_secs: u64,
+    delivery_target: String,
+    #[serde(default)]
+    active_start_hour: Option<u8>,
+    #[serde(default)]
+    active_end_hour: Option<u8>,
+    #[serde(default = "default_enabled")]
+    enabled: bool,
+}
+
+fn default_interval() -> u64 {
+    3600
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+struct DeleteCronRequest {
+    agent_id: String,
+    cron_id: String,
+}
+
+#[derive(Deserialize)]
+struct TriggerCronRequest {
+    agent_id: String,
+    cron_id: String,
+}
+
+#[derive(Deserialize)]
+struct ToggleCronRequest {
+    agent_id: String,
+    cron_id: String,
+    enabled: bool,
+}
+
+#[derive(Serialize)]
+struct CronJobWithStats {
+    id: String,
+    prompt: String,
+    interval_secs: u64,
+    delivery_target: String,
+    enabled: bool,
+    active_hours: Option<(u8, u8)>,
+    success_count: u64,
+    failure_count: u64,
+    last_executed_at: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CronListResponse {
+    jobs: Vec<CronJobWithStats>,
+}
+
+#[derive(Serialize)]
+struct CronExecutionsResponse {
+    executions: Vec<crate::cron::CronExecutionEntry>,
+}
+
+#[derive(Serialize)]
+struct CronActionResponse {
+    success: bool,
+    message: String,
+}
+
+/// List all cron jobs for an agent with execution statistics.
+async fn list_cron_jobs(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<CronQuery>,
+) -> Result<Json<CronListResponse>, StatusCode> {
+    let stores = state.cron_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let configs = store
+        .load_all_unfiltered()
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, "failed to load cron jobs");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let mut jobs = Vec::new();
+    for config in configs {
+        let stats = store
+            .get_execution_stats(&config.id)
+            .await
+            .unwrap_or_default();
+
+        jobs.push(CronJobWithStats {
+            id: config.id,
+            prompt: config.prompt,
+            interval_secs: config.interval_secs,
+            delivery_target: config.delivery_target,
+            enabled: config.enabled,
+            active_hours: config.active_hours,
+            success_count: stats.success_count,
+            failure_count: stats.failure_count,
+            last_executed_at: stats.last_executed_at,
+        });
+    }
+
+    Ok(Json(CronListResponse { jobs }))
+}
+
+/// Get execution history for cron jobs.
+async fn cron_executions(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<CronExecutionsQuery>,
+) -> Result<Json<CronExecutionsResponse>, StatusCode> {
+    let stores = state.cron_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let executions = if let Some(cron_id) = query.cron_id {
+        store
+            .load_executions(&cron_id, query.limit)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, agent_id = %query.agent_id, cron_id = %cron_id, "failed to load cron executions");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+    } else {
+        store
+            .load_all_executions(query.limit)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, agent_id = %query.agent_id, "failed to load cron executions");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+    };
+
+    Ok(Json(CronExecutionsResponse { executions }))
+}
+
+/// Create or update a cron job.
+async fn create_or_update_cron(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<CreateCronRequest>,
+) -> Result<Json<CronActionResponse>, StatusCode> {
+    let stores = state.cron_stores.load();
+    let schedulers = state.cron_schedulers.load();
+
+    let store = stores.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let scheduler = schedulers.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let active_hours = match (request.active_start_hour, request.active_end_hour) {
+        (Some(start), Some(end)) => Some((start, end)),
+        _ => None,
+    };
+
+    let config = crate::cron::CronConfig {
+        id: request.id.clone(),
+        prompt: request.prompt,
+        interval_secs: request.interval_secs,
+        delivery_target: request.delivery_target,
+        active_hours,
+        enabled: request.enabled,
+    };
+
+    // Save to database
+    store.save(&config).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %request.agent_id, cron_id = %request.id, "failed to save cron job");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Register or update in scheduler
+    scheduler.register(config).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %request.agent_id, cron_id = %request.id, "failed to register cron job");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(CronActionResponse {
+        success: true,
+        message: format!("Cron job '{}' saved successfully", request.id),
+    }))
+}
+
+/// Delete a cron job.
+async fn delete_cron(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<DeleteCronRequest>,
+) -> Result<Json<CronActionResponse>, StatusCode> {
+    let stores = state.cron_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let schedulers = state.cron_schedulers.load();
+    let scheduler = schedulers.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    // Unregister from scheduler first
+    scheduler.unregister(&query.cron_id).await;
+
+    // Delete from database
+    store.delete(&query.cron_id).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %query.agent_id, cron_id = %query.cron_id, "failed to delete cron job");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(CronActionResponse {
+        success: true,
+        message: format!("Cron job '{}' deleted successfully", query.cron_id),
+    }))
+}
+
+/// Trigger a cron job immediately.
+async fn trigger_cron(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<TriggerCronRequest>,
+) -> Result<Json<CronActionResponse>, StatusCode> {
+    let schedulers = state.cron_schedulers.load();
+    let scheduler = schedulers.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    scheduler.trigger_now(&request.cron_id).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %request.agent_id, cron_id = %request.cron_id, "failed to trigger cron job");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(CronActionResponse {
+        success: true,
+        message: format!("Cron job '{}' triggered", request.cron_id),
+    }))
+}
+
+/// Enable or disable a cron job.
+async fn toggle_cron(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<ToggleCronRequest>,
+) -> Result<Json<CronActionResponse>, StatusCode> {
+    let stores = state.cron_stores.load();
+    let store = stores.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let schedulers = state.cron_schedulers.load();
+    let scheduler = schedulers.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    // Update in database first
+    store.update_enabled(&request.cron_id, request.enabled).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %request.agent_id, cron_id = %request.cron_id, "failed to update cron job enabled state");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Update in scheduler (this will start/stop the timer as needed)
+    scheduler.set_enabled(&request.cron_id, request.enabled).await.map_err(|error| {
+        tracing::warn!(%error, agent_id = %request.agent_id, cron_id = %request.cron_id, "failed to update scheduler enabled state");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let status = if request.enabled { "enabled" } else { "disabled" };
+    Ok(Json(CronActionResponse {
+        success: true,
+        message: format!("Cron job '{}' {}", request.cron_id, status),
+    }))
+}
+
+// -- Process cancellation --
+
+#[derive(Deserialize)]
+struct CancelProcessRequest {
+    channel_id: String,
+    process_type: String,
+    process_id: String,
+}
+
+#[derive(Serialize)]
+struct CancelProcessResponse {
+    success: bool,
+    message: String,
+}
+
+/// Cancel a running worker or branch via the API.
+async fn cancel_process(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<CancelProcessRequest>,
+) -> Result<Json<CancelProcessResponse>, StatusCode> {
+    let states = state.channel_states.read().await;
+    let channel_state = states.get(&request.channel_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    match request.process_type.as_str() {
+        "worker" => {
+            let worker_id: crate::WorkerId = request.process_id.parse()
+                .map_err(|_| StatusCode::BAD_REQUEST)?;
+            channel_state.cancel_worker(worker_id).await
+                .map_err(|_| StatusCode::NOT_FOUND)?;
+            Ok(Json(CancelProcessResponse {
+                success: true,
+                message: format!("Worker {} cancelled", request.process_id),
+            }))
+        }
+        "branch" => {
+            let branch_id: crate::BranchId = request.process_id.parse()
+                .map_err(|_| StatusCode::BAD_REQUEST)?;
+            channel_state.cancel_branch(branch_id).await
+                .map_err(|_| StatusCode::NOT_FOUND)?;
+            Ok(Json(CancelProcessResponse {
+                success: true,
+                message: format!("Branch {} cancelled", request.process_id),
+            }))
+        }
+        _ => Err(StatusCode::BAD_REQUEST),
+    }
+}
+
+// -- Provider management --
+
+#[derive(Serialize)]
+struct ProviderStatus {
+    anthropic: bool,
+    openai: bool,
+    openrouter: bool,
+    zhipu: bool,
+    groq: bool,
+    together: bool,
+    fireworks: bool,
+    deepseek: bool,
+    xai: bool,
+    mistral: bool,
+    opencode_zen: bool,
+}
+
+#[derive(Serialize)]
+struct ProvidersResponse {
+    providers: ProviderStatus,
+    has_any: bool,
+}
+
+#[derive(Deserialize)]
+struct ProviderUpdateRequest {
+    provider: String,
+    api_key: String,
+}
+
+#[derive(Serialize)]
+struct ProviderUpdateResponse {
+    success: bool,
+    message: String,
+}
+
+async fn get_providers(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ProvidersResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+
+    // Check which providers have keys by reading the config
+    let (anthropic, openai, openrouter, zhipu, groq, together, fireworks, deepseek, xai, mistral, opencode_zen) = if config_path.exists() {
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let doc: toml_edit::DocumentMut = content
+            .parse()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        let has_key = |key: &str, env_var: &str| -> bool {
+            // Check the TOML [llm] table
+            if let Some(llm) = doc.get("llm") {
+                if let Some(val) = llm.get(key) {
+                    if let Some(s) = val.as_str() {
+                        // If it's an env reference, check if the env var is set
+                        if let Some(var_name) = s.strip_prefix("env:") {
+                            return std::env::var(var_name).is_ok();
+                        }
+                        return !s.is_empty();
+                    }
+                }
+            }
+            // Fall back to checking env vars directly
+            std::env::var(env_var).is_ok()
+        };
+
+        (
+            has_key("anthropic_key", "ANTHROPIC_API_KEY"),
+            has_key("openai_key", "OPENAI_API_KEY"),
+            has_key("openrouter_key", "OPENROUTER_API_KEY"),
+            has_key("zhipu_key", "ZHIPU_API_KEY"),
+            has_key("groq_key", "GROQ_API_KEY"),
+            has_key("together_key", "TOGETHER_API_KEY"),
+            has_key("fireworks_key", "FIREWORKS_API_KEY"),
+            has_key("deepseek_key", "DEEPSEEK_API_KEY"),
+            has_key("xai_key", "XAI_API_KEY"),
+            has_key("mistral_key", "MISTRAL_API_KEY"),
+            has_key("opencode_zen_key", "OPENCODE_ZEN_API_KEY"),
+        )
+    } else {
+        // No config file — check env vars only
+        (
+            std::env::var("ANTHROPIC_API_KEY").is_ok(),
+            std::env::var("OPENAI_API_KEY").is_ok(),
+            std::env::var("OPENROUTER_API_KEY").is_ok(),
+            std::env::var("ZHIPU_API_KEY").is_ok(),
+            std::env::var("GROQ_API_KEY").is_ok(),
+            std::env::var("TOGETHER_API_KEY").is_ok(),
+            std::env::var("FIREWORKS_API_KEY").is_ok(),
+            std::env::var("DEEPSEEK_API_KEY").is_ok(),
+            std::env::var("XAI_API_KEY").is_ok(),
+            std::env::var("MISTRAL_API_KEY").is_ok(),
+            std::env::var("OPENCODE_ZEN_API_KEY").is_ok(),
+        )
+    };
+
+    let providers = ProviderStatus {
+        anthropic,
+        openai,
+        openrouter,
+        zhipu,
+        groq,
+        together,
+        fireworks,
+        deepseek,
+        xai,
+        mistral,
+        opencode_zen,
+    };
+    let has_any = providers.anthropic 
+        || providers.openai 
+        || providers.openrouter 
+        || providers.zhipu
+        || providers.groq
+        || providers.together
+        || providers.fireworks
+        || providers.deepseek
+        || providers.xai
+        || providers.mistral
+        || providers.opencode_zen;
+
+    Ok(Json(ProvidersResponse { providers, has_any }))
+}
+
+async fn update_provider(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<ProviderUpdateRequest>,
+) -> Result<Json<ProviderUpdateResponse>, StatusCode> {
+    let key_name = match request.provider.as_str() {
+        "anthropic" => "anthropic_key",
+        "openai" => "openai_key",
+        "openrouter" => "openrouter_key",
+        "zhipu" => "zhipu_key",
+        "groq" => "groq_key",
+        "together" => "together_key",
+        "fireworks" => "fireworks_key",
+        "deepseek" => "deepseek_key",
+        "xai" => "xai_key",
+        "mistral" => "mistral_key",
+        "opencode-zen" => "opencode_zen_key",
+        _ => {
+            return Ok(Json(ProviderUpdateResponse {
+                success: false,
+                message: format!("Unknown provider: {}", request.provider),
+            }));
+        }
+    };
+
+    if request.api_key.trim().is_empty() {
+        return Ok(Json(ProviderUpdateResponse {
+            success: false,
+            message: "API key cannot be empty".into(),
+        }));
+    }
+
+    let config_path = state.config_path.read().await.clone();
+
+    // Read existing config or create a new document
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    } else {
+        String::new()
+    };
+
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Ensure [llm] table exists
+    if doc.get("llm").is_none() {
+        doc["llm"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+
+    // Set the key
+    doc["llm"][key_name] = toml_edit::value(request.api_key);
+
+    // Auto-set routing defaults if the current routing points to a provider
+    // the user doesn't have a key for. This prevents the common case where
+    // someone sets up OpenRouter but routing still defaults to anthropic/*.
+    let should_set_routing = {
+        let current_channel = doc
+            .get("defaults")
+            .and_then(|d| d.get("routing"))
+            .and_then(|r| r.get("channel"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("anthropic/claude-sonnet-4-20250514");
+
+        let current_provider =
+            crate::llm::routing::provider_from_model(current_channel);
+
+        // Check if the current routing provider has a key configured
+        let has_key_for_current = match current_provider {
+            "anthropic" => doc
+                .get("llm")
+                .and_then(|l| l.get("anthropic_key"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty()),
+            "openai" => doc
+                .get("llm")
+                .and_then(|l| l.get("openai_key"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty()),
+            "openrouter" => doc
+                .get("llm")
+                .and_then(|l| l.get("openrouter_key"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty()),
+            "zhipu" => doc
+                .get("llm")
+                .and_then(|l| l.get("zhipu_key"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty()),
+            "opencode-zen" => doc
+                .get("llm")
+                .and_then(|l| l.get("opencode_zen_key"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty()),
+            _ => false,
+        };
+
+        !has_key_for_current
+    };
+
+    if should_set_routing {
+        let routing =
+            crate::llm::routing::defaults_for_provider(&request.provider);
+
+        if doc.get("defaults").is_none() {
+            doc["defaults"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        
+        if let Some(defaults) = doc.get_mut("defaults").and_then(|d| d.as_table_mut()) {
+            if defaults.get("routing").is_none() {
+                defaults["routing"] = toml_edit::Item::Table(toml_edit::Table::new());
+            }
+            
+            if let Some(routing_table) = defaults.get_mut("routing").and_then(|r| r.as_table_mut()) {
+                routing_table["channel"] = toml_edit::value(&routing.channel);
+                routing_table["branch"] = toml_edit::value(&routing.branch);
+                routing_table["worker"] = toml_edit::value(&routing.worker);
+                routing_table["compactor"] = toml_edit::value(&routing.compactor);
+                routing_table["cortex"] = toml_edit::value(&routing.cortex);
+            }
+        }
+    }
+
+    // Write back to disk
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Signal the main loop that providers have been configured
+    state
+        .provider_setup_tx
+        .try_send(crate::ProviderSetupEvent::ProvidersConfigured)
+        .ok();
+
+    let routing_note = if should_set_routing {
+        format!(
+            " Model routing updated to use {} defaults.",
+            request.provider
+        )
+    } else {
+        String::new()
+    };
+
+    Ok(Json(ProviderUpdateResponse {
+        success: true,
+        message: format!(
+            "Provider '{}' configured.{}",
+            request.provider, routing_note
+        ),
+    }))
+}
+
+async fn delete_provider(
+    State(state): State<Arc<ApiState>>,
+    axum::extract::Path(provider): axum::extract::Path<String>,
+) -> Result<Json<ProviderUpdateResponse>, StatusCode> {
+    let key_name = match provider.as_str() {
+        "anthropic" => "anthropic_key",
+        "openai" => "openai_key",
+        "openrouter" => "openrouter_key",
+        "zhipu" => "zhipu_key",
+        "groq" => "groq_key",
+        "together" => "together_key",
+        "fireworks" => "fireworks_key",
+        "deepseek" => "deepseek_key",
+        "xai" => "xai_key",
+        "mistral" => "mistral_key",
+        "opencode-zen" => "opencode_zen_key",
+        _ => {
+            return Ok(Json(ProviderUpdateResponse {
+                success: false,
+                message: format!("Unknown provider: {}", provider),
+            }));
+        }
+    };
+
+    let config_path = state.config_path.read().await.clone();
+    if !config_path.exists() {
+        return Ok(Json(ProviderUpdateResponse {
+            success: false,
+            message: "No config file found".into(),
+        }));
+    }
+
+    let content = tokio::fs::read_to_string(&config_path)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Remove the key from [llm]
+    if let Some(llm) = doc.get_mut("llm") {
+        if let Some(table) = llm.as_table_mut() {
+            table.remove(key_name);
+        }
+    }
+
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(ProviderUpdateResponse {
+        success: true,
+        message: format!("Provider '{}' removed", provider),
+    }))
+}
+
+// -- Model listing --
+
+#[derive(Serialize, Clone)]
+struct ModelInfo {
+    /// Full routing string (e.g. "openrouter/anthropic/claude-sonnet-4-20250514")
+    id: String,
+    /// Human-readable name
+    name: String,
+    /// Provider ID ("anthropic", "openrouter", "openai", "zhipu")
+    provider: String,
+    /// Context window size in tokens, if known
+    context_window: Option<u64>,
+    /// Whether this is a curated/recommended model
+    curated: bool,
+}
+
+#[derive(Serialize)]
+struct ModelsResponse {
+    models: Vec<ModelInfo>,
+}
+
+/// Static curated model list — the "known good" models we recommend.
+fn curated_models() -> Vec<ModelInfo> {
+    vec![
+        // Anthropic (direct)
+        ModelInfo {
+            id: "anthropic/claude-sonnet-4-20250514".into(),
+            name: "Claude Sonnet 4".into(),
+            provider: "anthropic".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "anthropic/claude-haiku-4.5-20250514".into(),
+            name: "Claude Haiku 4.5".into(),
+            provider: "anthropic".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "anthropic/claude-opus-4-20250514".into(),
+            name: "Claude Opus 4".into(),
+            provider: "anthropic".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        // OpenRouter
+        ModelInfo {
+            id: "openrouter/anthropic/claude-sonnet-4-20250514".into(),
+            name: "Claude Sonnet 4".into(),
+            provider: "openrouter".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/anthropic/claude-haiku-4.5-20250514".into(),
+            name: "Claude Haiku 4.5".into(),
+            provider: "openrouter".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/anthropic/claude-opus-4-20250514".into(),
+            name: "Claude Opus 4".into(),
+            provider: "openrouter".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/google/gemini-2.5-pro-preview".into(),
+            name: "Gemini 2.5 Pro".into(),
+            provider: "openrouter".into(),
+            context_window: Some(1_048_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/google/gemini-2.5-flash-preview".into(),
+            name: "Gemini 2.5 Flash".into(),
+            provider: "openrouter".into(),
+            context_window: Some(1_048_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/deepseek/deepseek-r1".into(),
+            name: "DeepSeek R1".into(),
+            provider: "openrouter".into(),
+            context_window: Some(163_840),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/deepseek/deepseek-chat-v3-0324".into(),
+            name: "DeepSeek V3".into(),
+            provider: "openrouter".into(),
+            context_window: Some(163_840),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/moonshotai/kimi-k2".into(),
+            name: "Kimi K2".into(),
+            provider: "openrouter".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/moonshotai/kimi-k2.5".into(),
+            name: "Kimi K2.5".into(),
+            provider: "openrouter".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/openai/gpt-4.1".into(),
+            name: "GPT-4.1".into(),
+            provider: "openrouter".into(),
+            context_window: Some(1_047_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/openai/gpt-4.1-mini".into(),
+            name: "GPT-4.1 Mini".into(),
+            provider: "openrouter".into(),
+            context_window: Some(1_047_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/x-ai/grok-3-mini".into(),
+            name: "Grok 3 Mini".into(),
+            provider: "openrouter".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openrouter/mistralai/mistral-medium-3".into(),
+            name: "Mistral Medium 3".into(),
+            provider: "openrouter".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        // OpenAI (direct)
+        ModelInfo {
+            id: "openai/gpt-4.1".into(),
+            name: "GPT-4.1".into(),
+            provider: "openai".into(),
+            context_window: Some(1_047_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openai/gpt-4.1-mini".into(),
+            name: "GPT-4.1 Mini".into(),
+            provider: "openai".into(),
+            context_window: Some(1_047_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openai/gpt-4.1-nano".into(),
+            name: "GPT-4.1 Nano".into(),
+            provider: "openai".into(),
+            context_window: Some(1_047_576),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openai/o3".into(),
+            name: "o3".into(),
+            provider: "openai".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openai/o3-mini".into(),
+            name: "o3 Mini".into(),
+            provider: "openai".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "openai/o4-mini".into(),
+            name: "o4 Mini".into(),
+            provider: "openai".into(),
+            context_window: Some(200_000),
+            curated: true,
+        },
+        // Z.ai (GLM)
+        ModelInfo {
+            id: "zhipu/glm-4-plus".into(),
+            name: "GLM-4 Plus".into(),
+            provider: "zhipu".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "zhipu/glm-4-flash".into(),
+            name: "GLM-4 Flash".into(),
+            provider: "zhipu".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "zhipu/glm-4-flashx".into(),
+            name: "GLM-4 FlashX".into(),
+            provider: "zhipu".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        // Groq
+        ModelInfo {
+            id: "groq/llama-3.3-70b-versatile".into(),
+            name: "Llama 3.3 70B Versatile".into(),
+            provider: "groq".into(),
+            context_window: Some(32_768),
+            curated: true,
+        },
+        ModelInfo {
+            id: "groq/llama-3.3-70b-specdec".into(),
+            name: "Llama 3.3 70B Speculative Decoding".into(),
+            provider: "groq".into(),
+            context_window: Some(8192),
+            curated: true,
+        },
+        ModelInfo {
+            id: "groq/llama-3.1-70b-versatile".into(),
+            name: "Llama 3.1 70B Versatile".into(),
+            provider: "groq".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "groq/mixtral-8x7b-32768".into(),
+            name: "Mixtral 8x7B".into(),
+            provider: "groq".into(),
+            context_window: Some(32_768),
+            curated: true,
+        },
+        ModelInfo {
+            id: "groq/gemma2-9b-it".into(),
+            name: "Gemma 2 9B".into(),
+            provider: "groq".into(),
+            context_window: Some(8192),
+            curated: true,
+        },
+        // Together AI
+        ModelInfo {
+            id: "together/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo".into(),
+            name: "Llama 3.1 405B Instruct Turbo".into(),
+            provider: "together".into(),
+            context_window: Some(130_815),
+            curated: true,
+        },
+        ModelInfo {
+            id: "together/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo".into(),
+            name: "Llama 3.1 70B Instruct Turbo".into(),
+            provider: "together".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "together/meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo".into(),
+            name: "Llama 3.3 70B Instruct Turbo".into(),
+            provider: "together".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "together/Qwen/Qwen2.5-72B-Instruct-Turbo".into(),
+            name: "Qwen 2.5 72B Instruct Turbo".into(),
+            provider: "together".into(),
+            context_window: Some(32_768),
+            curated: true,
+        },
+        ModelInfo {
+            id: "together/deepseek-ai/DeepSeek-V3".into(),
+            name: "DeepSeek V3".into(),
+            provider: "together".into(),
+            context_window: Some(65_536),
+            curated: true,
+        },
+        // Fireworks AI
+        ModelInfo {
+            id: "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct".into(),
+            name: "Llama 3.3 70B Instruct".into(),
+            provider: "fireworks".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "fireworks/accounts/fireworks/models/llama-v3p1-405b-instruct".into(),
+            name: "Llama 3.1 405B Instruct".into(),
+            provider: "fireworks".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "fireworks/accounts/fireworks/models/llama-v3p1-70b-instruct".into(),
+            name: "Llama 3.1 70B Instruct".into(),
+            provider: "fireworks".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
+            name: "Llama 3.1 8B Instruct".into(),
+            provider: "fireworks".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "fireworks/accounts/fireworks/models/qwen2p5-72b-instruct".into(),
+            name: "Qwen 2.5 72B Instruct".into(),
+            provider: "fireworks".into(),
+            context_window: Some(32_768),
+            curated: true,
+        },
+        // DeepSeek
+        ModelInfo {
+            id: "deepseek/deepseek-chat".into(),
+            name: "DeepSeek Chat".into(),
+            provider: "deepseek".into(),
+            context_window: Some(65_536),
+            curated: true,
+        },
+        ModelInfo {
+            id: "deepseek/deepseek-reasoner".into(),
+            name: "DeepSeek Reasoner".into(),
+            provider: "deepseek".into(),
+            context_window: Some(65_536),
+            curated: true,
+        },
+        // xAI
+        ModelInfo {
+            id: "xai/grok-2-latest".into(),
+            name: "Grok 2".into(),
+            provider: "xai".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        ModelInfo {
+            id: "xai/grok-2-vision-latest".into(),
+            name: "Grok 2 Vision".into(),
+            provider: "xai".into(),
+            context_window: Some(32_768),
+            curated: true,
+        },
+        ModelInfo {
+            id: "xai/grok-beta".into(),
+            name: "Grok Beta".into(),
+            provider: "xai".into(),
+            context_window: Some(131_072),
+            curated: true,
+        },
+        // Mistral AI
+        ModelInfo {
+            id: "mistral/mistral-large-latest".into(),
+            name: "Mistral Large".into(),
+            provider: "mistral".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "mistral/mistral-small-latest".into(),
+            name: "Mistral Small".into(),
+            provider: "mistral".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "mistral/mistral-medium-latest".into(),
+            name: "Mistral Medium".into(),
+            provider: "mistral".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "mistral/codestral-latest".into(),
+            name: "Codestral".into(),
+            provider: "mistral".into(),
+            context_window: Some(32_000),
+            curated: true,
+        },
+        ModelInfo {
+            id: "mistral/pixtral-large-latest".into(),
+            name: "Pixtral Large".into(),
+            provider: "mistral".into(),
+            context_window: Some(128_000),
+            curated: true,
+        },
+        // OpenCode Zen (OpenAI-compatible)
+        ModelInfo {
+            id: "opencode-zen/kimi-k2.5".into(),
+            name: "Kimi K2.5".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/kimi-k2".into(),
+            name: "Kimi K2".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/kimi-k2-thinking".into(),
+            name: "Kimi K2 Thinking".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/glm-5".into(),
+            name: "GLM 5".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/minimax-m2.5".into(),
+            name: "MiniMax M2.5".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/qwen3-coder".into(),
+            name: "Qwen3 Coder 480B".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+        ModelInfo {
+            id: "opencode-zen/big-pickle".into(),
+            name: "Big Pickle".into(),
+            provider: "opencode-zen".into(),
+            context_window: None,
+            curated: true,
+        },
+    ]
+}
+
+/// In-memory cache for dynamically fetched models.
+static DYNAMIC_MODELS: std::sync::LazyLock<
+    tokio::sync::RwLock<(Vec<ModelInfo>, std::time::Instant)>,
+> = std::sync::LazyLock::new(|| {
+    tokio::sync::RwLock::new((Vec::new(), std::time::Instant::now()))
+});
+
+const MODEL_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+async fn get_models(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ModelsResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+
+    // Determine which providers are configured
+    let configured = configured_providers(&config_path).await;
+
+    // Start with curated models, filtered to configured providers
+    let mut models: Vec<ModelInfo> = curated_models()
+        .into_iter()
+        .filter(|m| configured.contains(&m.provider.as_str()))
+        .collect();
+
+    // Add cached dynamic models if fresh
+    let cache = DYNAMIC_MODELS.read().await;
+    if !cache.0.is_empty() && cache.1.elapsed() < MODEL_CACHE_TTL {
+        for model in &cache.0 {
+            if configured.contains(&model.provider.as_str()) {
+                // Skip if already in curated list
+                if !models.iter().any(|m| m.id == model.id) {
+                    models.push(model.clone());
+                }
+            }
+        }
+    }
+    drop(cache);
+
+    Ok(Json(ModelsResponse { models }))
+}
+
+async fn refresh_models(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ModelsResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    let configured = configured_providers(&config_path).await;
+
+    let mut dynamic = Vec::new();
+
+    // Query OpenRouter if configured
+    if configured.contains(&"openrouter") {
+        if let Ok(models) = fetch_openrouter_models(&config_path).await {
+            dynamic.extend(models);
+        }
+    }
+
+    // Cache the results
+    let mut cache = DYNAMIC_MODELS.write().await;
+    *cache = (dynamic, std::time::Instant::now());
+    drop(cache);
+
+    // Return full list (curated + dynamic)
+    get_models(State(state)).await
+}
+
+/// Helper: which providers have keys configured
+async fn configured_providers(config_path: &std::path::Path) -> Vec<&'static str> {
+    let mut providers = Vec::new();
+
+    let content = match tokio::fs::read_to_string(config_path).await {
+        Ok(c) => c,
+        Err(_) => return providers,
+    };
+    let doc: toml_edit::DocumentMut = match content.parse() {
+        Ok(d) => d,
+        Err(_) => return providers,
+    };
+
+    let has_key = |key: &str, env_var: &str| -> bool {
+        if let Some(llm) = doc.get("llm") {
+            if let Some(val) = llm.get(key) {
+                if let Some(s) = val.as_str() {
+                    if let Some(var_name) = s.strip_prefix("env:") {
+                        return std::env::var(var_name).is_ok();
+                    }
+                    return !s.is_empty();
+                }
+            }
+        }
+        std::env::var(env_var).is_ok()
+    };
+
+    if has_key("anthropic_key", "ANTHROPIC_API_KEY") {
+        providers.push("anthropic");
+    }
+    if has_key("openai_key", "OPENAI_API_KEY") {
+        providers.push("openai");
+    }
+    if has_key("openrouter_key", "OPENROUTER_API_KEY") {
+        providers.push("openrouter");
+    }
+    if has_key("zhipu_key", "ZHIPU_API_KEY") {
+        providers.push("zhipu");
+    }
+    if has_key("groq_key", "GROQ_API_KEY") {
+        providers.push("groq");
+    }
+    if has_key("together_key", "TOGETHER_API_KEY") {
+        providers.push("together");
+    }
+    if has_key("fireworks_key", "FIREWORKS_API_KEY") {
+        providers.push("fireworks");
+    }
+    if has_key("deepseek_key", "DEEPSEEK_API_KEY") {
+        providers.push("deepseek");
+    }
+    if has_key("xai_key", "XAI_API_KEY") {
+        providers.push("xai");
+    }
+    if has_key("mistral_key", "MISTRAL_API_KEY") {
+        providers.push("mistral");
+    }
+    if has_key("opencode_zen_key", "OPENCODE_ZEN_API_KEY") {
+        providers.push("opencode-zen");
+    }
+
+    providers
+}
+
+/// Fetch available models from OpenRouter's API.
+async fn fetch_openrouter_models(
+    config_path: &std::path::Path,
+) -> anyhow::Result<Vec<ModelInfo>> {
+    let content = tokio::fs::read_to_string(config_path).await?;
+    let doc: toml_edit::DocumentMut = content.parse()?;
+
+    let api_key = doc
+        .get("llm")
+        .and_then(|l| l.get("openrouter_key"))
+        .and_then(|v| v.as_str())
+        .map(|s| {
+            if let Some(var) = s.strip_prefix("env:") {
+                std::env::var(var).unwrap_or_default()
+            } else {
+                s.to_string()
+            }
+        })
+        .unwrap_or_default();
+
+    if api_key.is_empty() {
+        anyhow::bail!("no openrouter key");
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get("https://openrouter.ai/api/v1/models")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    #[derive(Deserialize)]
+    struct OpenRouterModelsResponse {
+        data: Vec<OpenRouterModel>,
+    }
+    #[derive(Deserialize)]
+    struct OpenRouterModel {
+        id: String,
+        name: Option<String>,
+        context_length: Option<u64>,
+    }
+
+    let body: OpenRouterModelsResponse = response.json().await?;
+
+    Ok(body
+        .data
+        .into_iter()
+        .map(|m| ModelInfo {
+            id: format!("openrouter/{}", m.id),
+            name: m.name.unwrap_or_else(|| m.id.clone()),
+            provider: "openrouter".into(),
+            context_window: m.context_length,
+            curated: false,
+        })
+        .collect())
+}
+
+// -- Ingest handlers --
+
+#[derive(Deserialize)]
+struct IngestQuery {
+    agent_id: String,
+}
+
+#[derive(Deserialize)]
+struct IngestDeleteQuery {
+    agent_id: String,
+    content_hash: String,
+}
+
+/// List ingested files with progress info for in-progress ones.
+async fn list_ingest_files(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<IngestQuery>,
+) -> Result<Json<IngestFilesResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let rows = sqlx::query(
+        r#"
+        SELECT f.content_hash, f.filename, f.file_size, f.total_chunks, f.status,
+               f.started_at, f.completed_at,
+               COALESCE(p.done, 0) as chunks_completed
+        FROM ingestion_files f
+        LEFT JOIN (
+            SELECT content_hash, COUNT(*) as done
+            FROM ingestion_progress
+            GROUP BY content_hash
+        ) p ON f.content_hash = p.content_hash
+        ORDER BY f.started_at DESC
+        LIMIT 100
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| {
+        tracing::warn!(%error, "failed to list ingest files");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let files = rows
+        .into_iter()
+        .map(|row| IngestFileInfo {
+            content_hash: row.get("content_hash"),
+            filename: row.get("filename"),
+            file_size: row.get("file_size"),
+            total_chunks: row.get("total_chunks"),
+            chunks_completed: row.get("chunks_completed"),
+            status: row.get("status"),
+            started_at: row.get("started_at"),
+            completed_at: row.get("completed_at"),
+        })
+        .collect();
+
+    Ok(Json(IngestFilesResponse { files }))
+}
+
+/// Upload one or more files to the agent's ingest directory.
+async fn upload_ingest_file(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<IngestQuery>,
+    mut multipart: axum::extract::Multipart,
+) -> Result<Json<IngestUploadResponse>, StatusCode> {
+    let workspaces = state.agent_workspaces.load();
+    let workspace = workspaces.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+    let ingest_dir = workspace.join("ingest");
+
+    tokio::fs::create_dir_all(&ingest_dir).await.map_err(|error| {
+        tracing::warn!(%error, "failed to create ingest directory");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut uploaded = Vec::new();
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let filename = field
+            .file_name()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("upload-{}.txt", uuid::Uuid::new_v4()));
+
+        let data = field.bytes().await.map_err(|error| {
+            tracing::warn!(%error, "failed to read upload field");
+            StatusCode::BAD_REQUEST
+        })?;
+
+        if data.is_empty() {
+            continue;
+        }
+
+        // Sanitize filename to prevent path traversal
+        let safe_name = Path::new(&filename)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("upload.txt");
+
+        let target = ingest_dir.join(safe_name);
+
+        // If file already exists, append a uuid suffix to avoid overwriting
+        let target = if target.exists() {
+            let stem = Path::new(safe_name)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("upload");
+            let ext = Path::new(safe_name)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("txt");
+            let unique = format!("{}-{}.{}", stem, &uuid::Uuid::new_v4().to_string()[..8], ext);
+            ingest_dir.join(unique)
+        } else {
+            target
+        };
+
+        tokio::fs::write(&target, &data).await.map_err(|error| {
+            tracing::warn!(%error, path = %target.display(), "failed to write uploaded file");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        // Insert a queued record so the file appears in the UI immediately
+        if let Ok(content) = std::str::from_utf8(&data) {
+            let hash = crate::agent::ingestion::content_hash(content);
+            let pools = state.agent_pools.load();
+            if let Some(pool) = pools.get(&query.agent_id) {
+                let file_size = data.len() as i64;
+                let _ = sqlx::query(
+                    r#"
+                    INSERT OR IGNORE INTO ingestion_files (content_hash, filename, file_size, total_chunks, status)
+                    VALUES (?, ?, ?, 0, 'queued')
+                    "#,
+                )
+                .bind(&hash)
+                .bind(safe_name)
+                .bind(file_size)
+                .execute(pool)
+                .await;
+            }
+        }
+
+        tracing::info!(
+            agent_id = %query.agent_id,
+            filename = %safe_name,
+            bytes = data.len(),
+            "file uploaded to ingest directory"
+        );
+
+        uploaded.push(safe_name.to_string());
+    }
+
+    Ok(Json(IngestUploadResponse { uploaded }))
+}
+
+/// Delete a completed ingestion file record from history.
+async fn delete_ingest_file(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<IngestDeleteQuery>,
+) -> Result<Json<IngestDeleteResponse>, StatusCode> {
+    let pools = state.agent_pools.load();
+    let pool = pools.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    sqlx::query("DELETE FROM ingestion_files WHERE content_hash = ?")
+        .bind(&query.content_hash)
+        .execute(pool)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to delete ingest file record");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(IngestDeleteResponse { success: true }))
+}
+
+// -- Skills --
+
+#[derive(Deserialize)]
+struct SkillsQuery {
+    agent_id: String,
+}
+
+/// List installed skills for an agent.
+async fn list_skills(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<SkillsQuery>,
+) -> Result<Json<SkillsListResponse>, StatusCode> {
+    let configs = state.agent_configs.load();
+    let agent = configs.iter().find(|a| a.id == query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    
+    let instance_dir = state.instance_dir.load();
+    let instance_skills_dir = instance_dir.join("skills");
+    let workspace_skills_dir = agent.workspace.join("skills");
+    
+    let skills = crate::skills::SkillSet::load(&instance_skills_dir, &workspace_skills_dir).await;
+    
+    let skill_infos: Vec<SkillInfo> = skills
+        .list()
+        .into_iter()
+        .map(|s| SkillInfo {
+            name: s.name,
+            description: s.description,
+            file_path: s.file_path.display().to_string(),
+            base_dir: s.base_dir.display().to_string(),
+            source: match s.source {
+                crate::skills::SkillSource::Instance => "instance".to_string(),
+                crate::skills::SkillSource::Workspace => "workspace".to_string(),
+            },
+        })
+        .collect();
+    
+    Ok(Json(SkillsListResponse { skills: skill_infos }))
+}
+
+/// Install a skill from GitHub.
+async fn install_skill(
+    State(state): State<Arc<ApiState>>,
+    axum::extract::Json(req): axum::extract::Json<InstallSkillRequest>,
+) -> Result<Json<InstallSkillResponse>, StatusCode> {
+    let configs = state.agent_configs.load();
+    let agent = configs.iter().find(|a| a.id == req.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    
+    let target_dir = if req.instance {
+        state.instance_dir.load().as_ref().join("skills")
+    } else {
+        agent.workspace.join("skills")
+    };
+    
+    let installed = crate::skills::install_from_github(&req.spec, &target_dir)
+        .await
+        .map_err(|e| {
+            tracing::warn!("failed to install skill: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    
+    state.send_event(ApiEvent::ConfigReloaded);
+    
+    Ok(Json(InstallSkillResponse { installed }))
+}
+
+/// Remove an installed skill.
+async fn remove_skill(
+    State(state): State<Arc<ApiState>>,
+    axum::extract::Json(req): axum::extract::Json<RemoveSkillRequest>,
+) -> Result<Json<RemoveSkillResponse>, StatusCode> {
+    let configs = state.agent_configs.load();
+    let agent = configs.iter().find(|a| a.id == req.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    
+    let instance_dir = state.instance_dir.load();
+    let instance_skills_dir = instance_dir.join("skills");
+    let workspace_skills_dir = agent.workspace.join("skills");
+    
+    let mut skills = crate::skills::SkillSet::load(&instance_skills_dir, &workspace_skills_dir).await;
+    
+    let removed_path = skills.remove(&req.name).await.map_err(|error| {
+        tracing::warn!(%error, skill = %req.name, "failed to remove skill");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    
+    // Trigger a config reload to update the skill list
+    state.send_event(ApiEvent::ConfigReloaded);
+    
+    tracing::info!(
+        agent_id = %req.agent_id,
+        skill = %req.name,
+        "skill removed"
+    );
+    
+    Ok(Json(RemoveSkillResponse {
+        success: removed_path.is_some(),
+        path: removed_path.map(|p| p.display().to_string()),
+    }))
+}
+
+// -- Skills Registry Proxy --
+
+#[derive(Deserialize)]
+struct RegistryBrowseQuery {
+    /// One of: all-time, trending, hot
+    #[serde(default = "default_registry_view")]
+    view: String,
+    #[serde(default)]
+    page: u32,
+}
+
+fn default_registry_view() -> String {
+    "all-time".into()
+}
+
+/// Proxy browse requests to skills.sh leaderboard API.
+async fn registry_browse(
+    Query(query): Query<RegistryBrowseQuery>,
+) -> Result<Json<RegistryBrowseResponse>, StatusCode> {
+    let view = match query.view.as_str() {
+        "all-time" | "trending" | "hot" => &query.view,
+        _ => "all-time",
+    };
+
+    let url = format!(
+        "https://skills.sh/api/skills/{}/{}",
+        view, query.page
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "skills.sh registry browse request failed");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    if !response.status().is_success() {
+        tracing::warn!(status = %response.status(), "skills.sh returned error");
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    #[derive(Deserialize)]
+    struct UpstreamResponse {
+        skills: Vec<RegistrySkill>,
+        #[serde(default)]
+        #[serde(rename = "hasMore")]
+        has_more: bool,
+    }
+
+    let body: UpstreamResponse = response.json().await.map_err(|error| {
+        tracing::warn!(%error, "failed to parse skills.sh response");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(Json(RegistryBrowseResponse {
+        skills: body.skills,
+        has_more: body.has_more,
+    }))
+}
+
+#[derive(Deserialize)]
+struct RegistrySearchQuery {
+    q: String,
+    #[serde(default = "default_registry_search_limit")]
+    limit: u32,
+}
+
+fn default_registry_search_limit() -> u32 {
+    50
+}
+
+/// Proxy search requests to skills.sh search API.
+async fn registry_search(
+    Query(query): Query<RegistrySearchQuery>,
+) -> Result<Json<RegistrySearchResponse>, StatusCode> {
+    if query.q.len() < 2 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get("https://skills.sh/api/search")
+        .query(&[("q", &query.q), ("limit", &query.limit.min(100).to_string())])
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "skills.sh search request failed");
+            StatusCode::BAD_GATEWAY
+        })?;
+
+    if !response.status().is_success() {
+        tracing::warn!(status = %response.status(), "skills.sh search returned error");
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+
+    #[derive(Deserialize)]
+    struct UpstreamSearchResponse {
+        skills: Vec<RegistrySkill>,
+        count: usize,
+        query: String,
+    }
+
+    let body: UpstreamSearchResponse = response.json().await.map_err(|error| {
+        tracing::warn!(%error, "failed to parse skills.sh search response");
+        StatusCode::BAD_GATEWAY
+    })?;
+
+    Ok(Json(RegistrySearchResponse {
+        skills: body.skills,
+        query: body.query,
+        count: body.count,
+    }))
+}
+
+// -- Messaging / Bindings --
+
+#[derive(Serialize, Clone)]
+struct PlatformStatus {
+    configured: bool,
+    enabled: bool,
+}
+
+#[derive(Serialize)]
+struct MessagingStatusResponse {
+    discord: PlatformStatus,
+    slack: PlatformStatus,
+    telegram: PlatformStatus,
+    webhook: PlatformStatus,
+}
+
+/// Get which messaging platforms are configured and enabled.
+async fn messaging_status(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<MessagingStatusResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+
+    let (discord, slack, telegram, webhook) = if config_path.exists() {
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to read config.toml for messaging status");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        let doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+            tracing::warn!(%error, "failed to parse config.toml for messaging status");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        let discord_status = doc
+            .get("messaging")
+            .and_then(|m| m.get("discord"))
+            .map(|d| {
+                let has_token = d
+                    .get("token")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| !s.is_empty());
+                let enabled = d
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                PlatformStatus {
+                    configured: has_token,
+                    enabled: has_token && enabled,
+                }
+            })
+            .unwrap_or(PlatformStatus {
+                configured: false,
+                enabled: false,
+            });
+
+        let slack_status = doc
+            .get("messaging")
+            .and_then(|m| m.get("slack"))
+            .map(|s| {
+                let has_bot_token = s
+                    .get("bot_token")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|t| !t.is_empty());
+                let has_app_token = s
+                    .get("app_token")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|t| !t.is_empty());
+                let enabled = s
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                PlatformStatus {
+                    configured: has_bot_token && has_app_token,
+                    enabled: has_bot_token && has_app_token && enabled,
+                }
+            })
+            .unwrap_or(PlatformStatus {
+                configured: false,
+                enabled: false,
+            });
+
+        let webhook_status = doc
+            .get("messaging")
+            .and_then(|m| m.get("webhook"))
+            .map(|w| {
+                let enabled = w
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                PlatformStatus {
+                    configured: true,
+                    enabled,
+                }
+            })
+            .unwrap_or(PlatformStatus {
+                configured: false,
+                enabled: false,
+            });
+
+        let telegram_status = doc
+            .get("messaging")
+            .and_then(|m| m.get("telegram"))
+            .map(|t| {
+                let has_token = t
+                    .get("token")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| !s.is_empty());
+                let enabled = t
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                PlatformStatus {
+                    configured: has_token,
+                    enabled: has_token && enabled,
+                }
+            })
+            .unwrap_or(PlatformStatus {
+                configured: false,
+                enabled: false,
+            });
+
+        (discord_status, slack_status, telegram_status, webhook_status)
+    } else {
+        let default = PlatformStatus {
+            configured: false,
+            enabled: false,
+        };
+        (default.clone(), default.clone(), default.clone(), default)
+    };
+
+    Ok(Json(MessagingStatusResponse {
+        discord,
+        slack,
+        telegram,
+        webhook,
+    }))
+}
+
+/// Disconnect a messaging platform: remove credentials from config, remove all
+/// bindings for that platform, and shut down the adapter.
+async fn disconnect_platform(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<DisconnectPlatformRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let platform = &request.platform;
+    let config_path = state.config_path.read().await.clone();
+
+    let content = tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+        tracing::warn!(%error, "failed to read config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Remove the platform section from [messaging]
+    if let Some(messaging) = doc.get_mut("messaging").and_then(|m| m.as_table_mut()) {
+        messaging.remove(platform);
+    }
+
+    // Remove all bindings for this platform
+    if let Some(bindings) = doc.get_mut("bindings").and_then(|b| b.as_array_of_tables_mut()) {
+        let mut i = 0;
+        while i < bindings.len() {
+            let matches = bindings
+                .get(i)
+                .and_then(|t| t.get("channel"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|ch| ch == platform);
+            if matches {
+                bindings.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    // Write back
+    tokio::fs::write(&config_path, doc.to_string()).await.map_err(|error| {
+        tracing::warn!(%error, "failed to write config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Hot-reload bindings
+    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+        let bindings_guard = state.bindings.read().await;
+        if let Some(bindings_swap) = bindings_guard.as_ref() {
+            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
+        }
+    }
+
+    // Shut down the adapter
+    let manager_guard = state.messaging_manager.read().await;
+    if let Some(manager) = manager_guard.as_ref() {
+        if let Err(error) = manager.remove_adapter(platform).await {
+            tracing::warn!(%error, platform = %platform, "failed to shut down adapter during disconnect");
+        }
+    }
+
+    tracing::info!(platform = %platform, "platform disconnected via API");
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "message": format!("{platform} disconnected")
+    })))
+}
+
+#[derive(Deserialize)]
+struct DisconnectPlatformRequest {
+    platform: String,
+}
+
+#[derive(Deserialize)]
+struct TogglePlatformRequest {
+    platform: String,
+    enabled: bool,
+}
+
+/// Toggle a messaging platform's enabled state. When disabling, shuts down the
+/// adapter. When enabling, reads credentials from config and hot-starts it.
+async fn toggle_platform(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<TogglePlatformRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let platform = &request.platform;
+    let config_path = state.config_path.read().await.clone();
+
+    let content = tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+        tracing::warn!(%error, "failed to read config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Check the platform section exists
+    let platform_table = doc
+        .get_mut("messaging")
+        .and_then(|m| m.as_table_mut())
+        .and_then(|m| m.get_mut(platform.as_str()))
+        .and_then(|p| p.as_table_mut());
+
+    let Some(table) = platform_table else {
+        return Ok(Json(serde_json::json!({
+            "success": false,
+            "message": format!("{platform} is not configured")
+        })));
+    };
+
+    table["enabled"] = toml_edit::value(request.enabled);
+
+    tokio::fs::write(&config_path, doc.to_string()).await.map_err(|error| {
+        tracing::warn!(%error, "failed to write config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let manager_guard = state.messaging_manager.read().await;
+    let manager = manager_guard.as_ref();
+
+    if request.enabled {
+        // Re-read the full config to get credentials and start the adapter
+        if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+            if let Some(manager) = manager {
+                match platform.as_str() {
+                    "discord" => {
+                        if let Some(discord_config) = &new_config.messaging.discord {
+                            let perms = {
+                                let perms_guard = state.discord_permissions.read().await;
+                                match perms_guard.as_ref() {
+                                    Some(existing) => existing.clone(),
+                                    None => {
+                                        drop(perms_guard);
+                                        let perms = crate::config::DiscordPermissions::from_config(
+                                            discord_config,
+                                            &new_config.bindings,
+                                        );
+                                        let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                                        state.set_discord_permissions(arc_swap.clone()).await;
+                                        arc_swap
+                                    }
+                                }
+                            };
+                            let adapter = crate::messaging::discord::DiscordAdapter::new(&discord_config.token, perms);
+                            if let Err(error) = manager.register_and_start(adapter).await {
+                                tracing::error!(%error, "failed to start discord adapter on toggle");
+                            }
+                        }
+                    }
+                    "slack" => {
+                        if let Some(slack_config) = &new_config.messaging.slack {
+                            let perms = {
+                                let perms_guard = state.slack_permissions.read().await;
+                                match perms_guard.as_ref() {
+                                    Some(existing) => existing.clone(),
+                                    None => {
+                                        drop(perms_guard);
+                                        let perms = crate::config::SlackPermissions::from_config(
+                                            slack_config,
+                                            &new_config.bindings,
+                                        );
+                                        let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                                        state.set_slack_permissions(arc_swap.clone()).await;
+                                        arc_swap
+                                    }
+                                }
+                            };
+                            let adapter = crate::messaging::slack::SlackAdapter::new(
+                                &slack_config.bot_token,
+                                &slack_config.app_token,
+                                perms,
+                            );
+                            if let Err(error) = manager.register_and_start(adapter).await {
+                                tracing::error!(%error, "failed to start slack adapter on toggle");
+                            }
+                        }
+                    }
+                    "telegram" => {
+                        if let Some(telegram_config) = &new_config.messaging.telegram {
+                            let perms = crate::config::TelegramPermissions::from_config(
+                                telegram_config,
+                                &new_config.bindings,
+                            );
+                            let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                            let adapter = crate::messaging::telegram::TelegramAdapter::new(
+                                &telegram_config.token,
+                                arc_swap,
+                            );
+                            if let Err(error) = manager.register_and_start(adapter).await {
+                                tracing::error!(%error, "failed to start telegram adapter on toggle");
+                            }
+                        }
+                    }
+                    "webhook" => {
+                        if let Some(webhook_config) = &new_config.messaging.webhook {
+                            let adapter = crate::messaging::webhook::WebhookAdapter::new(
+                                webhook_config.port,
+                                &webhook_config.bind,
+                            );
+                            if let Err(error) = manager.register_and_start(adapter).await {
+                                tracing::error!(%error, "failed to start webhook adapter on toggle");
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    } else {
+        // Shut down the adapter
+        if let Some(manager) = manager {
+            if let Err(error) = manager.remove_adapter(platform).await {
+                tracing::warn!(%error, platform = %platform, "failed to shut down adapter on toggle");
+            }
+        }
+    }
+
+    let action = if request.enabled { "enabled" } else { "disabled" };
+    tracing::info!(platform = %platform, action, "platform toggled via API");
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "message": format!("{platform} {action}")
+    })))
+}
+
+#[derive(Serialize)]
+struct BindingResponse {
+    agent_id: String,
+    channel: String,
+    guild_id: Option<String>,
+    workspace_id: Option<String>,
+    chat_id: Option<String>,
+    channel_ids: Vec<String>,
+    dm_allowed_users: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct BindingsListResponse {
+    bindings: Vec<BindingResponse>,
+}
+
+#[derive(Deserialize)]
+struct BindingsQuery {
+    #[serde(default)]
+    agent_id: Option<String>,
+}
+
+/// List all bindings, optionally filtered by agent_id.
+async fn list_bindings(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<BindingsQuery>,
+) -> Json<BindingsListResponse> {
+    let bindings_guard = state.bindings.read().await;
+    let bindings = match bindings_guard.as_ref() {
+        Some(arc_swap) => {
+            let loaded = arc_swap.load();
+            loaded.as_ref().clone()
+        }
+        None => Vec::new(),
+    };
+    drop(bindings_guard);
+
+    let filtered: Vec<BindingResponse> = bindings
+        .into_iter()
+        .filter(|b| {
+            query
+                .agent_id
+                .as_ref()
+                .map_or(true, |id| &b.agent_id == id)
+        })
+        .map(|b| BindingResponse {
+            agent_id: b.agent_id,
+            channel: b.channel,
+            guild_id: b.guild_id,
+            workspace_id: b.workspace_id,
+            chat_id: b.chat_id,
+            channel_ids: b.channel_ids,
+            dm_allowed_users: b.dm_allowed_users,
+        })
+        .collect();
+
+    Json(BindingsListResponse { bindings: filtered })
+}
+
+#[derive(Deserialize)]
+struct CreateBindingRequest {
+    agent_id: String,
+    channel: String,
+    #[serde(default)]
+    guild_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    #[serde(default)]
+    chat_id: Option<String>,
+    #[serde(default)]
+    channel_ids: Vec<String>,
+    #[serde(default)]
+    dm_allowed_users: Vec<String>,
+    /// Optional: set platform credentials if not yet configured.
+    #[serde(default)]
+    platform_credentials: Option<PlatformCredentials>,
+}
+
+#[derive(Deserialize)]
+struct PlatformCredentials {
+    /// Discord bot token.
+    #[serde(default)]
+    discord_token: Option<String>,
+    /// Slack bot token.
+    #[serde(default)]
+    slack_bot_token: Option<String>,
+    /// Slack app token.
+    #[serde(default)]
+    slack_app_token: Option<String>,
+    /// Telegram bot token.
+    #[serde(default)]
+    telegram_token: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CreateBindingResponse {
+    success: bool,
+    /// True if platform credentials were added/changed (adapter needs restart).
+    restart_required: bool,
+    message: String,
+}
+
+/// Create a new binding (and optionally configure platform credentials).
+async fn create_binding(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<CreateBindingRequest>,
+) -> Result<Json<CreateBindingResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+            tracing::warn!(%error, "failed to read config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+    } else {
+        String::new()
+    };
+
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Track adapters that need to be started at runtime
+    let mut new_discord_token: Option<String> = None;
+    let mut new_slack_tokens: Option<(String, String)> = None;
+    let mut new_telegram_token: Option<String> = None;
+
+    // Write platform credentials if provided
+    if let Some(credentials) = &request.platform_credentials {
+        if let Some(token) = &credentials.discord_token {
+            if !token.is_empty() {
+                if doc.get("messaging").is_none() {
+                    doc["messaging"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let messaging = doc["messaging"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                if !messaging.contains_key("discord") {
+                    messaging["discord"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let discord = messaging["discord"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                discord["enabled"] = toml_edit::value(true);
+                discord["token"] = toml_edit::value(token.as_str());
+                new_discord_token = Some(token.clone());
+            }
+        }
+        if let Some(bot_token) = &credentials.slack_bot_token {
+            let app_token = credentials.slack_app_token.as_deref().unwrap_or("");
+            if !bot_token.is_empty() && !app_token.is_empty() {
+                if doc.get("messaging").is_none() {
+                    doc["messaging"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let messaging = doc["messaging"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                if !messaging.contains_key("slack") {
+                    messaging["slack"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let slack = messaging["slack"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                slack["enabled"] = toml_edit::value(true);
+                slack["bot_token"] = toml_edit::value(bot_token.as_str());
+                slack["app_token"] = toml_edit::value(app_token);
+                new_slack_tokens = Some((bot_token.clone(), app_token.to_string()));
+            }
+        }
+        if let Some(token) = &credentials.telegram_token {
+            if !token.is_empty() {
+                if doc.get("messaging").is_none() {
+                    doc["messaging"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let messaging = doc["messaging"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                if !messaging.contains_key("telegram") {
+                    messaging["telegram"] = toml_edit::Item::Table(toml_edit::Table::new());
+                }
+                let telegram = messaging["telegram"].as_table_mut().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+                telegram["enabled"] = toml_edit::value(true);
+                telegram["token"] = toml_edit::value(token.as_str());
+                new_telegram_token = Some(token.clone());
+            }
+        }
+    }
+
+    // Add the binding to the [[bindings]] array
+    if doc.get("bindings").is_none() {
+        doc["bindings"] = toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new());
+    }
+    let bindings_array = doc["bindings"]
+        .as_array_of_tables_mut()
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut binding_table = toml_edit::Table::new();
+    binding_table["agent_id"] = toml_edit::value(&request.agent_id);
+    binding_table["channel"] = toml_edit::value(&request.channel);
+    if let Some(guild_id) = &request.guild_id {
+        binding_table["guild_id"] = toml_edit::value(guild_id.as_str());
+    }
+    if let Some(workspace_id) = &request.workspace_id {
+        binding_table["workspace_id"] = toml_edit::value(workspace_id.as_str());
+    }
+    if let Some(chat_id) = &request.chat_id {
+        binding_table["chat_id"] = toml_edit::value(chat_id.as_str());
+    }
+    if !request.channel_ids.is_empty() {
+        let mut arr = toml_edit::Array::new();
+        for id in &request.channel_ids {
+            arr.push(id.as_str());
+        }
+        binding_table["channel_ids"] = toml_edit::value(arr);
+    }
+    if !request.dm_allowed_users.is_empty() {
+        let mut arr = toml_edit::Array::new();
+        for id in &request.dm_allowed_users {
+            arr.push(id.as_str());
+        }
+        binding_table["dm_allowed_users"] = toml_edit::value(arr);
+    }
+    bindings_array.push(binding_table);
+
+    // Write back to disk
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!(
+        agent_id = %request.agent_id,
+        channel = %request.channel,
+        "binding created via API"
+    );
+
+    // Hot-reload bindings and permissions
+    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+        let bindings_guard = state.bindings.read().await;
+        if let Some(bindings_swap) = bindings_guard.as_ref() {
+            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
+        }
+        drop(bindings_guard);
+
+        // Rebuild Discord permissions
+        if let Some(discord_config) = &new_config.messaging.discord {
+            let new_perms =
+                crate::config::DiscordPermissions::from_config(discord_config, &new_config.bindings);
+            let perms = state.discord_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+
+        // Rebuild Slack permissions
+        if let Some(slack_config) = &new_config.messaging.slack {
+            let new_perms =
+                crate::config::SlackPermissions::from_config(slack_config, &new_config.bindings);
+            let perms = state.slack_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+
+        // Hot-start new adapters if platform credentials were provided
+        let manager_guard = state.messaging_manager.read().await;
+        if let Some(manager) = manager_guard.as_ref() {
+            if let Some(token) = new_discord_token {
+                // Ensure Discord permissions exist for the new adapter
+                let discord_perms = {
+                    let perms_guard = state.discord_permissions.read().await;
+                    match perms_guard.as_ref() {
+                        Some(existing) => existing.clone(),
+                        None => {
+                            drop(perms_guard);
+                            let perms = crate::config::DiscordPermissions::from_config(
+                                new_config.messaging.discord.as_ref().expect("discord config exists when token is provided"),
+                                &new_config.bindings,
+                            );
+                            let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                            state.set_discord_permissions(arc_swap.clone()).await;
+                            arc_swap
+                        }
+                    }
+                };
+                let adapter = crate::messaging::discord::DiscordAdapter::new(&token, discord_perms);
+                if let Err(error) = manager.register_and_start(adapter).await {
+                    tracing::error!(%error, "failed to hot-start discord adapter");
+                }
+            }
+
+            if let Some((bot_token, app_token)) = new_slack_tokens {
+                let slack_perms = {
+                    let perms_guard = state.slack_permissions.read().await;
+                    match perms_guard.as_ref() {
+                        Some(existing) => existing.clone(),
+                        None => {
+                            drop(perms_guard);
+                            let perms = crate::config::SlackPermissions::from_config(
+                                new_config.messaging.slack.as_ref().expect("slack config exists when tokens are provided"),
+                                &new_config.bindings,
+                            );
+                            let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                            state.set_slack_permissions(arc_swap.clone()).await;
+                            arc_swap
+                        }
+                    }
+                };
+                let adapter = crate::messaging::slack::SlackAdapter::new(&bot_token, &app_token, slack_perms);
+                if let Err(error) = manager.register_and_start(adapter).await {
+                    tracing::error!(%error, "failed to hot-start slack adapter");
+                }
+            }
+
+            if let Some(token) = new_telegram_token {
+                let telegram_perms = {
+                    let perms = crate::config::TelegramPermissions::from_config(
+                        new_config.messaging.telegram.as_ref().expect("telegram config exists when token is provided"),
+                        &new_config.bindings,
+                    );
+                    std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms))
+                };
+                let adapter = crate::messaging::telegram::TelegramAdapter::new(&token, telegram_perms);
+                if let Err(error) = manager.register_and_start(adapter).await {
+                    tracing::error!(%error, "failed to hot-start telegram adapter");
+                }
+            }
+        }
+    }
+
+    Ok(Json(CreateBindingResponse {
+        success: true,
+        restart_required: false,
+        message: "Binding created and active.".to_string(),
+    }))
+}
+
+#[derive(Deserialize)]
+struct DeleteBindingRequest {
+    agent_id: String,
+    channel: String,
+    #[serde(default)]
+    guild_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    #[serde(default)]
+    chat_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct DeleteBindingResponse {
+    success: bool,
+    message: String,
+}
+
+/// Update an existing binding.
+#[derive(Deserialize)]
+struct UpdateBindingRequest {
+    // Original identifier (to find the binding)
+    original_agent_id: String,
+    original_channel: String,
+    #[serde(default)]
+    original_guild_id: Option<String>,
+    #[serde(default)]
+    original_workspace_id: Option<String>,
+    #[serde(default)]
+    original_chat_id: Option<String>,
+    
+    // New values
+    agent_id: String,
+    channel: String,
+    #[serde(default)]
+    guild_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    #[serde(default)]
+    chat_id: Option<String>,
+    #[serde(default)]
+    channel_ids: Vec<String>,
+    #[serde(default)]
+    dm_allowed_users: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct UpdateBindingResponse {
+    success: bool,
+    message: String,
+}
+
+async fn update_binding(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<UpdateBindingRequest>,
+) -> Result<Json<UpdateBindingResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if !config_path.exists() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let content = tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+        tracing::warn!(%error, "failed to read config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let bindings_array = doc
+        .get_mut("bindings")
+        .and_then(|b| b.as_array_of_tables_mut())
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Find the matching binding by original identifiers
+    let mut match_idx: Option<usize> = None;
+    for (i, table) in bindings_array.iter().enumerate() {
+        let matches_agent = table
+            .get("agent_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v == request.original_agent_id);
+        let matches_channel = table
+            .get("channel")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v == request.original_channel);
+        let matches_guild = match &request.original_guild_id {
+            Some(gid) => table
+                .get("guild_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == gid),
+            None => table.get("guild_id").is_none(),
+        };
+        let matches_workspace = match &request.original_workspace_id {
+            Some(wid) => table
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == wid),
+            None => table.get("workspace_id").is_none(),
+        };
+        let matches_chat = match &request.original_chat_id {
+            Some(cid) => table
+                .get("chat_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == cid),
+            None => table.get("chat_id").is_none(),
+        };
+        if matches_agent && matches_channel && matches_guild && matches_workspace && matches_chat {
+            match_idx = Some(i);
+            break;
+        }
+    }
+
+    let Some(idx) = match_idx else {
+        return Ok(Json(UpdateBindingResponse {
+            success: false,
+            message: "No matching binding found.".to_string(),
+        }));
+    };
+
+    // Update the binding in place
+    let binding = bindings_array.get_mut(idx).ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    binding["agent_id"] = toml_edit::value(&request.agent_id);
+    binding["channel"] = toml_edit::value(&request.channel);
+    
+    // Clear and set optional fields
+    binding.remove("guild_id");
+    binding.remove("workspace_id");
+    binding.remove("chat_id");
+    
+    if let Some(ref guild_id) = request.guild_id {
+        if !guild_id.is_empty() {
+            binding["guild_id"] = toml_edit::value(guild_id);
+        }
+    }
+    if let Some(ref workspace_id) = request.workspace_id {
+        if !workspace_id.is_empty() {
+            binding["workspace_id"] = toml_edit::value(workspace_id);
+        }
+    }
+    if let Some(ref chat_id) = request.chat_id {
+        if !chat_id.is_empty() {
+            binding["chat_id"] = toml_edit::value(chat_id);
+        }
+    }
+    
+    // Update arrays
+    if !request.channel_ids.is_empty() {
+        let mut arr = toml_edit::Array::new();
+        for id in &request.channel_ids {
+            arr.push(id.as_str());
+        }
+        binding["channel_ids"] = toml_edit::value(arr);
+    } else {
+        binding.remove("channel_ids");
+    }
+    
+    if !request.dm_allowed_users.is_empty() {
+        let mut arr = toml_edit::Array::new();
+        for id in &request.dm_allowed_users {
+            arr.push(id.as_str());
+        }
+        binding["dm_allowed_users"] = toml_edit::value(arr);
+    } else {
+        binding.remove("dm_allowed_users");
+    }
+
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!(
+        agent_id = %request.agent_id,
+        channel = %request.channel,
+        "binding updated via API"
+    );
+
+    // Hot-reload bindings and permissions
+    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+        let bindings_guard = state.bindings.read().await;
+        if let Some(bindings_swap) = bindings_guard.as_ref() {
+            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
+        }
+        drop(bindings_guard);
+
+        if let Some(discord_config) = &new_config.messaging.discord {
+            let new_perms =
+                crate::config::DiscordPermissions::from_config(discord_config, &new_config.bindings);
+            let perms = state.discord_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+
+        if let Some(slack_config) = &new_config.messaging.slack {
+            let new_perms =
+                crate::config::SlackPermissions::from_config(slack_config, &new_config.bindings);
+            let perms = state.slack_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+    }
+
+    Ok(Json(UpdateBindingResponse {
+        success: true,
+        message: "Binding updated.".to_string(),
+    }))
+}
+
+/// Delete a binding by matching agent_id + channel + platform-specific identifiers.
+async fn delete_binding(
+    State(state): State<Arc<ApiState>>,
+    axum::Json(request): axum::Json<DeleteBindingRequest>,
+) -> Result<Json<DeleteBindingResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if !config_path.exists() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let content = tokio::fs::read_to_string(&config_path).await.map_err(|error| {
+        tracing::warn!(%error, "failed to read config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let bindings_array = doc
+        .get_mut("bindings")
+        .and_then(|b| b.as_array_of_tables_mut())
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Find the matching binding index by iterating
+    let mut match_idx: Option<usize> = None;
+    for (i, table) in bindings_array.iter().enumerate() {
+        let matches_agent = table
+            .get("agent_id")
+            .and_then(|v: &toml_edit::Item| v.as_str())
+            .is_some_and(|v| v == request.agent_id);
+        let matches_channel = table
+            .get("channel")
+            .and_then(|v: &toml_edit::Item| v.as_str())
+            .is_some_and(|v| v == request.channel);
+        let matches_guild = match &request.guild_id {
+            Some(gid) => table
+                .get("guild_id")
+                .and_then(|v: &toml_edit::Item| v.as_str())
+                .is_some_and(|v| v == gid),
+            None => table.get("guild_id").is_none(),
+        };
+        let matches_workspace = match &request.workspace_id {
+            Some(wid) => table
+                .get("workspace_id")
+                .and_then(|v: &toml_edit::Item| v.as_str())
+                .is_some_and(|v| v == wid),
+            None => table.get("workspace_id").is_none(),
+        };
+        let matches_chat = match &request.chat_id {
+            Some(cid) => table
+                .get("chat_id")
+                .and_then(|v: &toml_edit::Item| v.as_str())
+                .is_some_and(|v| v == cid),
+            None => table.get("chat_id").is_none(),
+        };
+        if matches_agent && matches_channel && matches_guild && matches_workspace && matches_chat {
+            match_idx = Some(i);
+            break;
+        }
+    }
+
+    let Some(idx) = match_idx else {
+        return Ok(Json(DeleteBindingResponse {
+            success: false,
+            message: "No matching binding found.".to_string(),
+        }));
+    };
+
+    bindings_array.remove(idx);
+
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!(
+        agent_id = %request.agent_id,
+        channel = %request.channel,
+        "binding deleted via API"
+    );
+
+    // Hot-reload bindings and permissions
+    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+        let bindings_guard = state.bindings.read().await;
+        if let Some(bindings_swap) = bindings_guard.as_ref() {
+            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
+        }
+        drop(bindings_guard);
+
+        if let Some(discord_config) = &new_config.messaging.discord {
+            let new_perms =
+                crate::config::DiscordPermissions::from_config(discord_config, &new_config.bindings);
+            let perms = state.discord_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+
+        if let Some(slack_config) = &new_config.messaging.slack {
+            let new_perms =
+                crate::config::SlackPermissions::from_config(slack_config, &new_config.bindings);
+            let perms = state.slack_permissions.read().await;
+            if let Some(arc_swap) = perms.as_ref() {
+                arc_swap.store(std::sync::Arc::new(new_perms));
+            }
+        }
+    }
+
+    Ok(Json(DeleteBindingResponse {
+        success: true,
+        message: "Binding deleted.".to_string(),
+    }))
+}
+
+// -- Global Settings handlers --
+
+#[derive(Serialize)]
+struct GlobalSettingsResponse {
+    brave_search_key: Option<String>,
+    api_enabled: bool,
+    api_port: u16,
+    api_bind: String,
+    worker_log_mode: String,
+    opencode: OpenCodeSettingsResponse,
+}
+
+#[derive(Serialize)]
+struct OpenCodeSettingsResponse {
+    enabled: bool,
+    path: String,
+    max_servers: usize,
+    server_startup_timeout_secs: u64,
+    max_restart_retries: u32,
+    permissions: OpenCodePermissionsResponse,
+}
+
+#[derive(Serialize)]
+struct OpenCodePermissionsResponse {
+    edit: String,
+    bash: String,
+    webfetch: String,
+}
+
+#[derive(Deserialize)]
+struct GlobalSettingsUpdate {
+    brave_search_key: Option<String>,
+    api_enabled: Option<bool>,
+    api_port: Option<u16>,
+    api_bind: Option<String>,
+    worker_log_mode: Option<String>,
+    opencode: Option<OpenCodeSettingsUpdate>,
+}
+
+#[derive(Deserialize)]
+struct OpenCodeSettingsUpdate {
+    enabled: Option<bool>,
+    path: Option<String>,
+    max_servers: Option<usize>,
+    server_startup_timeout_secs: Option<u64>,
+    max_restart_retries: Option<u32>,
+    permissions: Option<OpenCodePermissionsUpdate>,
+}
+
+#[derive(Deserialize)]
+struct OpenCodePermissionsUpdate {
+    edit: Option<String>,
+    bash: Option<String>,
+    webfetch: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GlobalSettingsUpdateResponse {
+    success: bool,
+    message: String,
+    requires_restart: bool,
+}
+
+async fn get_global_settings(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<GlobalSettingsResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    
+    let (brave_search_key, api_enabled, api_port, api_bind, worker_log_mode, opencode) = if config_path.exists() {
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let doc: toml_edit::DocumentMut = content
+            .parse()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        
+        let brave_search = doc
+            .get("defaults")
+            .and_then(|d| d.get("brave_search_key"))
+            .and_then(|v| v.as_str())
+            .map(|s| {
+                if let Some(var) = s.strip_prefix("env:") {
+                    std::env::var(var).ok()
+                } else {
+                    Some(s.to_string())
+                }
+            })
+            .flatten();
+        
+        let api_enabled = doc
+            .get("api")
+            .and_then(|a| a.get("enabled"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        
+        let api_port = doc
+            .get("api")
+            .and_then(|a| a.get("port"))
+            .and_then(|v| v.as_integer())
+            .and_then(|i| u16::try_from(i).ok())
+            .unwrap_or(19898);
+        
+        let api_bind = doc
+            .get("api")
+            .and_then(|a| a.get("bind"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("127.0.0.1")
+            .to_string();
+        
+        let worker_log_mode = doc
+            .get("defaults")
+            .and_then(|d| d.get("worker_log_mode"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("errors_only")
+            .to_string();
+        
+        let opencode_table = doc.get("defaults").and_then(|d| d.get("opencode"));
+        let opencode_perms = opencode_table.and_then(|o| o.get("permissions"));
+        let opencode = OpenCodeSettingsResponse {
+            enabled: opencode_table
+                .and_then(|o| o.get("enabled"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            path: opencode_table
+                .and_then(|o| o.get("path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("opencode")
+                .to_string(),
+            max_servers: opencode_table
+                .and_then(|o| o.get("max_servers"))
+                .and_then(|v| v.as_integer())
+                .and_then(|i| usize::try_from(i).ok())
+                .unwrap_or(5),
+            server_startup_timeout_secs: opencode_table
+                .and_then(|o| o.get("server_startup_timeout_secs"))
+                .and_then(|v| v.as_integer())
+                .and_then(|i| u64::try_from(i).ok())
+                .unwrap_or(30),
+            max_restart_retries: opencode_table
+                .and_then(|o| o.get("max_restart_retries"))
+                .and_then(|v| v.as_integer())
+                .and_then(|i| u32::try_from(i).ok())
+                .unwrap_or(5),
+            permissions: OpenCodePermissionsResponse {
+                edit: opencode_perms
+                    .and_then(|p| p.get("edit"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("allow")
+                    .to_string(),
+                bash: opencode_perms
+                    .and_then(|p| p.get("bash"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("allow")
+                    .to_string(),
+                webfetch: opencode_perms
+                    .and_then(|p| p.get("webfetch"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("allow")
+                    .to_string(),
+            },
+        };
+
+        (brave_search, api_enabled, api_port, api_bind, worker_log_mode, opencode)
+    } else {
+        (None, true, 19898, "127.0.0.1".to_string(), "errors_only".to_string(), OpenCodeSettingsResponse {
+            enabled: false,
+            path: "opencode".to_string(),
+            max_servers: 5,
+            server_startup_timeout_secs: 30,
+            max_restart_retries: 5,
+            permissions: OpenCodePermissionsResponse {
+                edit: "allow".to_string(),
+                bash: "allow".to_string(),
+                webfetch: "allow".to_string(),
+            },
+        })
+    };
+    
+    Ok(Json(GlobalSettingsResponse {
+        brave_search_key: brave_search_key,
+        api_enabled,
+        api_port,
+        api_bind,
+        worker_log_mode,
+        opencode,
+    }))
+}
+
+async fn update_global_settings(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<GlobalSettingsUpdate>,
+) -> Result<Json<GlobalSettingsUpdateResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    } else {
+        String::new()
+    };
+    
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    let mut requires_restart = false;
+    
+    // Update brave_search_key
+    if let Some(key) = request.brave_search_key {
+        if doc.get("defaults").is_none() {
+            doc["defaults"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        if key.is_empty() {
+            if let Some(table) = doc["defaults"].as_table_mut() {
+                table.remove("brave_search_key");
+            }
+        } else {
+            doc["defaults"]["brave_search_key"] = toml_edit::value(key);
+        }
+    }
+    
+    // Update API settings (requires restart)
+    if request.api_enabled.is_some() || request.api_port.is_some() || request.api_bind.is_some() {
+        requires_restart = true;
+        
+        if doc.get("api").is_none() {
+            doc["api"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        
+        if let Some(enabled) = request.api_enabled {
+            doc["api"]["enabled"] = toml_edit::value(enabled);
+        }
+        if let Some(port) = request.api_port {
+            doc["api"]["port"] = toml_edit::value(i64::from(port));
+        }
+        if let Some(bind) = request.api_bind {
+            doc["api"]["bind"] = toml_edit::value(bind);
+        }
+    }
+    
+    // Update worker_log_mode
+    if let Some(mode) = request.worker_log_mode {
+        // Validate the mode
+        if !["errors_only", "all_separate", "all_combined"].contains(&mode.as_str()) {
+            return Ok(Json(GlobalSettingsUpdateResponse {
+                success: false,
+                message: format!("Invalid worker log mode: {}", mode),
+                requires_restart: false,
+            }));
+        }
+        
+        if doc.get("defaults").is_none() {
+            doc["defaults"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        doc["defaults"]["worker_log_mode"] = toml_edit::value(mode);
+    }
+    
+    // Update OpenCode settings
+    if let Some(opencode) = request.opencode {
+        if doc.get("defaults").is_none() {
+            doc["defaults"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        if doc["defaults"].get("opencode").is_none() {
+            doc["defaults"]["opencode"] = toml_edit::Item::Table(toml_edit::Table::new());
+        }
+        
+        if let Some(enabled) = opencode.enabled {
+            doc["defaults"]["opencode"]["enabled"] = toml_edit::value(enabled);
+        }
+        if let Some(path) = opencode.path {
+            doc["defaults"]["opencode"]["path"] = toml_edit::value(path);
+        }
+        if let Some(max_servers) = opencode.max_servers {
+            doc["defaults"]["opencode"]["max_servers"] = toml_edit::value(max_servers as i64);
+        }
+        if let Some(timeout) = opencode.server_startup_timeout_secs {
+            doc["defaults"]["opencode"]["server_startup_timeout_secs"] = toml_edit::value(timeout as i64);
+        }
+        if let Some(retries) = opencode.max_restart_retries {
+            doc["defaults"]["opencode"]["max_restart_retries"] = toml_edit::value(retries as i64);
+        }
+        if let Some(permissions) = opencode.permissions {
+            if doc["defaults"]["opencode"].get("permissions").is_none() {
+                doc["defaults"]["opencode"]["permissions"] = toml_edit::Item::Table(toml_edit::Table::new());
+            }
+            if let Some(edit) = permissions.edit {
+                doc["defaults"]["opencode"]["permissions"]["edit"] = toml_edit::value(edit);
+            }
+            if let Some(bash) = permissions.bash {
+                doc["defaults"]["opencode"]["permissions"]["bash"] = toml_edit::value(bash);
+            }
+            if let Some(webfetch) = permissions.webfetch {
+                doc["defaults"]["opencode"]["permissions"]["webfetch"] = toml_edit::value(webfetch);
+            }
+        }
+    }
+
+    tokio::fs::write(&config_path, doc.to_string())
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    let message = if requires_restart {
+        "Settings updated. API server changes require a restart to take effect.".to_string()
+    } else {
+        "Settings updated successfully.".to_string()
+    };
+    
+    Ok(Json(GlobalSettingsUpdateResponse {
+        success: true,
+        message,
+        requires_restart,
+    }))
+}
+
+// -- Update handlers --
+
+/// Return the current update status (from background check).
+async fn update_check(State(state): State<Arc<ApiState>>) -> Json<crate::update::UpdateStatus> {
+    let status = state.update_status.load();
+    Json((**status).clone())
+}
+
+/// Force an immediate update check against GitHub.
+async fn update_check_now(State(state): State<Arc<ApiState>>) -> Json<crate::update::UpdateStatus> {
+    crate::update::check_for_update(&state.update_status).await;
+    let status = state.update_status.load();
+    Json((**status).clone())
+}
+
+/// Pull the new Docker image and recreate this container.
+async fn update_apply(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    match crate::update::apply_docker_update(&state.update_status).await {
+        Ok(()) => Ok(Json(serde_json::json!({ "status": "updating" }))),
+        Err(error) => {
+            tracing::error!(%error, "update apply failed");
+            Ok(Json(serde_json::json!({
+                "status": "error",
+                "error": error.to_string(),
+            })))
+        }
+    }
+}
+
+// -- Raw config endpoints --
+
+#[derive(Serialize)]
+struct RawConfigResponse {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct RawConfigUpdateRequest {
+    content: String,
+}
+
+#[derive(Serialize)]
+struct RawConfigUpdateResponse {
+    success: bool,
+    message: String,
+}
+
+async fn get_raw_config(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<RawConfigResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        tracing::error!("config_path not set in ApiState");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to read config.toml");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+    } else {
+        String::new()
+    };
+
+    Ok(Json(RawConfigResponse { content }))
+}
+
+async fn update_raw_config(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<RawConfigUpdateRequest>,
+) -> Result<Json<RawConfigUpdateResponse>, StatusCode> {
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        tracing::error!("config_path not set in ApiState");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // Validate TOML syntax and config structure
+    if let Err(error) = crate::config::Config::validate_toml(&request.content) {
+        return Ok(Json(RawConfigUpdateResponse {
+            success: false,
+            message: format!("Validation error: {error}"),
+        }));
+    }
+
+    // Write to disk
+    tokio::fs::write(&config_path, &request.content)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!("config.toml updated via raw editor");
+
+    // Reload RuntimeConfig for all agents
+    match crate::config::Config::load_from_path(&config_path) {
+        Ok(new_config) => {
+            let runtime_configs = state.runtime_configs.load();
+            for (agent_id, rc) in runtime_configs.iter() {
+                rc.reload_config(&new_config, agent_id);
+            }
+        }
+        Err(error) => {
+            tracing::warn!(%error, "config.toml written but failed to reload immediately");
+        }
+    }
+
+    Ok(Json(RawConfigUpdateResponse {
+        success: true,
+        message: "Config saved and reloaded.".to_string(),
+    }))
+}
+
+// -- Static file serving --
 
 async fn static_handler(uri: Uri) -> Response {
     let path = uri.path().trim_start_matches('/');

--- a/src/config.rs
+++ b/src/config.rs
@@ -1224,6 +1224,11 @@ struct TomlRoutingConfig {
     compactor: Option<String>,
     cortex: Option<String>,
     rate_limit_cooldown_secs: Option<u64>,
+    channel_thinking_effort: Option<String>,
+    branch_thinking_effort: Option<String>,
+    worker_thinking_effort: Option<String>,
+    compactor_thinking_effort: Option<String>,
+    cortex_thinking_effort: Option<String>,
     #[serde(default)]
     task_overrides: HashMap<String, String>,
     fallbacks: Option<HashMap<String, Vec<String>>>,
@@ -1493,6 +1498,21 @@ fn resolve_routing(toml: Option<TomlRoutingConfig>, base: &RoutingConfig) -> Rou
         rate_limit_cooldown_secs: t
             .rate_limit_cooldown_secs
             .unwrap_or(base.rate_limit_cooldown_secs),
+        channel_thinking_effort: t
+            .channel_thinking_effort
+            .unwrap_or_else(|| base.channel_thinking_effort.clone()),
+        branch_thinking_effort: t
+            .branch_thinking_effort
+            .unwrap_or_else(|| base.branch_thinking_effort.clone()),
+        worker_thinking_effort: t
+            .worker_thinking_effort
+            .unwrap_or_else(|| base.worker_thinking_effort.clone()),
+        compactor_thinking_effort: t
+            .compactor_thinking_effort
+            .unwrap_or_else(|| base.compactor_thinking_effort.clone()),
+        cortex_thinking_effort: t
+            .cortex_thinking_effort
+            .unwrap_or_else(|| base.cortex_thinking_effort.clone()),
     }
 }
 
@@ -1515,6 +1535,7 @@ impl Config {
         if config_path.exists() {
             return false;
         }
+<<<<<<< HEAD
 
         // Check if we have any legacy env keys configured
         let has_legacy_keys = std::env::var("ANTHROPIC_API_KEY").is_ok()
@@ -1547,7 +1568,14 @@ impl Config {
                 || key.contains("PROVIDER") && key.contains("API_KEY")
         });
 
-        !has_provider_env_vars
+        // Also check for specific legacy env vars that can bootstrap
+        let has_legacy_bootstrap_vars = std::env::var("ANTHROPIC_API_KEY").is_ok()
+            || std::env::var("ANTHROPIC_OAUTH_TOKEN").is_ok()
+            || std::env::var("OPENAI_API_KEY").is_ok()
+            || std::env::var("OPENROUTER_API_KEY").is_ok()
+            || std::env::var("OPENCODE_ZEN_API_KEY").is_ok();
+
+        !has_provider_env_vars && !has_legacy_bootstrap_vars
     }
 
     /// Load configuration from the default config file, falling back to env vars.

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,5 +1,6 @@
 //! LLM provider management and routing.
 
+pub mod anthropic;
 pub mod manager;
 pub mod model;
 pub mod providers;

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,0 +1,11 @@
+//! Anthropic API integration: auth routing, tool normalization, and caching.
+
+pub mod auth;
+pub mod cache;
+pub mod params;
+pub mod tools;
+
+pub use auth::{AnthropicAuthPath, apply_auth_headers, detect_auth_path};
+pub use cache::{CacheRetention, get_cache_control, resolve_cache_retention};
+pub use params::build_anthropic_request;
+pub use tools::{from_claude_code_name, to_claude_code_name};

--- a/src/llm/anthropic/auth.rs
+++ b/src/llm/anthropic/auth.rs
@@ -1,0 +1,153 @@
+//! Auth path detection and header construction for Anthropic API requests.
+
+use reqwest::RequestBuilder;
+
+const BETA_FINE_GRAINED_STREAMING: &str = "fine-grained-tool-streaming-2025-05-14";
+const BETA_INTERLEAVED_THINKING: &str = "interleaved-thinking-2025-05-14";
+const BETA_CLAUDE_CODE: &str = "claude-code-20250219";
+const BETA_OAUTH: &str = "oauth-2025-04-20";
+const CLAUDE_CODE_USER_AGENT: &str = "claude-cli/2.1.2 (external, cli)";
+
+/// Which authentication path to use for an Anthropic API call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnthropicAuthPath {
+    /// Standard API key (sk-ant-api*) — uses x-api-key header.
+    ApiKey,
+    /// OAuth token (sk-ant-oat*) — uses Bearer auth with Claude Code identity.
+    OAuthToken,
+}
+
+/// Detect the auth path from a token's prefix.
+pub fn detect_auth_path(token: &str) -> AnthropicAuthPath {
+    if token.starts_with("sk-ant-oat") {
+        AnthropicAuthPath::OAuthToken
+    } else {
+        AnthropicAuthPath::ApiKey
+    }
+}
+
+/// Apply authentication headers and beta headers to a request builder.
+///
+/// Returns the augmented builder and the detected auth path (so callers
+/// know whether tool name normalization and identity injection apply).
+pub fn apply_auth_headers(
+    builder: RequestBuilder,
+    token: &str,
+    interleaved_thinking: bool,
+) -> (RequestBuilder, AnthropicAuthPath) {
+    let auth_path = detect_auth_path(token);
+
+    let mut beta_parts: Vec<&str> = Vec::new();
+    let builder = match auth_path {
+        AnthropicAuthPath::ApiKey => {
+            beta_parts.push(BETA_FINE_GRAINED_STREAMING);
+            builder.header("x-api-key", token)
+        }
+        AnthropicAuthPath::OAuthToken => {
+            beta_parts.push(BETA_CLAUDE_CODE);
+            beta_parts.push(BETA_OAUTH);
+            beta_parts.push(BETA_FINE_GRAINED_STREAMING);
+            builder
+                .header("Authorization", format!("Bearer {token}"))
+                .header("user-agent", CLAUDE_CODE_USER_AGENT)
+                .header("x-app", "cli")
+        }
+    };
+
+    if interleaved_thinking {
+        beta_parts.push(BETA_INTERLEAVED_THINKING);
+    }
+
+    let beta_header = beta_parts.join(",");
+    let builder = builder.header("anthropic-beta", beta_header);
+
+    (builder, auth_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_request(token: &str, thinking: bool) -> (reqwest::Request, AnthropicAuthPath) {
+        let client = reqwest::Client::new();
+        let builder = client.post("https://api.anthropic.com/v1/messages");
+        let (builder, auth_path) = apply_auth_headers(builder, token, thinking);
+        (builder.build().unwrap(), auth_path)
+    }
+
+    #[test]
+    fn oauth_token_detected_correctly() {
+        assert_eq!(detect_auth_path("sk-ant-oat01-abc123"), AnthropicAuthPath::OAuthToken);
+    }
+
+    #[test]
+    fn api_key_detected_correctly() {
+        assert_eq!(detect_auth_path("sk-ant-api03-xyz789"), AnthropicAuthPath::ApiKey);
+    }
+
+    #[test]
+    fn unknown_prefix_defaults_to_api_key() {
+        assert_eq!(detect_auth_path("some-random-key"), AnthropicAuthPath::ApiKey);
+    }
+
+    #[test]
+    fn oauth_token_uses_bearer_header() {
+        let (request, auth_path) = build_request("sk-ant-oat01-abc123", false);
+        assert_eq!(auth_path, AnthropicAuthPath::OAuthToken);
+        assert_eq!(
+            request.headers().get("Authorization").unwrap(),
+            "Bearer sk-ant-oat01-abc123"
+        );
+        assert!(request.headers().get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn oauth_token_includes_identity_headers() {
+        let (request, _) = build_request("sk-ant-oat01-abc123", false);
+        assert_eq!(
+            request.headers().get("user-agent").unwrap(),
+            CLAUDE_CODE_USER_AGENT
+        );
+        assert_eq!(request.headers().get("x-app").unwrap(), "cli");
+    }
+
+    #[test]
+    fn oauth_token_includes_claude_code_beta() {
+        let (request, _) = build_request("sk-ant-oat01-abc123", false);
+        let beta = request.headers().get("anthropic-beta").unwrap().to_str().unwrap();
+        assert!(beta.contains(BETA_CLAUDE_CODE));
+        assert!(beta.contains(BETA_OAUTH));
+        assert!(beta.contains(BETA_FINE_GRAINED_STREAMING));
+    }
+
+    #[test]
+    fn api_key_uses_x_api_key_header() {
+        let (request, auth_path) = build_request("sk-ant-api03-xyz789", false);
+        assert_eq!(auth_path, AnthropicAuthPath::ApiKey);
+        assert_eq!(
+            request.headers().get("x-api-key").unwrap(),
+            "sk-ant-api03-xyz789"
+        );
+        assert!(request.headers().get("Authorization").is_none());
+    }
+
+    #[test]
+    fn api_key_has_no_identity_headers() {
+        let (request, _) = build_request("sk-ant-api03-xyz789", false);
+        assert!(request.headers().get("x-app").is_none());
+    }
+
+    #[test]
+    fn interleaved_thinking_appended_to_beta() {
+        let (request, _) = build_request("sk-ant-api03-xyz789", true);
+        let beta = request.headers().get("anthropic-beta").unwrap().to_str().unwrap();
+        assert!(beta.contains(BETA_INTERLEAVED_THINKING));
+    }
+
+    #[test]
+    fn no_interleaved_thinking_when_disabled() {
+        let (request, _) = build_request("sk-ant-api03-xyz789", false);
+        let beta = request.headers().get("anthropic-beta").unwrap().to_str().unwrap();
+        assert!(!beta.contains(BETA_INTERLEAVED_THINKING));
+    }
+}

--- a/src/llm/anthropic/cache.rs
+++ b/src/llm/anthropic/cache.rs
@@ -1,0 +1,97 @@
+//! Cache control for Anthropic API requests.
+
+/// Cache retention policy for Anthropic prompt caching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRetention {
+    /// No cache_control attached to blocks.
+    None,
+    /// Ephemeral caching (default).
+    Short,
+    /// Extended caching with optional TTL on api.anthropic.com.
+    Long,
+}
+
+/// Resolve cache retention from the environment, with a caller-provided override.
+///
+/// Precedence: explicit override > `PI_CACHE_RETENTION` env var > Short.
+pub fn resolve_cache_retention(override_value: Option<CacheRetention>) -> CacheRetention {
+    if let Some(value) = override_value {
+        return value;
+    }
+    if let Ok(env_val) = std::env::var("PI_CACHE_RETENTION") {
+        if env_val.eq_ignore_ascii_case("long") {
+            return CacheRetention::Long;
+        }
+        if env_val.eq_ignore_ascii_case("none") {
+            return CacheRetention::None;
+        }
+    }
+    CacheRetention::Short
+}
+
+/// Build a `cache_control` JSON value appropriate for the retention policy
+/// and base URL. Returns `None` when retention is `None`.
+pub fn get_cache_control(
+    base_url: &str,
+    retention: CacheRetention,
+) -> Option<serde_json::Value> {
+    match retention {
+        CacheRetention::None => None,
+        CacheRetention::Short => Some(serde_json::json!({"type": "ephemeral"})),
+        CacheRetention::Long => {
+            if base_url.contains("api.anthropic.com") {
+                Some(serde_json::json!({"type": "ephemeral", "ttl": "1h"}))
+            } else {
+                Some(serde_json::json!({"type": "ephemeral"}))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_short() {
+        // Rust 2024 edition requires unsafe for env mutation (not thread-safe)
+        unsafe { std::env::remove_var("PI_CACHE_RETENTION") };
+        assert_eq!(resolve_cache_retention(None), CacheRetention::Short);
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        assert_eq!(
+            resolve_cache_retention(Some(CacheRetention::Long)),
+            CacheRetention::Long
+        );
+        assert_eq!(
+            resolve_cache_retention(Some(CacheRetention::None)),
+            CacheRetention::None
+        );
+    }
+
+    #[test]
+    fn short_returns_ephemeral() {
+        let cc = get_cache_control("https://api.anthropic.com/v1/messages", CacheRetention::Short);
+        assert_eq!(cc, Some(serde_json::json!({"type": "ephemeral"})));
+    }
+
+    #[test]
+    fn long_returns_ttl_for_anthropic() {
+        let cc = get_cache_control("https://api.anthropic.com/v1/messages", CacheRetention::Long);
+        assert_eq!(cc, Some(serde_json::json!({"type": "ephemeral", "ttl": "1h"})));
+    }
+
+    #[test]
+    fn long_returns_ephemeral_for_other_hosts() {
+        let cc = get_cache_control("https://custom-proxy.example.com/v1/messages", CacheRetention::Long);
+        assert_eq!(cc, Some(serde_json::json!({"type": "ephemeral"})));
+    }
+
+    #[test]
+    fn none_returns_no_cache_control() {
+        let cc = get_cache_control("https://api.anthropic.com/v1/messages", CacheRetention::None);
+        assert!(cc.is_none());
+    }
+}

--- a/src/llm/anthropic/params.rs
+++ b/src/llm/anthropic/params.rs
@@ -1,0 +1,197 @@
+//! Build full Anthropic API requests with auth, system prompt, thinking, and tools.
+
+use super::auth::{self, AnthropicAuthPath};
+use super::cache;
+use super::tools;
+
+use reqwest::RequestBuilder;
+use rig::completion::CompletionRequest;
+
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const CLAUDE_CODE_SYSTEM_PREAMBLE: &str =
+    "You are Claude Code, Anthropic's official CLI for Claude.";
+
+/// Result of building an Anthropic request: the configured HTTP request builder,
+/// the auth path used, and the original tool names for response reverse-mapping.
+pub struct AnthropicRequest {
+    pub builder: RequestBuilder,
+    pub auth_path: AnthropicAuthPath,
+    /// Original tool (name, description) pairs for reverse-mapping response tool calls.
+    pub original_tools: Vec<(String, String)>,
+}
+
+/// Adaptive thinking is only available on 4.6-generation models.
+fn supports_adaptive_thinking(model_id: &str) -> bool {
+    model_id.contains("opus-4-6")
+        || model_id.contains("opus-4.6")
+        || model_id.contains("sonnet-4-6")
+        || model_id.contains("sonnet-4.6")
+}
+
+fn is_opus(model_id: &str) -> bool {
+    model_id.contains("opus")
+}
+
+/// Build a fully configured Anthropic API request from a CompletionRequest.
+///
+/// `thinking_effort` controls adaptive thinking: "auto" picks max for Opus /
+/// high for others, or pass "max", "high", "medium", "low" explicitly.
+pub fn build_anthropic_request(
+    http_client: &reqwest::Client,
+    api_key: &str,
+    model_name: &str,
+    request: &CompletionRequest,
+    thinking_effort: &str,
+) -> AnthropicRequest {
+    let is_oauth = auth::detect_auth_path(api_key) == AnthropicAuthPath::OAuthToken;
+    let adaptive_thinking = supports_adaptive_thinking(model_name);
+    let retention = cache::resolve_cache_retention(None);
+    let cache_control = cache::get_cache_control(ANTHROPIC_API_URL, retention);
+
+    let mut body = serde_json::json!({
+        "model": model_name,
+        "max_tokens": request.max_tokens.unwrap_or(16_000),
+    });
+
+    build_system_prompt(&mut body, request, is_oauth, &cache_control);
+
+    let messages = crate::llm::model::convert_messages_to_anthropic(&request.chat_history);
+    body["messages"] = serde_json::json!(messages);
+
+    let original_tools = build_tools(&mut body, request, is_oauth, &cache_control);
+
+    if let Some(temperature) = request.temperature {
+        body["temperature"] = serde_json::json!(temperature);
+    }
+
+    if adaptive_thinking {
+        body["thinking"] = serde_json::json!({ "type": "adaptive" });
+        let effort = match thinking_effort {
+            "max" | "high" | "medium" | "low" => thinking_effort,
+            _ => if is_opus(model_name) { "max" } else { "high" },
+        };
+        body["output_config"] = serde_json::json!({ "effort": effort });
+    }
+
+    let builder = http_client
+        .post(ANTHROPIC_API_URL)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json");
+
+    let (builder, auth_path) = auth::apply_auth_headers(builder, api_key, false);
+    let builder = builder.json(&body);
+
+    AnthropicRequest {
+        builder,
+        auth_path,
+        original_tools,
+    }
+}
+
+fn build_system_prompt(
+    body: &mut serde_json::Value,
+    request: &CompletionRequest,
+    is_oauth: bool,
+    cache_control: &Option<serde_json::Value>,
+) {
+    let mut system_blocks: Vec<serde_json::Value> = Vec::new();
+
+    if is_oauth {
+        let mut identity_block = serde_json::json!({
+            "type": "text",
+            "text": CLAUDE_CODE_SYSTEM_PREAMBLE,
+        });
+        if let Some(cc) = cache_control {
+            identity_block["cache_control"] = cc.clone();
+        }
+        system_blocks.push(identity_block);
+    }
+
+    if let Some(preamble) = &request.preamble {
+        let mut preamble_block = serde_json::json!({
+            "type": "text",
+            "text": preamble,
+        });
+        if let Some(cc) = cache_control {
+            preamble_block["cache_control"] = cc.clone();
+        }
+        system_blocks.push(preamble_block);
+    }
+
+    if !system_blocks.is_empty() {
+        body["system"] = serde_json::json!(system_blocks);
+    }
+}
+
+/// Build tool definitions, optionally normalizing names. Returns the original
+/// tool (name, description) pairs for reverse-mapping on response.
+fn build_tools(
+    body: &mut serde_json::Value,
+    request: &CompletionRequest,
+    is_oauth: bool,
+    cache_control: &Option<serde_json::Value>,
+) -> Vec<(String, String)> {
+    if request.tools.is_empty() {
+        return Vec::new();
+    }
+
+    let original_tools: Vec<(String, String)> = request
+        .tools
+        .iter()
+        .map(|t| (t.name.clone(), t.description.clone()))
+        .collect();
+
+    let tool_values: Vec<serde_json::Value> = request
+        .tools
+        .iter()
+        .enumerate()
+        .map(|(index, t)| {
+            let name = if is_oauth {
+                tools::to_claude_code_name(&t.name)
+            } else {
+                t.name.clone()
+            };
+
+            let mut tool = serde_json::json!({
+                "name": name,
+                "description": t.description,
+                "input_schema": t.parameters,
+            });
+
+            // Attach cache_control to the last tool definition
+            if index == request.tools.len() - 1 {
+                if let Some(cc) = cache_control {
+                    tool["cache_control"] = cc.clone();
+                }
+            }
+
+            tool
+        })
+        .collect();
+
+    body["tools"] = serde_json::json!(tool_values);
+
+    original_tools
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adaptive_thinking_detected_for_4_6_models() {
+        assert!(supports_adaptive_thinking("claude-opus-4-6-20250901"));
+        assert!(supports_adaptive_thinking("opus-4.6"));
+        assert!(supports_adaptive_thinking("anthropic/claude-opus-4-6"));
+        assert!(supports_adaptive_thinking("claude-sonnet-4-6-20250901"));
+        assert!(supports_adaptive_thinking("sonnet-4.6"));
+        assert!(supports_adaptive_thinking("anthropic/claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn adaptive_thinking_not_detected_for_older_models() {
+        assert!(!supports_adaptive_thinking("claude-sonnet-4-5"));
+        assert!(!supports_adaptive_thinking("claude-opus-4-0"));
+        assert!(!supports_adaptive_thinking("gpt-4o"));
+    }
+}

--- a/src/llm/anthropic/tools.rs
+++ b/src/llm/anthropic/tools.rs
@@ -1,0 +1,113 @@
+//! Claude Code tool name normalization.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Canonical Claude Code 2.x tool names.
+const CLAUDE_CODE_TOOLS: &[&str] = &[
+    "Read",
+    "Write",
+    "Edit",
+    "Bash",
+    "Grep",
+    "Glob",
+    "AskUserQuestion",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "KillShell",
+    "NotebookEdit",
+    "Skill",
+    "Task",
+    "TaskOutput",
+    "TodoWrite",
+    "WebFetch",
+    "WebSearch",
+];
+
+/// Lowercase → canonical casing lookup.
+static CC_TOOL_LOOKUP: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
+    CLAUDE_CODE_TOOLS
+        .iter()
+        .map(|&name| (name.to_lowercase(), name))
+        .collect()
+});
+
+/// Normalize a tool name to Claude Code canonical casing (case-insensitive).
+/// Unknown names pass through unchanged.
+pub fn to_claude_code_name(name: &str) -> String {
+    CC_TOOL_LOOKUP
+        .get(&name.to_lowercase())
+        .map(|&canonical| canonical.to_string())
+        .unwrap_or_else(|| name.to_string())
+}
+
+/// Reverse-map a Claude Code canonical name back to the original tool name
+/// from the request's tool definitions. Falls back to the input name if no
+/// match is found.
+pub fn from_claude_code_name(name: &str, original_tools: &[(String, String)]) -> String {
+    let lower = name.to_lowercase();
+    for (original_name, _description) in original_tools {
+        if original_name.to_lowercase() == lower {
+            return original_name.clone();
+        }
+    }
+    name.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_canonical_names_normalize() {
+        for &name in CLAUDE_CODE_TOOLS {
+            assert_eq!(to_claude_code_name(name), name);
+        }
+    }
+
+    #[test]
+    fn lowercase_normalizes_to_canonical() {
+        assert_eq!(to_claude_code_name("read"), "Read");
+        assert_eq!(to_claude_code_name("bash"), "Bash");
+        assert_eq!(to_claude_code_name("askuserquestion"), "AskUserQuestion");
+        assert_eq!(to_claude_code_name("webfetch"), "WebFetch");
+    }
+
+    #[test]
+    fn mixed_case_normalizes() {
+        assert_eq!(to_claude_code_name("READ"), "Read");
+        assert_eq!(to_claude_code_name("bAsH"), "Bash");
+        assert_eq!(to_claude_code_name("Grep"), "Grep");
+    }
+
+    #[test]
+    fn unknown_names_pass_through() {
+        assert_eq!(to_claude_code_name("custom_tool"), "custom_tool");
+        assert_eq!(to_claude_code_name("MySpecialTool"), "MySpecialTool");
+    }
+
+    #[test]
+    fn reverse_mapping_finds_original() {
+        let tools = vec![
+            ("my_read_tool".to_string(), "reads files".to_string()),
+            ("my_bash".to_string(), "runs commands".to_string()),
+        ];
+        assert_eq!(from_claude_code_name("my_read_tool", &tools), "my_read_tool");
+    }
+
+    #[test]
+    fn reverse_mapping_case_insensitive() {
+        let tools = vec![
+            ("read_file".to_string(), "reads files".to_string()),
+        ];
+        assert_eq!(from_claude_code_name("Read_File", &tools), "read_file");
+    }
+
+    #[test]
+    fn reverse_mapping_falls_back_to_input() {
+        let tools = vec![
+            ("other_tool".to_string(), "does things".to_string()),
+        ];
+        assert_eq!(from_claude_code_name("Read", &tools), "Read");
+    }
+}

--- a/src/llm/manager.rs
+++ b/src/llm/manager.rs
@@ -10,6 +10,7 @@
 
 use crate::config::{LlmConfig, ProviderConfig};
 use crate::error::{LlmError, Result};
+
 use anyhow::Context as _;
 use arc_swap::ArcSwap;
 use std::collections::HashMap;

--- a/src/llm/model.rs
+++ b/src/llm/model.rs
@@ -323,49 +323,27 @@ impl SpacebotModel {
         request: CompletionRequest,
         provider_config: &ProviderConfig,
     ) -> Result<completion::CompletionResponse<RawResponse>, CompletionError> {
-        let base_url = provider_config.base_url.trim_end_matches('/');
-        let messages_url = format!("{base_url}/v1/messages");
         let api_key = provider_config.api_key.as_str();
 
-        let messages = convert_messages_to_anthropic(&request.chat_history);
+        let effort = self
+            .routing
+            .as_ref()
+            .map(|r| r.thinking_effort_for_model(&self.model_name))
+            .unwrap_or("auto");
+        let anthropic_request = crate::llm::anthropic::build_anthropic_request(
+            self.llm_manager.http_client(),
+            &api_key,
+            &self.model_name,
+            &request,
+            effort,
+        );
 
-        let mut body = serde_json::json!({
-            "model": self.model_name,
-            "messages": messages,
-            "max_tokens": request.max_tokens.unwrap_or(4096),
-        });
+        let is_oauth =
+            anthropic_request.auth_path == crate::llm::anthropic::AnthropicAuthPath::OAuthToken;
+        let original_tools = anthropic_request.original_tools;
 
-        if let Some(preamble) = &request.preamble {
-            body["system"] = serde_json::json!(preamble);
-        }
-
-        if let Some(temperature) = request.temperature {
-            body["temperature"] = serde_json::json!(temperature);
-        }
-
-        if !request.tools.is_empty() {
-            let tools: Vec<serde_json::Value> = request
-                .tools
-                .iter()
-                .map(|t| {
-                    serde_json::json!({
-                        "name": t.name,
-                        "description": t.description,
-                        "input_schema": t.parameters,
-                    })
-                })
-                .collect();
-            body["tools"] = serde_json::json!(tools);
-        }
-
-        let response = self
-            .llm_manager
-            .http_client()
-            .post(&messages_url)
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&body)
+        let response = anthropic_request
+            .builder
             .send()
             .await
             .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
@@ -392,7 +370,14 @@ impl SpacebotModel {
             )));
         }
 
-        parse_anthropic_response(response_body)
+        let mut completion = parse_anthropic_response(response_body)?;
+
+        // Reverse-map tool names when using OAuth (Claude Code canonical → original)
+        if is_oauth && !original_tools.is_empty() {
+            reverse_map_tool_names(&mut completion, &original_tools);
+        }
+
+        Ok(completion)
     }
 
     async fn call_openai(
@@ -780,6 +765,20 @@ fn normalize_ollama_base_url(configured: Option<String>) -> String {
     base_url
 }
 
+/// Reverse-map Claude Code canonical tool names back to the original names
+/// from the request's tool definitions.
+fn reverse_map_tool_names(
+    completion: &mut completion::CompletionResponse<RawResponse>,
+    original_tools: &[(String, String)],
+) {
+    for content in completion.choice.iter_mut() {
+        if let AssistantContent::ToolCall(tc) = content {
+            tc.function.name =
+                crate::llm::anthropic::from_claude_code_name(&tc.function.name, original_tools);
+        }
+    }
+}
+
 fn tool_result_content_to_string(content: &OneOrMany<rig::message::ToolResultContent>) -> String {
     content
         .iter()
@@ -793,7 +792,7 @@ fn tool_result_content_to_string(content: &OneOrMany<rig::message::ToolResultCon
 
 // --- Message conversion ---
 
-fn convert_messages_to_anthropic(messages: &OneOrMany<Message>) -> Vec<serde_json::Value> {
+pub fn convert_messages_to_anthropic(messages: &OneOrMany<Message>) -> Vec<serde_json::Value> {
     messages
         .iter()
         .map(|message| match message {
@@ -1235,6 +1234,7 @@ fn parse_openai_response(
     })
 }
 
+<<<<<<< HEAD
 fn parse_openai_responses_response(
     body: serde_json::Value,
 ) -> Result<completion::CompletionResponse<RawResponse>, CompletionError> {
@@ -1301,4 +1301,48 @@ fn parse_openai_responses_response(
         },
         raw_response: RawResponse { body },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse_map_restores_original_tool_names() {
+        let original_tools = vec![
+            ("my_read".to_string(), "reads files".to_string()),
+            ("my_bash".to_string(), "runs commands".to_string()),
+        ];
+
+        let mut completion = completion::CompletionResponse {
+            choice: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+                id: "tc1".into(),
+                call_id: None,
+                function: ToolFunction {
+                    name: "My_Read".into(),
+                    arguments: serde_json::json!({}),
+                },
+                signature: None,
+                additional_params: None,
+            })),
+            usage: completion::Usage {
+                input_tokens: 0,
+                output_tokens: 0,
+                total_tokens: 0,
+                cached_input_tokens: 0,
+            },
+            raw_response: RawResponse {
+                body: serde_json::json!({}),
+            },
+        };
+
+        reverse_map_tool_names(&mut completion, &original_tools);
+
+        let first = completion.choice.first_ref();
+        if let AssistantContent::ToolCall(tc) = first {
+            assert_eq!(tc.function.name, "my_read");
+        } else {
+            panic!("expected ToolCall");
+        }
+    }
 }

--- a/src/llm/providers.rs
+++ b/src/llm/providers.rs
@@ -10,7 +10,7 @@ pub async fn init_providers(config: &LlmConfig) -> Result<()> {
     // during system startup
 
     if config.anthropic_key.is_some() {
-        tracing::info!("Anthropic provider configured");
+        tracing::info!("Anthropic provider configured (API key)");
     }
 
     if config.openai_key.is_some() {

--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -25,6 +25,12 @@ pub struct RoutingConfig {
 
     /// How long to deprioritize a rate-limited model (seconds).
     pub rate_limit_cooldown_secs: u64,
+
+    pub channel_thinking_effort: String,
+    pub branch_thinking_effort: String,
+    pub worker_thinking_effort: String,
+    pub compactor_thinking_effort: String,
+    pub cortex_thinking_effort: String,
 }
 
 impl Default for RoutingConfig {
@@ -45,6 +51,11 @@ impl RoutingConfig {
             task_overrides: HashMap::new(),
             fallbacks: HashMap::new(),
             rate_limit_cooldown_secs: 60,
+            channel_thinking_effort: "auto".into(),
+            branch_thinking_effort: "auto".into(),
+            worker_thinking_effort: "auto".into(),
+            compactor_thinking_effort: "auto".into(),
+            cortex_thinking_effort: "auto".into(),
         }
     }
 }
@@ -68,6 +79,15 @@ impl RoutingConfig {
             ProcessType::Compactor => &self.compactor,
             ProcessType::Cortex => &self.cortex,
         }
+    }
+
+    pub fn thinking_effort_for_model(&self, model_name: &str) -> &str {
+        if self.channel == model_name { return &self.channel_thinking_effort; }
+        if self.branch == model_name { return &self.branch_thinking_effort; }
+        if self.worker == model_name { return &self.worker_thinking_effort; }
+        if self.compactor == model_name { return &self.compactor_thinking_effort; }
+        if self.cortex == model_name { return &self.cortex_thinking_effort; }
+        "auto"
     }
 
     /// Get the fallback chain for a model, if any.
@@ -127,24 +147,163 @@ pub fn is_context_overflow_error(error_message: &str) -> bool {
 pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
     match provider {
         "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4".into()),
-        "openrouter" => RoutingConfig::for_model("openrouter/anthropic/claude-sonnet-4".into()),
-        "openai" => RoutingConfig::for_model("openai/gpt-4.1".into()),
-        "zhipu" => RoutingConfig::for_model("zhipu/glm-4-plus".into()),
-        "groq" => RoutingConfig::for_model("groq/llama-3.3-70b-versatile".into()),
-        "together" => RoutingConfig::for_model(
-            "together/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo".into(),
-        ),
-        "fireworks" => RoutingConfig::for_model(
-            "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct".into(),
-        ),
-        "deepseek" => RoutingConfig::for_model("deepseek/deepseek-chat".into()),
-        "xai" => RoutingConfig::for_model("xai/grok-2-latest".into()),
-        "mistral" => RoutingConfig::for_model("mistral/mistral-large-latest".into()),
+        "openrouter" => {
+            let channel: String = "openrouter/anthropic/claude-sonnet-4-20250514".into();
+            let worker: String = "openrouter/anthropic/claude-haiku-4.5-20250514".into();
+            RoutingConfig {
+                channel: "openrouter/anthropic/claude-sonnet-4-20250514".into(),
+                branch: "openrouter/anthropic/claude-sonnet-4-20250514".into(),
+                worker: "openrouter/anthropic/claude-haiku-4.5-20250514".into(),
+                compactor: "openrouter/anthropic/claude-haiku-4.5-20250514".into(),
+                cortex: "openrouter/anthropic/claude-haiku-4.5-20250514".into(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "openai" => {
+            let channel: String = "openai/gpt-4.1".into();
+            let worker: String = "openai/gpt-4.1-mini".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "zhipu" => {
+            let channel: String = "zhipu/glm-4-plus".into();
+            let worker: String = "zhipu/glm-4-flash".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "groq" => {
+            let channel: String = "groq/llama-3.3-70b-versatile".into();
+            let worker: String = "groq/llama-3.3-70b-specdec".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "together" => {
+            let channel: String = "together/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo".into();
+            let worker: String = "together/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "fireworks" => {
+            let channel: String =
+                "fireworks/accounts/fireworks/models/llama-v3p3-70b-instruct".into();
+            let worker: String =
+                "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "deepseek" => {
+            let channel: String = "deepseek/deepseek-chat".into();
+            let worker: String = "deepseek/deepseek-chat".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::new(),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "xai" => {
+            let channel: String = "xai/grok-2-latest".into();
+            let worker: String = "xai/grok-2-latest".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::new(),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "mistral" => {
+            let channel: String = "mistral/mistral-large-latest".into();
+            let worker: String = "mistral/mistral-small-latest".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::from([(channel, vec![worker])]),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
+        "opencode-zen" => {
+            let channel: String = "opencode-zen/kimi-k2.5".into();
+            let worker: String = "opencode-zen/kimi-k2.5".into();
+            RoutingConfig {
+                channel: channel.clone(),
+                branch: channel.clone(),
+                worker: worker.clone(),
+                compactor: worker.clone(),
+                cortex: worker.clone(),
+                task_overrides: HashMap::from([("coding".into(), channel.clone())]),
+                fallbacks: HashMap::new(),
+                rate_limit_cooldown_secs: 60,
+                ..RoutingConfig::default()
+            }
+        }
         "nvidia" => RoutingConfig::for_model("nvidia/meta/llama-3.1-405b-instruct".into()),
-        "opencode-zen" => RoutingConfig::for_model("opencode-zen/kimi-k2.5".into()),
         "minimax" => RoutingConfig::for_model("minimax/MiniMax-M1-80k".into()),
         "moonshot" => RoutingConfig::for_model("moonshot/kimi-k2.5".into()),
         "zai-coding-plan" => RoutingConfig::for_model("zai-coding-plan/glm-5".into()),
+        // Unknown — use the standard defaults
         _ => RoutingConfig::default(),
     }
 }


### PR DESCRIPTION
# Summary                                                                                                                             
                                                                                                                                        
  - Add Claude Code OAuth token (sk-ant-oat*) support, enabling use of Anthropic subscription-based authentication alongside standard API keys
  - Introduce a new src/llm/anthropic/ module handling auth routing, tool name normalization, prompt caching, and request building
  - Add per-slot adaptive thinking effort configuration (auto/max/high/medium/low) for Claude 4.6 models
  - Add frontend UI for thinking effort when a 4.6 model is selected
<img width="328" height="172" alt="Screenshot 2026-02-18 at 16 38 09" src="https://github.com/user-attachments/assets/413a418c-43d8-47f1-ae2d-7aa2996a7ce7" />


 # Details
Inspired & Ported from PI-AI OAuth token authentication. 

Anthropic API keys prefixes are auto-detected and route differently depending on whether it stems from a `claude setup-token`

**Tool name normalization** - When using a `claude setup-token`, tool names are mapped to Claude Code canonical casing  on the way out, and reverse-mapped back to original names on responses.

  **Prompt caching** - System prompt blocks and the last tool definition get cache_control attached

  **Adaptive thinking** -  4.6-generation models (opus-4-6, sonnet-4-6) get `thinking: { type: "adaptive" }` with configurable effort per  routing slot. Opus defaults to max, others to high.

  Test plan
  - Run `claude setup-token` and use that as your API key for Anthropic.
  - Verify standard API key auth (sk-ant-api*) still works as before
  - Verify thinking effort dropdown only appears for 4.6 models in the admin UI
  - Run cargo test — new unit tests cover auth detection, cache control, tool normalization, and reverse mapping
  
  # Known issues
- Different thinking levels for the same model needs a refactor to pipe per route.