### PR TITLE
feat(slack): slash commands (Phase 3) + Block Kit interactions (Phase 2b)

### DIFF
--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -409,6 +409,10 @@ impl Channel {
                     crate::MessageContent::Media { text, attachments } => {
                         (text.clone().unwrap_or_default(), attachments.clone())
                     }
+                    // Render interactions as their Display form so the LLM sees plain text.
+                    crate::MessageContent::Interaction { .. } => {
+                        (message.content.to_string(), Vec::new())
+                    }
                 };
                 
                 self.state.conversation_logger.log_user_message(
@@ -569,6 +573,10 @@ impl Channel {
             crate::MessageContent::Text(text) => (text.clone(), Vec::new()),
             crate::MessageContent::Media { text, attachments } => {
                 (text.clone().unwrap_or_default(), attachments.clone())
+            }
+            // Render interactions as their Display form so the LLM sees plain text.
+            crate::MessageContent::Interaction { .. } => {
+                (message.content.to_string(), Vec::new())
             }
         };
 

--- a/src/api/bindings.rs
+++ b/src/api/bindings.rs
@@ -368,7 +368,18 @@ pub(super) async fn create_binding(
                         }
                     }
                 };
-                match crate::messaging::slack::SlackAdapter::new(&bot_token, &app_token, slack_perms) {
+                let slack_commands = new_config
+                    .messaging
+                    .slack
+                    .as_ref()
+                    .map(|s| s.commands.clone())
+                    .unwrap_or_default();
+                match crate::messaging::slack::SlackAdapter::new(
+                    &bot_token,
+                    &app_token,
+                    slack_perms,
+                    slack_commands,
+                ) {
                     Ok(adapter) => {
                         if let Err(error) = manager.register_and_start(adapter).await {
                             tracing::error!(%error, "failed to hot-start slack adapter");

--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -311,6 +311,7 @@ pub(super) async fn toggle_platform(
                                 &slack_config.bot_token,
                                 &slack_config.app_token,
                                 perms,
+                                slack_config.commands.clone(),
                             ) {
                                 Ok(adapter) => {
                                     if let Err(error) = manager.register_and_start(adapter).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,15 +611,12 @@ impl Binding {
         }
 
         if let Some(chat_id) = &self.chat_id {
-            let message_chat = message
-                .metadata
-                .get("telegram_chat_id")
-                .and_then(|value| {
-                    value
-                        .as_str()
-                        .map(std::borrow::ToOwned::to_owned)
-                        .or_else(|| value.as_i64().map(|id| id.to_string()))
-                });
+            let message_chat = message.metadata.get("telegram_chat_id").and_then(|value| {
+                value
+                    .as_str()
+                    .map(std::borrow::ToOwned::to_owned)
+                    .or_else(|| value.as_i64().map(|id| id.to_string()))
+            });
             if message_chat.as_deref() != Some(chat_id.as_str()) {
                 return false;
             }
@@ -666,6 +663,20 @@ pub struct DiscordConfig {
     pub allow_bot_messages: bool,
 }
 
+/// A single slash command definition for the Slack adapter.
+///
+/// Maps a Slack slash command (e.g. `/ask`) to a target agent.
+/// Commands not listed here are acknowledged but produce a "not configured" reply.
+#[derive(Debug, Clone)]
+pub struct SlackCommandConfig {
+    /// The slash command string exactly as Slack sends it, e.g. `"/ask"`.
+    pub command: String,
+    /// ID of the agent that should handle this command.
+    pub agent_id: String,
+    /// Short description shown in Slack's command autocomplete hint (optional).
+    pub description: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SlackConfig {
     pub enabled: bool,
@@ -673,6 +684,8 @@ pub struct SlackConfig {
     pub app_token: String,
     /// User IDs allowed to DM the bot. If empty, DMs are ignored entirely.
     pub dm_allowed_users: Vec<String>,
+    /// Slash command definitions. If empty, all slash commands are ignored.
+    pub commands: Vec<SlackCommandConfig>,
 }
 
 /// Hot-reloadable Discord permission filters.
@@ -1209,6 +1222,15 @@ struct TomlSlackConfig {
     app_token: Option<String>,
     #[serde(default)]
     dm_allowed_users: Vec<String>,
+    #[serde(default)]
+    commands: Vec<TomlSlackCommandConfig>,
+}
+
+#[derive(Deserialize)]
+struct TomlSlackCommandConfig {
+    command: String,
+    agent_id: String,
+    description: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -1915,6 +1937,15 @@ impl Config {
                     bot_token,
                     app_token,
                     dm_allowed_users: s.dm_allowed_users,
+                    commands: s
+                        .commands
+                        .into_iter()
+                        .map(|c| SlackCommandConfig {
+                            command: c.command,
+                            agent_id: c.agent_id,
+                            description: c.description,
+                        })
+                        .collect(),
                 })
             }),
             telegram: toml.messaging.telegram.and_then(|t| {
@@ -2459,6 +2490,7 @@ pub fn spawn_file_watcher(
                                     &slack_config.bot_token,
                                     &slack_config.app_token,
                                     perms,
+                                    slack_config.commands.clone(),
                                 ) {
                                     Ok(adapter) => {
                                         if let Err(error) = manager.register_and_start(adapter).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1263,6 +1263,7 @@ async fn initialize_agents(
                 slack_permissions
                     .clone()
                     .expect("slack permissions initialized when slack is enabled"),
+                slack_config.commands.clone(),
             ) {
                 Ok(adapter) => { new_messaging_manager.register(adapter).await; }
                 Err(error) => { tracing::error!(%error, "failed to build slack adapter"); }


### PR DESCRIPTION
Completes the Slack enhancement plan from `docs/PRD-slack-enhancements.md` (shipped with PR #58).

Depends on #58 (or rebases cleanly if that merges first).

---

## Phase 2b — Block Kit interactive components (inbound)

### New `MessageContent::Interaction` variant (`src/lib.rs`)

Carries the result of a button click or select menu action:

- `action_id`, `block_id` — identifies which block element was actioned
- `value`, `label` — submitted value and human-readable label
- `message_ts` — ts of the original message, for thread correlation

**Slack-only inbound** — Discord, Telegram, and Webhook never produce this variant. The `Display` impl renders it as `[interaction: action_id → value]` so every existing text-processing code path in `channel.rs` receives readable plain text with zero adaptation. Exhaustive match enforcement means no adapter was silently missed.

### `interaction_callback` wired in Socket Mode

- `handle_interaction_event()` registered via `.with_interaction_events()`
- Only `SlackInteractionEvent::BlockActions` is converted to `InboundMessage`; all other types (view submission, shortcuts, etc.) are acknowledged and logged at `debug` — no silent failures
- Each action in the payload becomes a separate `InboundMessage` so multi-action payloads are handled correctly
- `message_ts` threaded through both `slack_message_ts` and `slack_thread_ts` metadata so the agent replies in the correct thread
- `trigger_id` used as message ID (Slack guarantees uniqueness per interaction)

---

## Phase 3 — Slash commands

### `SlackCommandConfig` (`src/config.rs`)

New config type, added as `Vec<SlackCommandConfig>` on `SlackConfig` only. TOML syntax:

```toml
[[messaging.slack.commands]]
command = "/ask"
agent_id = "main"
description = "Ask the agent a question"

[[messaging.slack.commands]]
command = "/task"
agent_id = "main"
description = "Kick off a background task"
```

**Fully backwards compatible** — field defaults to empty vec. Existing configs need no changes. Discord, Telegram, and Webhook configs are untouched.

### `command_callback` wired in Socket Mode

- `handle_command_event()` registered via `.with_command_events()`
- **3-second ack requirement met**: returns immediately; the real reply arrives via the normal `respond()` path
- Commands not in config get an ephemeral "not configured" reply — users get feedback instead of silence
- Command forwarded as `MessageContent::Text("/ask <args>")` — familiar format for the agent
- `slack_command` and `slack_command_agent_id` metadata keys allow per-command agent routing without requiring a separate binding entry per command

### `SlackAdapter::new()` — new `commands` parameter

All four call sites updated (`src/main.rs`, `src/api/messaging.rs`, `src/api/bindings.rs`, `src/config.rs`). Commands converted to `Arc<HashMap<String, String>>` once at construction; read-only from callbacks.

---

## What is not changed

- Discord, Telegram, Webhook adapters — zero modifications
- `OutboundResponse` enum — unchanged (interaction replies use existing `Text`/`Ephemeral`/`RichMessage` variants)
- Binding resolution logic — unchanged; `slack_command_agent_id` metadata is advisory, existing bindings continue to work
- All non-Slack `MessageContent` match sites — only two arms added, no existing arms modified

## Test results

- `cargo check` (lib + bin) — clean
- `cargo test --lib` — 43/43 pass