### PR TITLE
Fix cron timezone resolution and delete drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8079,6 +8079,7 @@ dependencies = [
  "chromiumoxide",
  "chromiumoxide_cdp",
  "chrono",
+ "chrono-tz",
  "clap",
  "config",
  "daemonize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ uuid = { version = "1.15", features = ["v4", "serde"] }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 
 # Regular expressions (for leak detection)
 regex = "1.11"

--- a/docs/content/docs/(configuration)/config.mdx
+++ b/docs/content/docs/(configuration)/config.mdx
@@ -59,6 +59,7 @@ max_turns = 5                  # max LLM turns per channel message
 context_window = 128000        # context window size in tokens
 history_backfill_count = 50    # messages to fetch from platform on new channel
 worker_log_mode = "errors_only" # "errors_only", "all_separate", or "all_combined"
+cron_timezone = "UTC"          # optional default timezone for cron active hours
 
 # Model routing per process type.
 [defaults.routing]
@@ -105,6 +106,7 @@ screenshot_dir = "/path/to/screenshots" # optional, defaults to data_dir/screens
 id = "main"
 default = true
 workspace = "/custom/workspace/path"   # optional, defaults to ~/.spacebot/agents/{id}/workspace
+cron_timezone = "America/Los_Angeles"  # optional per-agent cron timezone override
 
 # Per-agent routing overrides (merges with defaults).
 [agents.routing]
@@ -180,7 +182,7 @@ This creates a single "main" agent with default settings.
 For any setting, the resolution chain is:
 
 ```
-agent-level override  >  [defaults] section  >  hardcoded default
+agent-level override  >  [defaults] section  >  env var fallback (if supported)  >  hardcoded default
 ```
 
 An agent with no overrides inherits everything from `[defaults]`. An agent with partial overrides gets those values from its own config and everything else from defaults. See [Agents](/docs/agents) for how agent config merging works.
@@ -394,6 +396,7 @@ At least one provider (legacy key or custom provider) must be configured.
 | `context_window` | integer | 128000 | Context window size in tokens |
 | `history_backfill_count` | integer | 50 | Messages to fetch from platform on new channel |
 | `worker_log_mode` | string | `"errors_only"` | Worker log persistence: `"errors_only"`, `"all_separate"`, or `"all_combined"` |
+| `cron_timezone` | string | None | Default timezone for cron active-hours evaluation (IANA name like `UTC` or `America/New_York`) |
 
 ### `[defaults.routing]`
 
@@ -481,6 +484,7 @@ Thresholds are fractions of `context_window`.
 | `id` | string | **required** | Agent identifier |
 | `default` | bool | false | Whether this is the default agent |
 | `workspace` | string | `~/.spacebot/agents/{id}/workspace` | Custom workspace path |
+| `cron_timezone` | string | inherits | Per-agent timezone override for cron active-hours evaluation |
 | `max_concurrent_branches` | integer | inherits | Override instance default |
 | `max_turns` | integer | inherits | Override instance default |
 | `context_window` | integer | inherits | Override instance default |
@@ -498,6 +502,15 @@ Agent-specific routing is set via `[agents.routing]` with the same keys as `[def
 | `active_start_hour` | integer | None | Start of active hours window (24h format) |
 | `active_end_hour` | integer | None | End of active hours window |
 | `enabled` | bool | true | Whether this cron job is active |
+
+Cron timezone precedence is:
+
+1. `agents.cron_timezone`
+2. `defaults.cron_timezone`
+3. `SPACEBOT_CRON_TIMEZONE`
+4. server local timezone
+
+If a configured timezone is invalid, Spacebot logs a warning and falls back to server local time.
 
 ### `[messaging.discord]`
 

--- a/docs/content/docs/(features)/cron.mdx
+++ b/docs/content/docs/(features)/cron.mdx
@@ -149,11 +149,20 @@ Any code with access to `CronStore` and `Scheduler` can create cron jobs. The co
 
 ## Active Hours
 
-The active window uses 24-hour local time. If `active_start_hour` and `active_end_hour` are both set, the cron job only fires within that window.
+The active window uses a resolved timezone for each agent:
+
+1. `agents.cron_timezone`
+2. `defaults.cron_timezone`
+3. `SPACEBOT_CRON_TIMEZONE`
+4. server local timezone
+
+If `active_start_hour` and `active_end_hour` are both set, the cron job only fires within that window.
 
 Midnight wrapping is handled: a window of `22:00-06:00` means "10pm to 6am" — the cron job fires if the current hour is >= 22 or < 6.
 
 If active hours are not set, the cron job runs at all hours.
+
+If a configured timezone is invalid, Spacebot logs a warning and falls back to server local timezone.
 
 Active hours don't affect the timer interval — the timer still ticks at `interval_secs`. When a tick lands outside the active window, it's skipped. The next tick happens at the normal interval, not "as soon as the window opens."
 

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -296,6 +296,7 @@ pub(super) async fn create_agent(
         browser: None,
         mcp: None,
         brave_search_key: None,
+        cron_timezone: None,
         cron: Vec::new(),
     };
     let agent_config = raw_config.resolve(&instance_dir, defaults);


### PR DESCRIPTION
## Summary
- add `cron_timezone` config support at defaults and per-agent levels, plus `SPACEBOT_CRON_TIMEZONE` env fallback with validation and system-time fallback
- switch active-hour checks to use the resolved timezone, and expose timezone context in cron list API and tool output
- fix cron tool delete behavior to unregister in-memory scheduler timers before deleting from storage
- update cron/config docs to explain timezone precedence and behavior

## Testing
- `cargo check`
- `cargo test test_cron_timezone_ --lib`
- `cargo test hour_in_active_window --lib`