### PR TITLE
feat(slack): cache user identities and resolve channel names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ interface/dist/
 
 .idea
 list/
+agents/

--- a/docs/content/docs/(messaging)/slack-setup.mdx
+++ b/docs/content/docs/(messaging)/slack-setup.mdx
@@ -37,9 +37,13 @@ In your Slack app settings, go to **OAuth & Permissions** → scroll to **Bot To
 | `reactions:write` | Thinking indicator |
 | `reactions:read` | Read reactions |
 | `channels:history` | Read message history in public channels |
+| `channels:read` | Read public channel metadata (for channel names) |
 | `groups:history` | Same, for private channels |
+| `groups:read` | Read private channel metadata (for channel names) |
 | `im:history` | Same, for DMs |
+| `im:read` | Read DM metadata (for conversation names) |
 | `mpim:history` | Same, for group DMs |
+| `mpim:read` | Read group DM metadata (for conversation names) |
 | `users:read` | Resolve display names |
 | `files:write` | Upload file attachments |
 | `files:read` | Read file metadata |

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -28,6 +28,7 @@ export interface InboundMessageEvent {
 	type: "inbound_message";
 	agent_id: string;
 	channel_id: string;
+	sender_name?: string | null;
 	sender_id: string;
 	text: string;
 }

--- a/interface/src/hooks/useChannelLiveState.ts
+++ b/interface/src/hooks/useChannelLiveState.ts
@@ -189,7 +189,7 @@ export function useChannelLiveState(channels: ChannelInfo[]) {
 			type: "message",
 			id: `in-${Date.now()}-${crypto.randomUUID()}`,
 			role: "user",
-			sender_name: event.sender_id,
+			sender_name: event.sender_name ?? event.sender_id,
 			sender_id: event.sender_id,
 			content: event.text,
 			created_at: new Date().toISOString(),

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -99,6 +99,7 @@ pub enum ApiEvent {
     InboundMessage {
         agent_id: String,
         channel_id: String,
+        sender_name: Option<String>,
         sender_id: String,
         text: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -881,9 +881,17 @@ async fn run(
                     *active.latest_message.write().await = message.clone();
 
                     // Emit inbound message to SSE clients
+                    let sender_name = message.formatted_author.clone().or_else(|| {
+                        message
+                            .metadata
+                            .get("sender_display_name")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    });
                     api_state.event_tx.send(spacebot::api::ApiEvent::InboundMessage {
                         agent_id: agent_id.to_string(),
                         channel_id: conversation_id.clone(),
+                        sender_name,
                         sender_id: message.sender_id.clone(),
                         text: message.content.to_string(),
                     }).ok();

--- a/src/tools/reply.rs
+++ b/src/tools/reply.rs
@@ -108,12 +108,11 @@ async fn convert_mentions(
         if let (Some(name), Some(id), Some(meta_str)) =
             (&msg.sender_name, &msg.sender_id, &msg.metadata)
         {
-            // Parse metadata JSON to get clean display name (without mention syntax)
+            // Parse metadata JSON to get clean display name
             if let Ok(meta) = serde_json::from_str::<HashMap<String, serde_json::Value>>(meta_str) {
                 if let Some(display_name) = meta.get("sender_display_name").and_then(|v| v.as_str())
                 {
-                    // For Slack (from PR #43), sender_display_name includes mention: "Name (<@ID>)"
-                    // Extract just the name part
+                    // Older rows may include mention syntax "Name (<@ID>)"; strip it.
                     let clean_name = display_name.split(" (<@").next().unwrap_or(display_name);
                     name_to_id.insert(clean_name.to_string(), id.clone());
                 }


### PR DESCRIPTION
## Summary

Fresh implementation of the changes from #62 (now stale/conflicting), rebased on current main.

- Add in-memory caches for user identities and channel names on `SlackAdapterState` to avoid repeated `users.info` and `conversations.info` API calls per message
- Resolve channel names via `conversations.info` and populate `slack_channel_name` in metadata so the dashboard shows real names with `#` prefix (DMs fall back to `dm-{sender}`)
- Propagate `sender_name` through `ApiEvent::InboundMessage` to the frontend SSE stream so the dashboard shows real usernames on live messages
- Clean up `formatted_author` / `sender_display_name` to use plain display names instead of the `Name (<@ID>)` format
- Add `channels:read`, `groups:read`, `im:read`, `mpim:read` to required Slack scopes in docs

Closes #62