### PR TITLE
feat: add auto_display_name toggle to cortex settings

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -494,6 +494,7 @@ export interface CortexSection {
 	bulletin_interval_secs: number;
 	bulletin_max_words: number;
 	bulletin_max_turns: number;
+	auto_display_name: boolean;
 }
 
 export interface CoalesceSection {
@@ -570,6 +571,7 @@ export interface CortexUpdate {
 	bulletin_interval_secs?: number;
 	bulletin_max_words?: number;
 	bulletin_max_turns?: number;
+	auto_display_name?: boolean;
 }
 
 export interface CoalesceUpdate {

--- a/interface/src/routes/AgentConfig.tsx
+++ b/interface/src/routes/AgentConfig.tsx
@@ -640,6 +640,12 @@ function ConfigSectionEditor({ sectionId, label, description, detail, config, on
 			case "cortex":
 				return (
 					<div className="grid gap-4">
+						<ConfigToggleField
+							label="Auto Display Name"
+							description="When enabled, cortex generates a creative display name. When disabled, the agent ID is used as display name."
+							value={localValues.auto_display_name as boolean}
+							onChange={(v) => handleChange("auto_display_name", v)}
+						/>
 						<NumberStepper
 							label="Tick Interval"
 							description="How often the cortex checks system state"

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -43,6 +43,7 @@ pub(super) struct CortexSection {
     bulletin_interval_secs: u64,
     bulletin_max_words: usize,
     bulletin_max_turns: usize,
+    auto_display_name: bool,
 }
 
 #[derive(Serialize, Debug)]
@@ -148,6 +149,7 @@ pub(super) struct CortexUpdate {
     bulletin_interval_secs: Option<u64>,
     bulletin_max_words: Option<usize>,
     bulletin_max_turns: Option<usize>,
+    auto_display_name: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -226,6 +228,7 @@ pub(super) async fn get_agent_config(
             bulletin_interval_secs: cortex.bulletin_interval_secs,
             bulletin_max_words: cortex.bulletin_max_words,
             bulletin_max_turns: cortex.bulletin_max_turns,
+            auto_display_name: cortex.auto_display_name,
         },
         coalesce: CoalesceSection {
             enabled: coalesce.enabled,
@@ -521,6 +524,9 @@ fn update_cortex_table(
     }
     if let Some(v) = cortex.bulletin_max_turns {
         table["bulletin_max_turns"] = toml_edit::value(v as i64);
+    }
+    if let Some(v) = cortex.auto_display_name {
+        table["auto_display_name"] = toml_edit::value(v);
     }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -545,6 +545,9 @@ pub struct CortexConfig {
     pub association_updates_threshold: f32,
     /// Max associations to create per pass (rate limit).
     pub association_max_per_pass: usize,
+    /// When true, cortex auto-generates the display name. When false,
+    /// the display name equals the agent ID and cortex won't overwrite it.
+    pub auto_display_name: bool,
 }
 
 impl Default for CortexConfig {
@@ -561,6 +564,7 @@ impl Default for CortexConfig {
             association_similarity_threshold: 0.85,
             association_updates_threshold: 0.95,
             association_max_per_pass: 100,
+            auto_display_name: true,
         }
     }
 }
@@ -1546,6 +1550,7 @@ struct TomlCortexConfig {
     association_similarity_threshold: Option<f32>,
     association_updates_threshold: Option<f32>,
     association_max_per_pass: Option<usize>,
+    auto_display_name: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -2705,6 +2710,9 @@ impl Config {
                     association_max_per_pass: c
                         .association_max_per_pass
                         .unwrap_or(base_defaults.cortex.association_max_per_pass),
+                    auto_display_name: c
+                        .auto_display_name
+                        .unwrap_or(base_defaults.cortex.auto_display_name),
                 })
                 .unwrap_or(base_defaults.cortex),
             browser: toml
@@ -2881,6 +2889,9 @@ impl Config {
                         association_max_per_pass: c
                             .association_max_per_pass
                             .unwrap_or(defaults.cortex.association_max_per_pass),
+                        auto_display_name: c
+                            .auto_display_name
+                            .unwrap_or(defaults.cortex.auto_display_name),
                     }),
                     browser: a.browser.map(|b| BrowserConfig {
                         enabled: b.enabled.unwrap_or(defaults.browser.enabled),


### PR DESCRIPTION
## Summary
- Adds `auto_display_name` boolean to cortex config (default: `true`)
- When enabled (default): cortex generates a creative display name (current behavior)
- When disabled: display name = agent ID, cortex skips name generation
- Toggle available in the UI under Settings > Cortex section

## Changes
- `src/config.rs`: Added field to `CortexConfig`, `TomlCortexConfig`, default, and both parsing blocks
- `src/api/config.rs`: Added to API response/update structs and TOML update function
- `src/agent/cortex.rs`: Early return in `generate_profile` when disabled
- `interface/src/api/client.ts`: Updated TypeScript interfaces
- `interface/src/routes/AgentConfig.tsx`: Added toggle in cortex settings UI