### PR TITLE
fix(channel): prevent bot spamming from retrigger cascades

### DIFF
--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -25,6 +25,14 @@ use tokio::sync::broadcast;
 use tokio::sync::{RwLock, mpsc};
 use tracing::Instrument as _;
 
+/// Debounce window for retriggers: coalesce rapid branch/worker completions
+/// into a single retrigger instead of firing one per event.
+const RETRIGGER_DEBOUNCE_MS: u64 = 500;
+
+/// Maximum retriggers allowed since the last real user message. Prevents
+/// infinite retrigger cascades where each retrigger spawns more work.
+const MAX_RETRIGGERS_PER_TURN: usize = 3;
+
 /// Shared state that channel tools need to act on the channel.
 ///
 /// Wrapped in Arc and passed to tools (branch, spawn_worker, route, cancel)
@@ -129,6 +137,14 @@ pub struct Channel {
     coalesce_buffer: Vec<InboundMessage>,
     /// Deadline for flushing the coalesce buffer.
     coalesce_deadline: Option<tokio::time::Instant>,
+    /// Number of retriggers fired since the last real user message.
+    retrigger_count: usize,
+    /// Whether a retrigger is pending (debounce window active).
+    pending_retrigger: bool,
+    /// Metadata for the pending retrigger (e.g. Discord reply target).
+    pending_retrigger_metadata: HashMap<String, serde_json::Value>,
+    /// Deadline for firing the pending retrigger (debounce timer).
+    retrigger_deadline: Option<tokio::time::Instant>,
 }
 
 impl Channel {
@@ -206,6 +222,10 @@ impl Channel {
             branch_reply_targets: HashMap::new(),
             coalesce_buffer: Vec::new(),
             coalesce_deadline: None,
+            retrigger_count: 0,
+            pending_retrigger: false,
+            pending_retrigger_metadata: HashMap::new(),
+            retrigger_deadline: None,
         };
 
         (channel, message_tx)
@@ -216,9 +236,14 @@ impl Channel {
         tracing::info!(channel_id = %self.id, "channel started");
 
         loop {
-            // Compute sleep duration based on coalesce deadline
-            let sleep_duration = self
-                .coalesce_deadline
+            // Compute next deadline from coalesce and retrigger timers
+            let next_deadline = match (self.coalesce_deadline, self.retrigger_deadline) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            };
+            let sleep_duration = next_deadline
                 .map(|deadline| {
                     let now = tokio::time::Instant::now();
                     if deadline > now {
@@ -254,10 +279,17 @@ impl Channel {
                         tracing::error!(%error, channel_id = %self.id, "error handling event");
                     }
                 }
-                _ = tokio::time::sleep(sleep_duration), if self.coalesce_deadline.is_some() => {
-                    // Deadline reached - flush the buffer
-                    if let Err(error) = self.flush_coalesce_buffer().await {
-                        tracing::error!(%error, channel_id = %self.id, "error flushing coalesce buffer on deadline");
+                _ = tokio::time::sleep(sleep_duration), if next_deadline.is_some() => {
+                    let now = tokio::time::Instant::now();
+                    // Check coalesce deadline
+                    if self.coalesce_deadline.is_some_and(|d| d <= now) {
+                        if let Err(error) = self.flush_coalesce_buffer().await {
+                            tracing::error!(%error, channel_id = %self.id, "error flushing coalesce buffer on deadline");
+                        }
+                    }
+                    // Check retrigger deadline
+                    if self.retrigger_deadline.is_some_and(|d| d <= now) {
+                        self.flush_pending_retrigger().await;
                     }
                 }
                 else => break,
@@ -542,7 +574,7 @@ impl Channel {
             )
             .await?;
 
-        self.handle_agent_result(result, &skip_flag, &replied_flag)
+        self.handle_agent_result(result, &skip_flag, &replied_flag, false)
             .await;
         // Check compaction
         if let Err(error) = self.compactor.check_and_compact().await {
@@ -698,6 +730,8 @@ impl Channel {
             *reply_target = extract_discord_message_id(&message);
         }
 
+        let is_retrigger = message.source == "system";
+
         let (result, skip_flag, replied_flag) = self
             .run_agent_turn(
                 &user_text,
@@ -707,7 +741,7 @@ impl Channel {
             )
             .await?;
 
-        self.handle_agent_result(result, &skip_flag, &replied_flag)
+        self.handle_agent_result(result, &skip_flag, &replied_flag, is_retrigger)
             .await;
 
         // Check context size and trigger compaction if needed
@@ -716,7 +750,8 @@ impl Channel {
         }
 
         // Increment message counter and spawn memory persistence branch if threshold reached
-        if message.source != "system" {
+        if !is_retrigger {
+            self.retrigger_count = 0;
             self.message_count += 1;
             self.check_memory_persistence().await;
         }
@@ -903,11 +938,17 @@ impl Channel {
     }
 
     /// Dispatch the LLM result: send fallback text, log errors, clean up typing.
+    ///
+    /// On retrigger turns (`is_retrigger = true`), fallback text is suppressed.
+    /// The LLM must explicitly call the `reply` tool to send a message; returning
+    /// plain text on a retrigger is treated as internal acknowledgment, not a
+    /// user-facing response.
     async fn handle_agent_result(
         &self,
         result: std::result::Result<String, rig::completion::PromptError>,
         skip_flag: &crate::tools::SkipFlag,
         replied_flag: &crate::tools::RepliedFlag,
+        is_retrigger: bool,
     ) {
         match result {
             Ok(response) => {
@@ -918,6 +959,16 @@ impl Channel {
                     tracing::debug!(channel_id = %self.id, "channel turn skipped (no response)");
                 } else if replied {
                     tracing::debug!(channel_id = %self.id, "channel turn replied via tool (fallback suppressed)");
+                } else if is_retrigger {
+                    // On retrigger turns, suppress fallback text. The LLM should
+                    // use the reply tool explicitly if it has something to say, or
+                    // the skip tool if not. Raw text output from retriggers is
+                    // almost always internal acknowledgment, not a real response.
+                    tracing::debug!(
+                        channel_id = %self.id,
+                        response_len = response.len(),
+                        "retrigger turn fallback suppressed (LLM did not use reply/skip tool)"
+                    );
                 } else {
                     // If the LLM returned text without using the reply tool, send it
                     // directly. Some models respond with text instead of tool calls.
@@ -1079,33 +1130,75 @@ impl Channel {
             _ => {}
         }
 
-        // Re-trigger the channel LLM so it can process the result and respond
-        if should_retrigger && let Some(conversation_id) = &self.conversation_id {
-            let retrigger_message = self
-                .deps
-                .runtime_config
-                .prompts
-                .load()
-                .render_system_retrigger()
-                .expect("failed to render retrigger message");
-
-            let synthetic = InboundMessage {
-                id: uuid::Uuid::new_v4().to_string(),
-                source: "system".into(),
-                conversation_id: conversation_id.clone(),
-                sender_id: "system".into(),
-                agent_id: None,
-                content: crate::MessageContent::Text(retrigger_message),
-                timestamp: chrono::Utc::now(),
-                metadata: retrigger_metadata,
-                formatted_author: None,
-            };
-            if let Err(error) = self.self_tx.try_send(synthetic) {
-                tracing::warn!(%error, "failed to re-trigger channel after process completion");
+        // Debounce retriggers: instead of firing immediately, set a deadline.
+        // Multiple branch/worker completions within the debounce window are
+        // coalesced into a single retrigger to prevent message spam.
+        if should_retrigger {
+            if self.retrigger_count >= MAX_RETRIGGERS_PER_TURN {
+                tracing::warn!(
+                    channel_id = %self.id,
+                    retrigger_count = self.retrigger_count,
+                    max = MAX_RETRIGGERS_PER_TURN,
+                    "retrigger cap reached, suppressing further retriggers until next user message"
+                );
+            } else {
+                self.pending_retrigger = true;
+                // Merge metadata (later events override earlier ones for the same key)
+                for (key, value) in retrigger_metadata {
+                    self.pending_retrigger_metadata.insert(key, value);
+                }
+                self.retrigger_deadline =
+                    Some(tokio::time::Instant::now() + std::time::Duration::from_millis(RETRIGGER_DEBOUNCE_MS));
             }
         }
 
         Ok(())
+    }
+
+    /// Flush the pending retrigger: send a synthetic system message to re-trigger
+    /// the channel LLM so it can process background results and respond.
+    async fn flush_pending_retrigger(&mut self) {
+        self.retrigger_deadline = None;
+
+        if !self.pending_retrigger {
+            return;
+        }
+        self.pending_retrigger = false;
+        let metadata = std::mem::take(&mut self.pending_retrigger_metadata);
+
+        let Some(conversation_id) = &self.conversation_id else {
+            return;
+        };
+
+        self.retrigger_count += 1;
+        tracing::info!(
+            channel_id = %self.id,
+            retrigger_count = self.retrigger_count,
+            "firing debounced retrigger"
+        );
+
+        let retrigger_message = self
+            .deps
+            .runtime_config
+            .prompts
+            .load()
+            .render_system_retrigger()
+            .expect("failed to render retrigger message");
+
+        let synthetic = InboundMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            source: "system".into(),
+            conversation_id: conversation_id.clone(),
+            sender_id: "system".into(),
+            agent_id: None,
+            content: crate::MessageContent::Text(retrigger_message),
+            timestamp: chrono::Utc::now(),
+            metadata,
+            formatted_author: None,
+        };
+        if let Err(error) = self.self_tx.try_send(synthetic) {
+            tracing::warn!(%error, "failed to re-trigger channel after process completion");
+        }
     }
 
     /// Get the current status block as a string.


### PR DESCRIPTION
## Summary

- **Suppress fallback text on retrigger turns** — when a branch/worker completion re-enters the channel, the LLM must now explicitly call the `reply` tool to send a message; plain text output from retrigger turns is discarded
- **Debounce retriggers (500ms)** — multiple branch/worker completions within the debounce window are coalesced into a single retrigger, preventing parallel completions from multiplying LLM turns
- **Cap retriggers per user message (max 3)** — counter resets on real user messages, preventing infinite cascades where retrigger results spawn more work
- **Cap worker segments (max 10)** — the previously unbounded worker segment loop now terminates gracefully with a partial result after 10 segments

## What was happening

When branches or workers completed, the channel injected a synthetic system message and ran a new LLM turn (retrigger). If the LLM returned text without calling `reply` or `skip`, `handle_agent_result` sent that text directly to the user as a fallback message. With up to 5 concurrent branches completing near-simultaneously, this produced multiple unwanted messages per user interaction.

Additionally, workers could loop indefinitely through segments when repeatedly hitting `MaxTurnsError`, never terminating.

## Changes

| File | Lines | What |
|------|-------|------|
| `src/agent/channel.rs` | +125/-33 | Added `RETRIGGER_DEBOUNCE_MS`, `MAX_RETRIGGERS_PER_TURN` constants; 4 new struct fields for debounce state; modified `run()` loop to handle dual deadlines; `handle_agent_result()` takes `is_retrigger` param; `handle_event()` debounces instead of immediate retrigger; new `flush_pending_retrigger()` method |
| `src/agent/worker.rs` | +32/0 | Added `MAX_SEGMENTS` constant; segment cap check with graceful partial result extraction from history |

## Testing

- LSP diagnostics clean on both files
- `cargo check` blocked by missing `protoc` system dependency (LanceDB build requirement) — not related to these changes