### PR TITLE
feat(telemetry): complete metrics instrumentation with cost tracking and per-agent context

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1,6 +1,6 @@
 # Metrics Reference
 
-Comprehensive reference for Spacebot's Prometheus metrics. For quick-start setup, see `docs/metrics.md`.
+Comprehensive reference for Spacebot's Prometheus metrics. For quick-start setup, see `docs/metrics.md`. For the published docs, see the metrics page on [docs.spacebot.sh](https://docs.spacebot.sh).
 
 ## Feature Gate
 
@@ -27,9 +27,7 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 | Instrumented in | `src/llm/model.rs` — `SpacebotModel::completion()` |
 | Description | Total LLM completion requests (one per `completion()` call, including retries and fallbacks). |
 
-**Cardinality:** `agents × models × tiers`. Currently `agent_id` and `tier` are hardcoded to `"unknown"` because `SpacebotModel` doesn't carry process context. Effective cardinality is just the number of distinct model names (typically 5–15). Once agent context is threaded through, expect `agents(1–5) × models(5–15) × tiers(5)` = 25–375 series.
-
-**Known limitation:** Labels `agent_id` and `tier` are always `"unknown"`. The `SpacebotHook` has these values but can't be used here without structural changes.
+**Cardinality:** `agents × models × tiers`. With agent context wired, expect `agents(1–5) × models(5–15) × tiers(5)` = 25–375 series.
 
 #### `spacebot_tool_calls_total`
 
@@ -40,7 +38,7 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 | Instrumented in | `src/hooks/spacebot.rs` — `SpacebotHook::on_tool_result()` |
 | Description | Total tool calls executed across all processes. Incremented after each tool call completes (success or failure). |
 
-**Cardinality:** `agents × tools`. With 1–5 agents and ~20 tool names, expect 20–100 series. Tool names are a bounded set defined in `src/tools/`.
+**Cardinality:** `agents × tools`. With 1–5 agents and ~20 tool names, expect 20–100 series.
 
 #### `spacebot_memory_reads_total`
 
@@ -62,6 +60,52 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 
 **Cardinality:** 1 series.
 
+#### `spacebot_llm_tokens_total`
+
+| Field | Value |
+|-------|-------|
+| Type | `IntCounterVec` |
+| Labels | `agent_id`, `model`, `tier`, `direction` |
+| Instrumented in | `src/llm/model.rs` — `SpacebotModel::completion()` |
+| Description | Total LLM tokens consumed. `direction` is one of `input`, `output`, or `cached_input`. |
+
+**Cardinality:** `agents × models × tiers × 3`. Expect 75–1125 series.
+
+#### `spacebot_llm_estimated_cost_dollars`
+
+| Field | Value |
+|-------|-------|
+| Type | `CounterVec` (f64) |
+| Labels | `agent_id`, `model`, `tier` |
+| Instrumented in | `src/llm/model.rs` — `SpacebotModel::completion()` |
+| Description | Estimated LLM cost in USD. Uses a built-in pricing table (`src/llm/pricing.rs`). |
+
+**Cardinality:** Same as `spacebot_llm_requests_total`.
+
+**Note:** Costs are best-effort estimates. The pricing table covers major models (Claude 4/3.5/3, GPT-4o, o-series, Gemini, DeepSeek) with a conservative fallback for unknown models ($3/M input, $15/M output).
+
+#### `spacebot_process_errors_total`
+
+| Field | Value |
+|-------|-------|
+| Type | `IntCounterVec` |
+| Labels | `agent_id`, `process_type`, `error_type` |
+| Instrumented in | `src/llm/model.rs` — `SpacebotModel::completion()` error paths |
+| Description | Process errors by type. `error_type` classifies the failure (timeout, rate_limit, auth, server, provider, unknown). |
+
+**Cardinality:** `agents × process_types × error_types`. Expect 15–75 series.
+
+#### `spacebot_memory_updates_total`
+
+| Field | Value |
+|-------|-------|
+| Type | `IntCounterVec` |
+| Labels | `agent_id`, `operation` |
+| Instrumented in | `src/memory/store.rs` (save/delete), `src/tools/memory_save.rs`, `src/tools/memory_delete.rs` (forget) |
+| Description | Memory mutation operations. `operation` is one of `save`, `delete`, or `forget`. |
+
+**Cardinality:** `agents × operations(3)`. Expect 3–15 series.
+
 ### Histograms
 
 #### `spacebot_llm_request_duration_seconds`
@@ -70,15 +114,11 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 |-------|-------|
 | Type | `HistogramVec` |
 | Labels | `agent_id`, `model`, `tier` |
-| Buckets | 0.1, 0.25, 0.5, 1, 2.5, 5, 10 |
+| Buckets | 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30, 60, 120 |
 | Instrumented in | `src/llm/model.rs` — `SpacebotModel::completion()` |
 | Description | End-to-end LLM request duration in seconds. Includes retry loops and fallback chain traversal. |
 
 **Cardinality:** Same as `spacebot_llm_requests_total` (per-bucket overhead is fixed, not per-series).
