### PR TITLE
prompts: add missing memory-type guidance in memory flows

### DIFF
--- a/prompts/en/branch.md.j2
+++ b/prompts/en/branch.md.j2
@@ -29,7 +29,7 @@ Depending on why the channel branched, you might:
 Search for relevant memories. Be specific with queries — use key terms the memory might contain, not abstract descriptions. You'll get curated results ranked by relevance. Use these to inform your conclusion.
 
 ### memory_save
-Save something important that came up during your thinking. If you discovered a fact, noticed a preference, reached a decision, identified a goal, or heard a task for later — save it. The channel doesn't save memories — that's your job.
+Save something important that came up during your thinking. If you discovered a fact, identity detail, noticed a preference, reached a decision, captured an event, identified a goal, noticed an observation pattern, or heard a task for later — save it. The channel doesn't save memories — that's your job.
 
 ### memory_delete
 Forget a memory by ID. Use this when the user wants something removed, or when you find memories that are wrong or outdated. Get memory IDs from memory_recall results. When asked to forget something, recall first to find the relevant memories, then delete them.
@@ -45,8 +45,11 @@ If the user wants something done now and it needs execution tools (shell, file, 
 4. If you spawn a worker, your conclusion should tell the channel what was started and what to expect. Then you're done — the worker runs independently.
 5. You have a limited number of turns. Don't loop. Recall, think, conclude.
 6. Save memories proactively. If the conversation reveals a preference, a fact, a decision, a goal, or a task, save it before returning your conclusion. Use the right type:
+   - **identity** — core information about who the user or agent is ("the user is a backend engineer", "the agent's role is release coordination")
    - **fact** — something stated as true ("the API uses OAuth2")
    - **preference** — likes, dislikes, ways of working ("I prefer TypeScript")
    - **decision** — a choice that was made ("we'll use PostgreSQL")
+   - **event** — something that happened ("we shipped the migration last Friday")
+   - **observation** — a pattern noticed over time ("the user usually asks for code-first answers")
    - **goal** — something the user or agent wants to achieve ("migrate to the new API by Q3"). Goals are aspirational and may span multiple conversations.
    - **todo** — a concrete actionable task or reminder ("update the auth tests", "remind me to check the deploy tomorrow"). Todos are specific and completable.

--- a/prompts/en/compactor.md.j2
+++ b/prompts/en/compactor.md.j2
@@ -28,8 +28,10 @@ The channel's context is getting full. You've been given the oldest turns that n
 After your summary, use `memory_save` for each memory worth extracting. Pick the right type:
 
 - **fact** — things stated as true ("I work at Acme Corp", "the API uses OAuth2")
+- **identity** — core information about who the user or agent is ("the user is a staff engineer", "the agent specializes in Rust")
 - **preference** — likes, dislikes, ways of working ("I prefer TypeScript", "don't use emojis")
 - **decision** — choices that were made ("we decided to use PostgreSQL", "auth will use JWT")
+- **event** — things that happened ("the deploy failed this morning", "the migration was completed")
 - **observation** — patterns noticed ("user tends to ask for code examples", "conversations are usually technical")
 - **goal** — something the user or agent wants to achieve ("migrate to the new API by Q3"). Goals are aspirational and may span multiple conversations.
 - **todo** — a concrete actionable task or reminder ("update the auth tests", "check the deploy status tomorrow"). Todos are specific and completable.

--- a/prompts/en/ingestion.md.j2
+++ b/prompts/en/ingestion.md.j2
@@ -10,6 +10,7 @@ You are a memory ingestion process. You are given a chunk of text from a file th
    - Update existing memories when the chunk contains newer or more complete information
 
 3. **Save memories selectively.** Extract distinct pieces of information and save each as a separate memory with the appropriate type:
+   - **identity** — core information about who the user or agent is (roles, background, stable traits)
    - **fact** — concrete information (names, dates, technical details, project facts)
    - **preference** — expressed likes, dislikes, communication preferences, tool choices
    - **decision** — choices that were made, with reasoning if available

--- a/prompts/en/memory_persistence.md.j2
+++ b/prompts/en/memory_persistence.md.j2
@@ -12,6 +12,7 @@ This is an automatic process triggered periodically during conversation. You are
    - Increase weight on patterns that are being reinforced
 
 2. **Save selectively.** After recalling, save memories for information worth persisting:
+   - Identity details that clarify who the user or agent is
    - Facts the user shared about themselves, their work, or their preferences
    - Decisions that were made
    - Preferences expressed (explicitly or implicitly)


### PR DESCRIPTION
## Summary
- add missing memory-type guidance in memory-related prompts
- update branch, compactor, ingestion, and memory_persistence prompts for consistency of listed types

## Included commit
- 4a2463c
