### PR TITLE
fix(slack): deliver file_share messages and authenticate url_private downloads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,11 @@ pub struct Attachment {
     pub mime_type: String,
     pub url: String,
     pub size_bytes: Option<u64>,
+    /// Bearer token required to download this attachment.
+    /// Slack's `url_private` URLs require `Authorization: Bearer <bot_token>`;
+    /// without it the request returns 403. Other platforms leave this `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub download_token: Option<String>,
 }
 
 /// Outbound response to messaging platforms.

--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -749,6 +749,7 @@ fn extract_content(message: &Message) -> MessageContent {
                 mime_type: attachment.content_type.clone().unwrap_or_default(),
                 url: attachment.url.clone(),
                 size_bytes: Some(attachment.size as u64),
+                download_token: None, // Discord CDN URLs are public, no auth needed
             })
             .collect();
 

--- a/src/messaging/telegram.rs
+++ b/src/messaging/telegram.rs
@@ -577,6 +577,7 @@ fn extract_attachments(message: &teloxide::types::Message) -> Vec<Attachment> {
                     mime_type: "image/jpeg".into(),
                     url: largest.file.id.to_string(),
                     size_bytes: Some(largest.file.size as u64),
+                    download_token: None,
                 });
             }
         }
@@ -595,6 +596,7 @@ fn extract_attachments(message: &teloxide::types::Message) -> Vec<Attachment> {
                     .unwrap_or_else(|| "application/octet-stream".into()),
                 url: doc.document.file.id.to_string(),
                 size_bytes: Some(doc.document.file.size as u64),
+                download_token: None,
             });
         }
         MediaKind::Video(video) => {
@@ -612,6 +614,7 @@ fn extract_attachments(message: &teloxide::types::Message) -> Vec<Attachment> {
                     .unwrap_or_else(|| "video/mp4".into()),
                 url: video.video.file.id.to_string(),
                 size_bytes: Some(video.video.file.size as u64),
+                download_token: None,
             });
         }
         MediaKind::Voice(voice) => {
@@ -625,6 +628,7 @@ fn extract_attachments(message: &teloxide::types::Message) -> Vec<Attachment> {
                     .unwrap_or_else(|| "audio/ogg".into()),
                 url: voice.voice.file.id.to_string(),
                 size_bytes: Some(voice.voice.file.size as u64),
+                download_token: None,
             });
         }
         MediaKind::Audio(audio) => {
@@ -642,6 +646,7 @@ fn extract_attachments(message: &teloxide::types::Message) -> Vec<Attachment> {
                     .unwrap_or_else(|| "audio/mpeg".into()),
                 url: audio.audio.file.id.to_string(),
                 size_bytes: Some(audio.audio.file.size as u64),
+                download_token: None,
             });
         }
         _ => {}


### PR DESCRIPTION
## Problem

Two separate bugs caused agents to completely ignore files and images shared in Slack.

### Bug 1 — Messages silently dropped (root cause of "agent doesn't reply at all")

`handle_message_event` had a blanket early return on any message with a `subtype` field:

```rust
// Skip message edits / deletes / bot_message subtypes
if msg_event.subtype.is_some() {
    return Ok(());
}
```

Slack sets `subtype: "file_share"` on every message that contains an uploaded file or image. So the message never reached `extract_message_content`, and the agent never saw it — no reply, no error, complete silence.

The fix keeps the intent (skip edits/deletes/bot noise) but explicitly allows `FileShare` through using a match on `SlackMessageEventType`.

### Bug 2 — Download returns 403 (would have caused corrupt LLM input even if Bug 1 were fixed)

Slack's `url_private` URLs require an `Authorization: Bearer <bot_token>` header. The download path called `http.get(url).send()` with no auth header — Slack returns a 403 HTML page. The code then base64-encoded that HTML and sent it to the LLM as image data.

**Fix:**
- Added `download_token: Option<String>` to the shared `Attachment` struct (`src/lib.rs`). Field is `#[serde(default, skip_serializing_if = "Option::is_none")]` so it's backwards-compatible.
- Slack adapter populates it with the bot token when building attachments from `url_private`.
- All three download functions (`download_image_attachment`, `download_audio_attachment`, `download_text_attachment`) pass it as a bearer header when present.
- Added HTTP status check before reading bytes — bad responses now produce a clear `warn!` log and a `[Failed to download image: ... (HTTP 403)]` placeholder instead of silently corrupt data.

Discord and Telegram set `download_token: None` — Discord CDN URLs are public, Telegram uses file IDs resolved through its own API.

## Testing
- `cargo check` clean
- `cargo test --lib` 58/58 pass