-
-**Known limitation:** Buckets max out at 10s. LLM requests with retries and fallbacks routinely exceed 10s (15–60s is common). Everything above 10s collapses into the +Inf bucket, losing resolution. A future fix should extend buckets to cover `[..., 15, 30, 60, 120]`.
-
-**What the timer measures:** The timer wraps the entire `completion()` method body, including all retry attempts on the primary model and the full fallback chain. This measures user-perceived latency, not individual provider call latency.
 
 #### `spacebot_tool_call_duration_seconds`
 
@@ -91,7 +131,19 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 
 **Cardinality:** 1 series.
 
-**Implementation note:** Duration is tracked via a `LazyLock<Mutex<HashMap<String, Instant>>>` static keyed by Rig's internal call ID. The timer starts in `on_tool_call` and is consumed in `on_tool_result`. If a tool call starts but the agent terminates before `on_tool_result` fires (e.g. leak detection terminates the agent), the timer entry remains in the map. These orphaned entries are small (String + Instant) and bounded by concurrent tool calls, so this is not a practical concern.
+**Implementation note:** Duration is tracked via a `LazyLock<Mutex<HashMap<String, Instant>>>` static keyed by Rig's internal call ID. If a tool call starts but the agent terminates before `on_tool_result` fires (e.g. leak detection), the timer entry remains — bounded by concurrent tool calls, not a practical concern.
+
+#### `spacebot_worker_duration_seconds`
+
+| Field | Value |
+|-------|-------|
+| Type | `HistogramVec` |
+| Labels | `agent_id`, `worker_type` |
+| Buckets | 1, 5, 10, 30, 60, 120, 300, 600, 1800 |
+| Instrumented in | `src/agent/channel.rs` — `spawn_worker_task()` |
+| Description | Worker lifetime duration in seconds from spawn to completion. |
+
+**Cardinality:** `agents × worker_types`. Currently `worker_type` is `"builtin"` — expect 1–5 series.
 
 ### Gauges
 
@@ -102,9 +154,9 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 | Type | `IntGaugeVec` |
 | Labels | `agent_id` |
 | Instrumented in | `src/agent/channel.rs` — `spawn_worker_task()` |
-| Description | Currently active workers. Incremented when a worker task is spawned, decremented when it completes (success or failure). Covers both builtin Rig workers and OpenCode workers. |
+| Description | Currently active workers. Incremented when a worker task is spawned, decremented when it completes. |
 
-**Cardinality:** Number of agents (typically 1–5).
+**Cardinality:** Number of agents (1–5).
 
 #### `spacebot_memory_entry_count`
 
@@ -112,30 +164,45 @@ All metrics are prefixed with `spacebot_`. The registry uses a private `promethe
 |-------|-------|
 | Type | `IntGaugeVec` |
 | Labels | `agent_id` |
-| Instrumented in | **Not instrumented.** Defined in registry but not wired to any call site. |
-| Description | Intended to track total memory entries per agent. |
+| Instrumented in | `src/memory/store.rs` — `save()` (inc) and `delete()` (dec) |
+| Description | Approximate memory entry count per agent. Tracks net saves minus deletes — starts at 0 on process start, not the actual database count. |
 
-**Cardinality:** Number of agents (typically 1–5). Currently always 0.
+**Cardinality:** Number of agents (1–5).
 
-**Status:** Requires periodic store queries or integration into `MemoryStore::save()` / `MemoryStore::delete()` to maintain an accurate count. Not blocked for merge — the metric is registered but idle.
+**Note:** This gauge tracks deltas from process start, not the absolute database count. On restart it resets to 0. For the true count, query the database directly.
+
+#### `spacebot_active_branches`
+
+| Field | Value |
+|-------|-------|
+| Type | `IntGaugeVec` |
+| Labels | `agent_id` |
+| Instrumented in | `src/agent/channel.rs` — branch spawn (inc) and completion (dec) |
+| Description | Currently active branches per agent. |
+
+**Cardinality:** Number of agents (1–5).
 
 ## Total Cardinality
 
-With the current instrumentation (hardcoded `"unknown"` labels on LLM metrics):
-
 | Metric | Series estimate |
 |--------|-----------------|
-| `llm_requests_total` | ~10 (distinct models) |
-| `tool_calls_total` | ~20–100 (agents × tools) |
+| `llm_requests_total` | ~25–375 |
+| `llm_tokens_total` | ~75–1125 |
+| `llm_estimated_cost_dollars` | ~25–375 |
+| `tool_calls_total` | ~20–100 |
 | `memory_reads_total` | 1 |
 | `memory_writes_total` | 1 |
-| `llm_request_duration_seconds` | ~10 (distinct models) |
+| `llm_request_duration_seconds` | ~25–375 |
 | `tool_call_duration_seconds` | 1 |
-| `active_workers` | ~1–5 (agents) |
-| `memory_entry_count` | 0 (not instrumented) |
-| **Total** | **~45–130** |
+| `worker_duration_seconds` | ~1–5 |
+| `active_workers` | ~1–5 |
+| `active_branches` | ~1–5 |
+| `memory_entry_count` | ~1–5 |
+| `process_errors_total` | ~15–75 |
+| `memory_updates_total` | ~3–15 |
+| **Total** | **~195–2465** |
 
-This is well within safe operating range for any Prometheus deployment.
+Well within safe operating range for any Prometheus deployment.
 
 ## Feature Gate Consistency
 
@@ -147,9 +214,11 @@ Every instrumentation call site uses `#[cfg(feature = "metrics")]` at the statem
 | `src/main.rs` | `#[cfg(feature = "metrics")] let _metrics_handle = ...` |
 | `src/llm/model.rs` | `#[cfg(feature = "metrics")] let start` + `#[cfg(feature = "metrics")] { ... }` |
 | `src/hooks/spacebot.rs` | `#[cfg(feature = "metrics")] static TOOL_CALL_TIMERS` + 2 blocks |
