### PR TITLE
Add CI workflow for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: Build & Test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo check
+        run: cargo check --all-targets
+
+      - name: cargo test (lib)
+        run: cargo test --lib


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on PRs to main and pushes to main.

- `cargo check --all-targets` — compilation check
- `cargo test --lib` — unit tests (skips integration tests that need running databases)

Uses rust-cache for faster builds. Clippy and fmt checks are left out for now — the codebase has ~22 warnings and 60 unformatted files that would need a separate cleanup PR.