### PR TITLE
Fix Fireworks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1932,7 +1932,8 @@ impl Config {
                     api_type: ApiType::OpenAiCompletions,
                     base_url: FIREWORKS_PROVIDER_BASE_URL.to_string(),
                     api_key: fireworks_key,
-                                  });
+                    name: None,
+                });
         }
 
         if let Some(gemini_key) = llm.gemini_key.clone() {
@@ -2278,6 +2279,7 @@ impl Config {
                     api_type: ApiType::OpenAiCompletions,
                     base_url: FIREWORKS_PROVIDER_BASE_URL.to_string(),
                     api_key: fireworks_key,
+                    name: None,
                 });
         }
 


### PR DESCRIPTION
Fixes #90

UNTESTED AS I DONT HAVE A API KEY 

but this fix is just like the NVIDIA fix that worked fine


- **Added Fireworks base URL constant** (`src/config.rs`):
  - Added `FIREWORKS_PROVIDER_BASE_URL` constant set to `https://api.fireworks.ai/inference`
- **Added Fireworks provider registration** (`src/config.rs`):
  - Registered Fireworks provider in `load_from_env()` function (environment variable loading)
  - Registered Fireworks provider in `from_toml()` function (TOML config file loading)
  - Both use `ApiType::OpenAiCompletions` API type and the Fireworks base URL