### PR TITLE
fix: prevent panic in split_message on multibyte UTF-8 char boundaries

### DIFF
--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -636,10 +636,18 @@ fn split_message(text: &str, max_len: usize) -> Vec<String> {
             break;
         }
 
-        let split_at = remaining[..max_len]
+        let safe_max = {
+            let mut i = max_len.min(remaining.len());
+            while !remaining.is_char_boundary(i) {
+                i -= 1;
+            }
+            i
+        };
+
+        let split_at = remaining[..safe_max]
             .rfind('\n')
-            .or_else(|| remaining[..max_len].rfind(' '))
-            .unwrap_or(max_len);
+            .or_else(|| remaining[..safe_max].rfind(' '))
+            .unwrap_or(safe_max);
 
         chunks.push(remaining[..split_at].to_string());
         remaining = remaining[split_at..].trim_start();


### PR DESCRIPTION
## Summary

- `split_message` slices the message string at a fixed byte index (`max_len = 2000`), but multibyte UTF-8 characters (e.g. `ý`, `č`, `ě`) can span that boundary
- This causes a panic: `byte index 2000 is not a char boundary; it is inside 'ý'`
- The panic kills the tokio worker thread handling that channel's outbound messages, closing the internal mpsc channel — all subsequent messages to that channel silently fail with `channel closed`

## Fix

Before slicing, walk back from `max_len` to the nearest valid char boundary:

```rust
let safe_max = {
    let mut i = max_len.min(remaining.len());
    while !remaining.is_char_boundary(i) {
        i -= 1;
    }
    i
};
```

## Reproduction

Send a Discord message long enough to trigger chunking (>2000 bytes) that contains non-ASCII characters near the 2000-byte boundary. Bot panics and stops responding in that channel for the rest of its lifetime.