### PR TITLE
feat: support ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN and SPACEBOT_MODEL env vars

### DIFF
--- a/src/llm/model.rs
+++ b/src/llm/model.rs
@@ -352,6 +352,7 @@ impl SpacebotModel {
         let anthropic_request = crate::llm::anthropic::build_anthropic_request(
             self.llm_manager.http_client(),
             api_key,
+            &provider_config.base_url,
             &self.model_name,
             &request,
             effort,


### PR DESCRIPTION
## Summary

- Add `ANTHROPIC_BASE_URL` env var to override the Anthropic API endpoint
- Add `ANTHROPIC_AUTH_TOKEN` env var as an alternative to `ANTHROPIC_API_KEY` for proxy auth
- Add `SPACEBOT_MODEL` env var to override all process types with a single model
- Fix bug where `build_anthropic_request()` hardcoded the API URL, ignoring configured `base_url`

## Why

Many organizations run Anthropic-compatible API proxies (LiteLLM, Azure AI Gateway, corporate proxies). This makes Spacebot usable in enterprise and self-hosted environments where direct API access isn't available.

## New Environment Variables

| Variable | Purpose | Default |
|----------|---------|---------|
| `ANTHROPIC_BASE_URL` | Custom API endpoint URL | `https://api.anthropic.com` |
| `ANTHROPIC_AUTH_TOKEN` | Bearer token for proxy auth (fallback if no `ANTHROPIC_API_KEY`) | — |
| `SPACEBOT_MODEL` | Override all process types at once | — |

These are non-breaking — existing `ANTHROPIC_API_KEY` behavior stays the same.

## Changes

### `src/llm/anthropic/params.rs`
- Remove hardcoded `ANTHROPIC_API_URL` constant
- Add `base_url` parameter to `build_anthropic_request()`
- Add `messages_url()` helper that appends `/v1/messages` to the base URL

### `src/llm/model.rs`
- Pass `provider_config.base_url` to `build_anthropic_request()`

### `src/config.rs`
- `ANTHROPIC_AUTH_TOKEN` as fallback for `ANTHROPIC_API_KEY` in both `load_from_env()` and `from_toml()`
- `ANTHROPIC_BASE_URL` overrides the default base URL when registering the Anthropic provider
- `SPACEBOT_MODEL` sets all routing process types (channel, branch, worker, compactor, cortex); specific vars like `SPACEBOT_CHANNEL_MODEL` take precedence

## Bug Fix

Previously, `build_anthropic_request()` always posted to `https://api.anthropic.com/v1/messages` regardless of what `base_url` was configured in `ProviderConfig`. This meant custom base URLs set via `[llm.provider.anthropic]` TOML config were silently ignored. Now the provider's `base_url` is passed through and used.

## Test plan
- [ ] Verify existing `ANTHROPIC_API_KEY` still works (no regression)
- [ ] Test `ANTHROPIC_AUTH_TOKEN` as sole credential
- [ ] Test `ANTHROPIC_BASE_URL` with a proxy endpoint
- [ ] Test `SPACEBOT_MODEL` overrides all process types
- [ ] Test `SPACEBOT_CHANNEL_MODEL` takes precedence over `SPACEBOT_MODEL`
- [ ] All 26 existing Anthropic tests pass

Closes #132