### PR TITLE
fix(config): support numeric telegram chat_id binding match

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -559,8 +559,13 @@ impl Binding {
             let message_chat = message
                 .metadata
                 .get("telegram_chat_id")
-                .and_then(|v| v.as_str());
-            if message_chat != Some(chat_id) {
+                .and_then(|value| {
+                    value
+                        .as_str()
+                        .map(std::borrow::ToOwned::to_owned)
+                        .or_else(|| value.as_i64().map(|id| id.to_string()))
+                });
+            if message_chat.as_deref() != Some(chat_id.as_str()) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Fix Telegram binding resolution to accept numeric `telegram_chat_id` metadata in addition to string values.
- Keep `chat_id` comparison stable by normalizing metadata to string before matching.
- Restores reliable one-chat-per-agent routing for Telegram bindings.

## Why
Telegram metadata writes `telegram_chat_id` as a JSON number, while binding config provides `chat_id` as a string. The previous matcher only read string metadata, so valid bindings could be skipped.

## Validation
- `cargo test --lib` (43 passed)

Fixes #33