### PR TITLE
Add GitHub CLI to default docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libsqlite3-0 \
     curl \
+    gh \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/bin/spacebot /usr/local/bin/spacebot


### PR DESCRIPTION
This pr does what it says.

# Reasoning
Quite likely that people want to use this to code, esp once opencode is a little more integrated, this gives the models access to the github cli for auth, repo access, etc (it can be a little tricky to get the bot to actually auth with github but it is doable)