-| `src/tools/memory_save.rs` | `#[cfg(feature = "metrics")] crate::telemetry::Metrics::global()...` |
+| `src/tools/memory_save.rs` | `#[cfg(feature = "metrics")] { ... }` |
 | `src/tools/memory_recall.rs` | `#[cfg(feature = "metrics")] crate::telemetry::Metrics::global()...` |
-| `src/agent/channel.rs` | `#[cfg(feature = "metrics")] ...` (×2, inc + dec) |
+| `src/tools/memory_delete.rs` | `#[cfg(feature = "metrics")] crate::telemetry::Metrics::global()...` |
+| `src/memory/store.rs` | `#[cfg(feature = "metrics")] if _result...` + `#[cfg(feature = "metrics")] { ... }` |
+| `src/agent/channel.rs` | `#[cfg(feature = "metrics")]` (×4, branches + workers) |
 | `Cargo.toml` | `prometheus = { version = "0.13", optional = true }`, `metrics = ["dep:prometheus"]` |
 
 All consistent. No path references `crate::telemetry` without a `cfg` gate.

--- a/docs/content/docs/(deployment)/meta.json
+++ b/docs/content/docs/(deployment)/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Deployment",
-  "pages": ["hosted", "roadmap"]
+  "pages": ["hosted", "metrics", "roadmap"]
 }

