### PR TITLE
fix: register NVIDIA provider and base URL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,7 @@ const MOONSHOT_PROVIDER_BASE_URL: &str = "https://api.moonshot.ai";
 
 const ZHIPU_PROVIDER_BASE_URL: &str = "https://api.z.ai/api/paas/v4";
 const ZAI_CODING_PLAN_BASE_URL: &str = "https://api.z.ai/api/coding/paas/v4";
+const NVIDIA_PROVIDER_BASE_URL: &str = "https://integrate.api.nvidia.com";
 
 /// Defaults inherited by all agents. Individual agents can override any field.
 #[derive(Debug, Clone)]
@@ -1690,6 +1691,17 @@ impl Config {
                 });
         }
 
+        if let Some(nvidia_key) = llm.nvidia_key.clone() {
+            llm.providers
+                .entry("nvidia".to_string())
+                .or_insert_with(|| ProviderConfig {
+                    api_type: ApiType::OpenAiCompletions,
+                    base_url: NVIDIA_PROVIDER_BASE_URL.to_string(),
+                    api_key: nvidia_key,
+                    name: None,
+                });
+        }
+
         // Note: We allow boot without provider keys now. System starts in setup mode.
         // Agents are initialized later when keys are added via API.
 
@@ -1987,6 +1999,17 @@ impl Config {
                     api_type: ApiType::OpenAiCompletions,
                     base_url: MOONSHOT_PROVIDER_BASE_URL.to_string(),
                     api_key: moonshot_key,
+                    name: None,
+                });
+        }
+
+        if let Some(nvidia_key) = llm.nvidia_key.clone() {
+            llm.providers
+                .entry("nvidia".to_string())
+                .or_insert_with(|| ProviderConfig {
+                    api_type: ApiType::OpenAiCompletions,
+                    base_url: NVIDIA_PROVIDER_BASE_URL.to_string(),
+                    api_key: nvidia_key,
                     name: None,
                 });
         }

--- a/src/llm/providers.rs
+++ b/src/llm/providers.rs
@@ -33,5 +33,9 @@ pub async fn init_providers(config: &LlmConfig) -> Result<()> {
         tracing::info!("Moonshot AI provider configured");
     }
 
+    if config.nvidia_key.is_some() {
+        tracing::info!("NVIDIA provider configured");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes the "Unknown provider: nvidia" error when adding NVIDIA API keys via the web UI or config file. The NVIDIA provider was configured in the API layer but wasn't being registered in the `LlmConfig.providers` HashMap during configuration loading.

Fixes #72

## Changes

- **Added NVIDIA base URL constant** (`src/config.rs`):
  - Added `NVIDIA_PROVIDER_BASE_URL` constant set to `https://integrate.api.nvidia.com`

- **Added NVIDIA provider registration** (`src/config.rs`):
  - Registered NVIDIA provider in `from_env()` function (environment variable loading)
  - Registered NVIDIA provider in `from_toml()` function (TOML config file loading)
  - Both use `ApiType::OpenAiCompletions` API type and the NVIDIA base URL

- **Added NVIDIA provider logging** (`src/llm/providers.rs`):
  - Added startup log message when NVIDIA provider is configured (consistent with other providers)

## Testing

Tested and verified working with:
- Model: `nvidia/stepfun-ai/step-3.5-flash`
- API endpoint: `https://integrate.api.nvidia.com/v1/chat/completions`
- Successfully added NVIDIA API key via web UI
- Successfully made completion requests through the channel agent

The provider now correctly registers when:
- Adding via web UI settings page
- Setting `NVIDIA_API_KEY` environment variable
- Adding `nvidia_key` to `config.toml`