### PR TITLE
fix(build): restore compile after security middleware + URL validation changes

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -7,8 +7,8 @@ use super::{
 };
 
 use axum::Json;
-use axum::extract::Request;
 use axum::Router;
+use axum::extract::{Request, State};
 use axum::http::{StatusCode, Uri, header};
 use axum::middleware::{self, Next};
 use axum::response::{Html, IntoResponse, Response};
@@ -177,7 +177,11 @@ pub async fn start_http_server(
     Ok(handle)
 }
 
-async fn api_auth_middleware(state: Arc<ApiState>, request: Request, next: Next) -> Response {
+async fn api_auth_middleware(
+    State(state): State<Arc<ApiState>>,
+    request: Request,
+    next: Next,
+) -> Response {
     let Some(expected_token) = state.auth_token.as_deref() else {
         return next.run(request).await;
     };
@@ -197,7 +201,11 @@ async fn api_auth_middleware(state: Arc<ApiState>, request: Request, next: Next)
     if is_authorized {
         next.run(request).await
     } else {
-        (StatusCode::UNAUTHORIZED, Json(json!({"error": "unauthorized"}))).into_response()
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "unauthorized"})),
+        )
+            .into_response()
     }
 }
 

--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -4,7 +4,6 @@
 //! via headless Chrome using chromiumoxide. Uses an accessibility-tree based
 //! ref system for LLM-friendly element addressing.
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use crate::config::BrowserConfig;
 
 use chromiumoxide::browser::{Browser, BrowserConfig as ChromeConfig};
@@ -17,11 +16,13 @@ use chromiumoxide_cdp::cdp::browser_protocol::input::{
 };
 use chromiumoxide_cdp::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use futures::StreamExt as _;
+use reqwest::Url;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -31,9 +32,8 @@ use tokio::task::JoinHandle;
 /// Blocks private/loopback IPs, link-local addresses, and cloud metadata endpoints
 /// to prevent server-side request forgery.
 fn validate_url(url: &str) -> Result<(), BrowserError> {
-    let parsed = url::Url::parse(url).map_err(|error| {
-        BrowserError::new(format!("invalid URL '{url}': {error}"))
-    })?;
+    let parsed = Url::parse(url)
+        .map_err(|error| BrowserError::new(format!("invalid URL '{url}': {error}")))?;
 
     match parsed.scheme() {
         "http" | "https" => {}
@@ -91,7 +91,7 @@ fn is_blocked_ip(ip: IpAddr) -> bool {
             || v4.is_link_local()                         // 169.254.0.0/16
             || v4.is_broadcast()                          // 255.255.255.255
             || v4.is_unspecified()                        // 0.0.0.0
-            || is_v4_cgnat(v4)                            // 100.64.0.0/10
+            || is_v4_cgnat(v4) // 100.64.0.0/10
         }
         IpAddr::V6(v6) => {
             v6.is_loopback()                             // ::1


### PR DESCRIPTION
**PR Description**  
## Summary
`main` failed to compile after recent security hardening changes due to two integration issues:
1. Browser URL validation referenced `url::Url` without a matching dependency/import.
2. API auth middleware used an Axum signature incompatible with `from_fn_with_state`.

This PR applies minimal fixes to restore successful builds.

## What Changed
- Updated browser URL parsing to use `reqwest::Url`:
  - Added `use reqwest::Url;`
  - Replaced `url::Url::parse(...)` with `Url::parse(...)`
- Fixed Axum middleware state extraction in API server:
  - Changed middleware signature to:
    - `State(state): State<Arc<ApiState>>`
  - Kept `from_fn_with_state(state.clone(), api_auth_middleware)` usage intact.

## Scope
- Build/integration fix only.
- No behavior changes intended beyond resolving compile errors.

## Validation
- Ran `cargo check --lib` successfully on this branch.

This is my first proper OSS change, I hope it's up to scratch 🙏