### PR TITLE
fix: set skip_flag in ReplyTool to prevent double reply

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -121,6 +121,7 @@ pub async fn add_channel_tools(
         conversation_id,
         state.conversation_logger.clone(),
         state.channel_id.clone(),
+        skip_flag.clone(),
     )).await?;
     handle.add_tool(BranchTool::new(state.clone())).await?;
     handle.add_tool(SpawnWorkerTool::new(state.clone())).await?;


### PR DESCRIPTION
## Problem

When the LLM calls the `reply` tool, the response is sent immediately via `response_tx`. However, `handle_agent_result` in `channel.rs` also sends the final LLM text output as a fallback — resulting in the bot posting the same message twice to Discord.

The `skip_flag` already exists for this purpose (the `skip` tool sets it to suppress the fallback), but `ReplyTool` was never wiring into it.

## Fix

Add a `SkipFlag` field to `ReplyTool` and set it to `true` after a successful send. This signals `handle_agent_result` to skip the fallback, exactly as `SkipTool` does.

## Changes

- `src/tools/reply.rs` — add `skip_flag: SkipFlag` field, set it after sending
- `src/tools.rs` — pass `skip_flag.clone()` when constructing `ReplyTool`