### PR TITLE
chore: optimize release profile to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,3 +145,8 @@ unimplemented = "forbid"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[profile.release]
+lto = "thin"
+strip = true
+


### PR DESCRIPTION
Adds `strip = true` and `lto = "thin"` to the release profile to drastically reduce the compiled binary size. 

This prevents out-of-storage / `No space left on device` errors during container builds (e.g. copying the release binary), especially since the project contains heavy dependencies like LanceDB and DataFusion.