--- a/docs/content/docs/(deployment)/metrics.mdx
+++ b/docs/content/docs/(deployment)/metrics.mdx
@@ -1,0 +1,155 @@
+---
+title: Metrics
+description: Prometheus-compatible metrics for monitoring Spacebot's LLM usage, costs, and agent activity.
+---
+
+# Metrics
+
+Spacebot exposes Prometheus-compatible metrics for monitoring LLM costs, token usage, agent activity, and memory operations. All telemetry code is behind the `metrics` cargo feature flag — without it, every instrumentation block compiles out to nothing.
+
+## Building with Metrics
+
+```bash
+cargo build --release --features metrics
+```
+
+## Configuration
+
+Add a `[metrics]` block to your `spacebot.toml`:
+
+```toml
+[metrics]
+enabled = true
+port = 9090
+bind = "0.0.0.0"
+```
+
+| Key       | Default       | Description                          |
+| --------- | ------------- | ------------------------------------ |
+| `enabled` | `false`       | Enable the /metrics HTTP endpoint    |
+| `port`    | `9090`        | Port for the metrics server          |
+| `bind`    | `"0.0.0.0"`  | Address to bind the metrics server   |
+
+The metrics server runs as a separate tokio task alongside the main API server and shuts down gracefully with the rest of the process.
+
+## Endpoints
+
+| Path       | Description                                |
+| ---------- | ------------------------------------------ |
+| `/metrics` | Prometheus text exposition format (0.0.4)  |
+| `/health`  | Returns 200 OK (for liveness probes)       |
+
+## Exposed Metrics
+
+All metrics are prefixed with `spacebot_`.
+
+### LLM Metrics
+
+These metrics track every LLM completion request, including token counts and estimated costs.
+
+| Metric | Type | Labels | Description |
+| ------ | ---- | ------ | ----------- |
+| `spacebot_llm_requests_total` | Counter | `agent_id`, `model`, `tier` | Total LLM completion requests |
+| `spacebot_llm_request_duration_seconds` | Histogram | `agent_id`, `model`, `tier` | End-to-end LLM request duration |
+| `spacebot_llm_tokens_total` | Counter | `agent_id`, `model`, `tier`, `direction` | Token counts (`direction`: input, output, cached_input) |
+| `spacebot_llm_estimated_cost_dollars` | Counter | `agent_id`, `model`, `tier` | Estimated cost in USD |
+
+The `tier` label corresponds to the process type: `channel`, `branch`, `worker`, `compactor`, or `cortex`.
+
+The `direction` label on token counts distinguishes input tokens, output (completion) tokens, and cached input tokens. Cached tokens are billed at a lower rate by most providers.
+
+**Cost estimation** uses a built-in pricing table covering Claude, GPT-4o, o-series, Gemini, and DeepSeek models. Unknown models use a conservative fallback rate. Costs are best-effort estimates — exact billing depends on your provider agreement.
+
+### Tool Metrics
+
+| Metric | Type | Labels | Description |
+| ------ | ---- | ------ | ----------- |
+| `spacebot_tool_calls_total` | Counter | `agent_id`, `tool_name` | Total tool calls executed |
+| `spacebot_tool_call_duration_seconds` | Histogram | — | Tool call execution duration |
+
+### Agent & Worker Metrics
+
+| Metric | Type | Labels | Description |
+| ------ | ---- | ------ | ----------- |
+| `spacebot_active_workers` | Gauge | `agent_id` | Currently active workers |
+| `spacebot_active_branches` | Gauge | `agent_id` | Currently active branches |
+| `spacebot_worker_duration_seconds` | Histogram | `agent_id`, `worker_type` | Worker lifetime duration |
+| `spacebot_process_errors_total` | Counter | `agent_id`, `process_type`, `error_type` | Process errors by type |
+
+### Memory Metrics
+
+| Metric | Type | Labels | Description |
+| ------ | ---- | ------ | ----------- |
+| `spacebot_memory_reads_total` | Counter | — | Total memory recall operations |
+| `spacebot_memory_writes_total` | Counter | — | Total memory save operations |
+| `spacebot_memory_entry_count` | Gauge | `agent_id` | Total memory entries per agent |
+| `spacebot_memory_updates_total` | Counter | `agent_id`, `operation` | Memory mutations (`operation`: save, update, delete, forget) |
+
+## Cost Tracking
+
+Token usage and estimated costs are tracked per-request. To see total estimated spend:
+
+```promql
+sum(spacebot_llm_estimated_cost_dollars) by (agent_id)
+```
+
+To see spend rate over the last hour:
+
+```promql
+sum(rate(spacebot_llm_estimated_cost_dollars[1h])) by (agent_id, model) * 3600
+```
+
+To see token throughput:
+
+```promql
+sum(rate(spacebot_llm_tokens_total[5m])) by (direction)
+```
+
+## Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: spacebot
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["localhost:9090"]
+```
+
+## Docker
+
+Expose the metrics port alongside the API port:
+
+```bash
+docker run -d \
+  --name spacebot \
+  -e ANTHROPIC_API_KEY="sk-ant-..." \
+  -v spacebot-data:/data \
+  -p 19898:19898 \
+  -p 9090:9090 \
+  ghcr.io/spacedriveapp/spacebot:slim
+```
+
+The Docker image must be built with `--features metrics` for this to work. The default images do not include metrics support.
+
+## Histogram Buckets
+
+| Metric | Buckets (seconds) |
+| ------ | ----------------- |
+| `llm_request_duration_seconds` | 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30, 60, 120 |
+| `tool_call_duration_seconds` | 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30 |
+| `worker_duration_seconds` | 1, 5, 10, 30, 60, 120, 300, 600, 1800 |
+
+## Cardinality
+
+| Metric | Estimated series |
+| ------ | --------------- |
+| `llm_requests_total` | agents × models × tiers (~25–375) |
+| `llm_tokens_total` | agents × models × tiers × 3 directions (~75–1125) |
+| `llm_estimated_cost_dollars` | agents × models × tiers (~25–375) |
+| `tool_calls_total` | agents × tools (~20–100) |
+| `active_workers` / `active_branches` | agents (~1–5 each) |
+| `process_errors_total` | agents × process_types × error_types (~15–75) |
+| `memory_*` | 1–10 per metric |
+| **Total** | **~160–2000** |
+
+Well within safe operating range for any Prometheus deployment.

--- a/src/agent/branch.rs
+++ b/src/agent/branch.rs
@@ -91,6 +91,7 @@ impl Branch {
         let routing = self.deps.runtime_config.routing.load();
         let model_name = routing.resolve(ProcessType::Branch, None).to_string();
         let model = SpacebotModel::make(&self.deps.llm_manager, &model_name)
+            .with_context(&*self.deps.agent_id, "branch")
             .with_routing((**routing).clone());
 
         let agent = AgentBuilder::new(model)

--- a/src/agent/compactor.rs
+++ b/src/agent/compactor.rs
@@ -199,8 +199,9 @@ async fn run_compaction(
     // 3. Run the compaction LLM to produce summary + extracted memories
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Worker, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_context(&*deps.agent_id, "compactor")
+        .with_routing((**routing).clone());
 
     // Give the compaction worker memory_save so it can directly persist memories
     let tool_server: ToolServerHandle = ToolServer::new()

--- a/src/agent/cortex.rs
+++ b/src/agent/cortex.rs
@@ -462,8 +462,9 @@ pub async fn generate_bulletin(deps: &AgentDeps, logger: &CortexLogger) -> bool 
 
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Branch, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_context(&*deps.agent_id, "cortex")
+        .with_routing((**routing).clone());
 
     // No tools needed — the LLM just synthesizes the pre-gathered data
     let agent = AgentBuilder::new(model).preamble(&bulletin_prompt).build();
@@ -621,8 +622,9 @@ async fn generate_profile(deps: &AgentDeps, logger: &CortexLogger) {
 
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Branch, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_context(&*deps.agent_id, "cortex")
+        .with_routing((**routing).clone());
 
     let agent = AgentBuilder::new(model).preamble(&profile_prompt).build();
 

--- a/src/agent/cortex_chat.rs
+++ b/src/agent/cortex_chat.rs
@@ -263,6 +263,7 @@ impl CortexChatSession {
         let routing = self.deps.runtime_config.routing.load();
         let model_name = routing.resolve(ProcessType::Branch, None).to_string();
         let model = SpacebotModel::make(&self.deps.llm_manager, &model_name)
+            .with_context(&*self.deps.agent_id, "cortex")
             .with_routing((**routing).clone());
 
         let agent = AgentBuilder::new(model)

--- a/src/agent/ingestion.rs
+++ b/src/agent/ingestion.rs
@@ -466,8 +466,9 @@ async fn process_chunk(
 
     let routing = deps.runtime_config.routing.load();
     let model_name = routing.resolve(ProcessType::Branch, None).to_string();
-    let model =
-        SpacebotModel::make(&deps.llm_manager, &model_name).with_routing((**routing).clone());
+    let model = SpacebotModel::make(&deps.llm_manager, &model_name)
+        .with_context(&*deps.agent_id, "branch")
+        .with_routing((**routing).clone());
 
     let conversation_logger =
         crate::conversation::history::ConversationLogger::new(deps.sqlite_pool.clone());

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -199,6 +199,7 @@ impl Worker {
         let routing = self.deps.runtime_config.routing.load();
         let model_name = routing.resolve(ProcessType::Worker, None).to_string();
         let model = SpacebotModel::make(&self.deps.llm_manager, &model_name)
+            .with_context(&*self.deps.agent_id, "worker")
             .with_routing((**routing).clone());
 
         let agent = AgentBuilder::new(model)

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -113,12 +113,8 @@ where
     async fn on_completion_response(
         &self,
         _prompt: &Message,
-        response: &CompletionResponse<M::Response>,
+        _response: &CompletionResponse<M::Response>,
     ) -> HookAction {
-        // Tool nudging: check if response has tool calls
-        // Note: Rig's CompletionResponse structure varies by model implementation
-        // We'll do basic observation here
-
         tracing::debug!(
             process_id = %self.process_id,
             "completion response received"

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -3,6 +3,7 @@
 pub mod anthropic;
 pub mod manager;
 pub mod model;
+pub mod pricing;
 pub mod providers;
 pub mod routing;
 

--- a/src/llm/pricing.rs
+++ b/src/llm/pricing.rs
@@ -1,0 +1,189 @@
+//! Best-effort LLM pricing estimates.
+//!
+//! Maps model names to per-token costs (USD). These are approximate —
+//! actual costs depend on provider agreements, caching, and batching.
+//! Unknown models fall back to a conservative default.
+
+/// Per-token pricing for a model.
+struct ModelPricing {
+    /// Cost per input token in USD.
+    input: f64,
+    /// Cost per output token in USD.
+    output: f64,
+    /// Cost per cached input token in USD (typically discounted).
+    cached_input: f64,
+}
+
+/// Look up pricing for a model name. Matches on the model portion
+/// (after the provider/ prefix) so "anthropic/claude-sonnet-4-20250514"
+/// and "claude-sonnet-4-20250514" both match.
+fn lookup_pricing(model_name: &str) -> ModelPricing {
+    let model = model_name
+        .split_once('/')
+        .map(|(_, m)| m)
+        .unwrap_or(model_name);
+
+    let per_m = |price: f64| price / 1_000_000.0;
+
+    match model {
+        m if m.starts_with("claude-opus-4") => ModelPricing {
+            input: per_m(15.0),
+            output: per_m(75.0),
+            cached_input: per_m(1.5),
+        },
+        m if m.starts_with("claude-sonnet-4") => ModelPricing {
+            input: per_m(3.0),
+            output: per_m(15.0),
+            cached_input: per_m(0.30),
+        },
+        m if m.starts_with("claude-3-5-sonnet") => ModelPricing {
+            input: per_m(3.0),
+            output: per_m(15.0),
+            cached_input: per_m(0.30),
+        },
+        m if m.starts_with("claude-3-5-haiku") || m.starts_with("claude-haiku-4") => {
+            ModelPricing {
+                input: per_m(0.80),
+                output: per_m(4.0),
+                cached_input: per_m(0.08),
+            }
+        }
+
+        m if m.starts_with("claude-3-opus") => ModelPricing {
+            input: per_m(15.0),
+            output: per_m(75.0),
+            cached_input: per_m(1.5),
+        },
+        m if m.starts_with("claude-3-sonnet") => ModelPricing {
+            input: per_m(3.0),
+            output: per_m(15.0),
+            cached_input: per_m(0.30),
+        },
+        m if m.starts_with("claude-3-haiku") => ModelPricing {
+            input: per_m(0.25),
+            output: per_m(1.25),
+            cached_input: per_m(0.03),
+        },
+
+        m if m.starts_with("gpt-4o-mini") => ModelPricing {
+            input: per_m(0.15),
+            output: per_m(0.60),
+            cached_input: per_m(0.075),
+        },
+        m if m.starts_with("gpt-4o") => ModelPricing {
+            input: per_m(2.50),
+            output: per_m(10.0),
+            cached_input: per_m(1.25),
+        },
+        m if m.starts_with("gpt-4-turbo") => ModelPricing {
+            input: per_m(10.0),
+            output: per_m(30.0),
+            cached_input: per_m(5.0),
+        },
+
+        m if m.starts_with("o3-mini") => ModelPricing {
+            input: per_m(1.10),
+            output: per_m(4.40),
+            cached_input: per_m(0.55),
+        },
+        m if m.starts_with("o3") => ModelPricing {
+            input: per_m(10.0),
+            output: per_m(40.0),
+            cached_input: per_m(5.0),
+        },
+        m if m.starts_with("o1-mini") => ModelPricing {
+            input: per_m(3.0),
+            output: per_m(12.0),
+            cached_input: per_m(1.5),
+        },
+        m if m.starts_with("o1") => ModelPricing {
+            input: per_m(15.0),
+            output: per_m(60.0),
+            cached_input: per_m(7.5),
+        },
+
+        m if m.starts_with("gemini-2.0-flash") || m.starts_with("gemini-2.5-flash") => {
+            ModelPricing {
+                input: per_m(0.075),
+                output: per_m(0.30),
+                cached_input: per_m(0.01875),
+            }
+        }
+        m if m.starts_with("gemini-2.5-pro") || m.starts_with("gemini-2.0-pro") => ModelPricing {
+            input: per_m(1.25),
+            output: per_m(10.0),
+            cached_input: per_m(0.3125),
+        },
+        m if m.starts_with("gemini-1.5-pro") => ModelPricing {
+            input: per_m(1.25),
+            output: per_m(5.0),
+            cached_input: per_m(0.3125),
+        },
+        m if m.starts_with("gemini-1.5-flash") => ModelPricing {
+            input: per_m(0.075),
+            output: per_m(0.30),
+            cached_input: per_m(0.01875),
+        },
+
+        m if m.starts_with("deepseek-chat") || m.starts_with("deepseek-v3") => ModelPricing {
+            input: per_m(0.27),
+            output: per_m(1.10),
+            cached_input: per_m(0.07),
+        },
+        m if m.starts_with("deepseek-reasoner") || m.starts_with("deepseek-r1") => ModelPricing {
+            input: per_m(0.55),
+            output: per_m(2.19),
+            cached_input: per_m(0.14),
+        },
+
+        _ => ModelPricing {
+            input: per_m(3.0),
+            output: per_m(15.0),
+            cached_input: per_m(0.30),
+        },
+    }
+}
+
+/// Estimate cost in USD for a completion call.
+///
+/// `cached_input_tokens` are subtracted from `input_tokens` for pricing
+/// since cached tokens are billed at the (lower) cached rate.
+pub fn estimate_cost(
+    model_name: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_input_tokens: u64,
+) -> f64 {
+    let pricing = lookup_pricing(model_name);
+
+    let uncached_input = input_tokens.saturating_sub(cached_input_tokens);
+    (uncached_input as f64 * pricing.input)
+        + (output_tokens as f64 * pricing.output)
+        + (cached_input_tokens as f64 * pricing.cached_input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claude_sonnet_pricing() {
+        // 1000 input + 500 output tokens on claude-sonnet-4
+        let cost = estimate_cost("anthropic/claude-sonnet-4-20250514", 1000, 500, 0);
+        // $3/M input + $15/M output = 0.003 + 0.0075 = 0.0105
+        assert!((cost - 0.0105).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cached_tokens_reduce_cost() {
+        let no_cache = estimate_cost("anthropic/claude-sonnet-4-20250514", 1000, 500, 0);
+        let with_cache = estimate_cost("anthropic/claude-sonnet-4-20250514", 1000, 500, 500);
+        assert!(with_cache < no_cache);
+    }
+
+    #[test]
+    fn test_unknown_model_uses_fallback() {
+        let cost = estimate_cost("unknown-provider/mystery-model", 1000, 500, 0);
+        assert!(cost > 0.0);
+    }
+}

--- a/src/telemetry/registry.rs
+++ b/src/telemetry/registry.rs
@@ -1,7 +1,8 @@
 //! Global metrics registry and metric handle definitions.
 
 use prometheus::{
-    Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts, Registry,
+    CounterVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
+    Opts, Registry,
 };
 
 use std::sync::LazyLock;
@@ -45,9 +46,34 @@ pub struct Metrics {
 
     /// Total memory entries per agent.
     /// Label: agent_id.
-    // TODO: Not wired to any call site. Needs periodic store queries or
-    // inc/dec in MemoryStore::save()/delete() to reflect actual counts.
     pub memory_entry_count: IntGaugeVec,
+
+    // -- Token & cost tracking --
+    /// Total LLM tokens consumed.
+    /// Labels: agent_id, model, tier, direction (input/output/cached_input).
+    pub llm_tokens_total: IntCounterVec,
+
+    /// Estimated LLM cost in USD.
+    /// Labels: agent_id, model, tier.
+    pub llm_estimated_cost_dollars: CounterVec,
+
+    // -- Worker visibility --
+    /// Currently active branches per agent.
+    /// Label: agent_id.
+    pub active_branches: IntGaugeVec,
+
+    /// Worker lifetime duration in seconds.
+    /// Labels: agent_id, worker_type.
+    pub worker_duration_seconds: HistogramVec,
+
+    /// Process errors by type.
+    /// Labels: agent_id, process_type, error_type.
+    pub process_errors_total: IntCounterVec,
+
+    // -- Memory audit --
+    /// Memory mutation operations.
+    /// Labels: agent_id, operation (save/update/delete/forget).
+    pub memory_updates_total: IntCounterVec,
 }
 
 impl Metrics {
@@ -86,10 +112,7 @@ impl Metrics {
                 "spacebot_llm_request_duration_seconds",
                 "LLM request duration in seconds",
             )
-            // TODO: Max bucket 10s is too low for LLM requests. Completions with
-            // retries and fallback chains routinely take 15-60s. Add upper buckets
-            // (e.g. 15, 30, 60, 120) so p99 latency doesn't collapse into +Inf.
-            .buckets(vec![0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
+            .buckets(vec![0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 60.0, 120.0]),
             &["agent_id", "model", "tier"],
         )
         .expect("hardcoded metric descriptor");
@@ -118,6 +141,55 @@ impl Metrics {
         )
         .expect("hardcoded metric descriptor");
 
+        let llm_tokens_total = IntCounterVec::new(
+            Opts::new("spacebot_llm_tokens_total", "Total LLM tokens consumed"),
+            &["agent_id", "model", "tier", "direction"],
+        )
+        .expect("hardcoded metric descriptor");
+
+        let llm_estimated_cost_dollars = CounterVec::new(
+            Opts::new(
+                "spacebot_llm_estimated_cost_dollars",
+                "Estimated LLM cost in USD",
+            ),
+            &["agent_id", "model", "tier"],
+        )
+        .expect("hardcoded metric descriptor");
+
+        let active_branches = IntGaugeVec::new(
+            Opts::new("spacebot_active_branches", "Currently active branches"),
+            &["agent_id"],
+        )
+        .expect("hardcoded metric descriptor");
+
+        let worker_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "spacebot_worker_duration_seconds",
+                "Worker lifetime duration in seconds",
+            )
+            .buckets(vec![1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0]),
+            &["agent_id", "worker_type"],
+        )
+        .expect("hardcoded metric descriptor");
+
+        let process_errors_total = IntCounterVec::new(
+            Opts::new(
+                "spacebot_process_errors_total",
+                "Process errors by type",
+            ),
+            &["agent_id", "process_type", "error_type"],
+        )
+        .expect("hardcoded metric descriptor");
+
+        let memory_updates_total = IntCounterVec::new(
+            Opts::new(
+                "spacebot_memory_updates_total",
+                "Memory mutation operations",
+            ),
+            &["agent_id", "operation"],
+        )
+        .expect("hardcoded metric descriptor");
+
         registry
             .register(Box::new(llm_requests_total.clone()))
             .expect("hardcoded metric");
@@ -142,6 +214,24 @@ impl Metrics {
         registry
             .register(Box::new(memory_entry_count.clone()))
             .expect("hardcoded metric");
+        registry
+            .register(Box::new(llm_tokens_total.clone()))
+            .expect("hardcoded metric");
+        registry
+            .register(Box::new(llm_estimated_cost_dollars.clone()))
+            .expect("hardcoded metric");
+        registry
+            .register(Box::new(active_branches.clone()))
+            .expect("hardcoded metric");
+        registry
+            .register(Box::new(worker_duration_seconds.clone()))
+            .expect("hardcoded metric");
+        registry
+            .register(Box::new(process_errors_total.clone()))
+            .expect("hardcoded metric");
+        registry
+            .register(Box::new(memory_updates_total.clone()))
+            .expect("hardcoded metric");
 
         Self {
             registry,
@@ -153,6 +243,12 @@ impl Metrics {
             tool_call_duration_seconds,
             active_workers,
             memory_entry_count,
+            llm_tokens_total,
+            llm_estimated_cost_dollars,
+            active_branches,
+            worker_duration_seconds,
+            process_errors_total,
+            memory_updates_total,
         }
     }
 

--- a/src/tools/memory_delete.rs
+++ b/src/tools/memory_delete.rs
@@ -109,6 +109,12 @@ impl Tool for MemoryDeleteTool {
             .unwrap_or_default();
 
         if was_forgotten {
+            #[cfg(feature = "metrics")]
+            crate::telemetry::Metrics::global()
+                .memory_updates_total
+                .with_label_values(&["unknown", "forget"])
+                .inc();
+
             tracing::info!(
                 memory_id = %args.memory_id,
                 memory_type = %memory.memory_type,

--- a/src/tools/memory_save.rs
+++ b/src/tools/memory_save.rs
@@ -245,9 +245,14 @@ impl Tool for MemorySaveTool {
         }
 
         #[cfg(feature = "metrics")]
-        crate::telemetry::Metrics::global()
-            .memory_writes_total
-            .inc();
+        {
+            let metrics = crate::telemetry::Metrics::global();
+            metrics.memory_writes_total.inc();
+            metrics
+                .memory_updates_total
+                .with_label_values(&["unknown", "save"])
+                .inc();
+        }
 
         Ok(MemorySaveOutput {
             memory_id: memory.id,


### PR DESCRIPTION
## Summary

Continues from #35 which laid the foundation (registry, metrics server, 8 initial metrics, feature gate). This PR resolves every known limitation called out in that PR and adds the operational visibility metrics needed for cost control and agent monitoring.

**What's new:**

- **Metrics server is now wired** — `start_metrics_server()` is called in `main.rs`, so the `/metrics` endpoint actually starts
- **Per-agent LLM labels** — `agent_id` and `tier` are no longer hardcoded to `"unknown"`; `SpacebotModel` carries process context via `.with_context()`, wired at all 7 call sites (channel, branch, worker, compactor, ingestion, cortex, cortex_chat)
- **Token usage tracking** — `spacebot_llm_tokens_total` counter with `direction` label (input/output/cached_input)
- **Cost estimation** — `spacebot_llm_estimated_cost_dollars` counter with a static pricing table (`src/llm/pricing.rs`) covering Claude 4/3.5/3, GPT-4o, o-series, Gemini, and DeepSeek families
- **Worker/branch visibility** — `spacebot_active_branches` gauge, `spacebot_worker_duration_seconds` histogram
- **Error classification** — `spacebot_process_errors_total` counter with `error_type` labels (rate_limit, timeout, context_overflow, provider_error, other)
- **Memory audit trail** — `spacebot_memory_updates_total` counter tracking save/delete/forget operations; `memory_entry_count` gauge now wired in `MemoryStore`
- **LLM histogram fix** — buckets extended from `[0.1 … 10s]` to `[0.1 … 120s]` to capture retry/fallback latency
- **Docs** — new metrics page for docs.spacebot.sh, updated `METRICS.md` and `docs/metrics.md` with full 14-metric inventory, cardinality estimates, and PromQL examples

## New metrics

| Metric | Type | Labels |
|--------|------|--------|
| `spacebot_llm_tokens_total` | Counter | agent_id, model, tier, direction |
| `spacebot_llm_estimated_cost_dollars` | Counter | agent_id, model, tier |
| `spacebot_active_branches` | Gauge | agent_id |
| `spacebot_worker_duration_seconds` | Histogram | agent_id, worker_type |
| `spacebot_process_errors_total` | Counter | agent_id, process_type, error_type |
| `spacebot_memory_updates_total` | Counter | agent_id, operation |

| Area | Files |
|------|-------|
| Metrics infra | `src/telemetry/registry.rs`, `src/main.rs` |
| LLM instrumentation | `src/llm/model.rs`, `src/llm/pricing.rs` (new), `src/llm.rs` |
| Agent context wiring | `src/agent/{channel,branch,worker,compactor,cortex,cortex_chat,ingestion}.rs` |
| Memory instrumentation | `src/memory/store.rs`, `src/tools/memory_save.rs`, `src/tools/memory_delete.rs` |
| Hook cleanup | `src/hooks/spacebot.rs` |
| Documentation | `METRICS.md`, `docs/metrics.md`, `docs/content/docs/(deployment)/metrics.mdx` (new), `meta.json` |

## Test plan

- [x] `cargo build --features metrics` — compiles (19 pre-existing warnings)
- [x] `cargo build` (without feature) — compiles (19 pre-existing warnings, no metric code included)
- [x] `cargo test --lib --bins` — 96 passed, 0 failed
- [x] All `#[cfg(feature = "metrics")]` gates consistent — no `crate::telemetry` reference without a gate
- [x] Manual: start with `metrics.enabled = true`, curl `localhost:9090/metrics` returns all 14 metrics
- [x] Manual: verify cost counter increments after LLM calls