### PR TITLE
fix(skills): inject skill via parameter, not file path

### DIFF
--- a/prompts/en/fragments/skills_channel.md.j2
+++ b/prompts/en/fragments/skills_channel.md.j2
@@ -2,14 +2,16 @@
 
 You have access to the following skills. Skills contain specialized instructions for specific tasks. When a user's request matches a skill, spawn a worker to handle it and include the skill name in the task description so the worker knows which skill to follow.
 
-To use a skill, spawn a worker with a task like: "Use the [skill-name] skill to [task]. Read the skill instructions at [path] first."
+The worker will automatically receive the skill's instructions in its system prompt — do not include file paths in the task description.
+
+To use a skill, spawn a worker and set the `skill` parameter to the skill name. This is what injects the skill instructions into the worker. Example:
+`spawn_worker(skill="generate_music", task="Generate a 30-second downtempo track, no lyrics.")`
 
 <available_skills>
 {%- for skill in skills %}
   <skill>
     <name>{{ skill.name }}</name>
     <description>{{ skill.description }}</description>
-    <location>{{ skill.location }}</location>
   </skill>
 {%- endfor %}
 </available_skills>

--- a/prompts/en/fragments/skills_worker.md.j2
+++ b/prompts/en/fragments/skills_worker.md.j2
@@ -1,5 +1,5 @@
 ## Skill Instructions
 
-You are executing the **{{ skill_name }}** skill. Follow these instructions:
+You are executing the **{{ skill_name }}** skill. The full skill instructions are included below — do NOT use the file tool to look for skill files on disk, they are not accessible and you already have everything you need here. Follow the instructions below exactly and immediately:
 
 {{ skill_content }}


### PR DESCRIPTION
Workers were receiving file paths in their task description and trying to read skill files from disk, hitting ACCESS DENIED since the file tool is restricted in worker contexts.

The root cause: the channel prompt instructed the LLM to include `[path]` in the task description. But the `skill=` parameter on `spawn_worker` is what actually injects the skill content into the worker's system prompt — the path is irrelevant and misleading.

Changes:
- Remove `<location>` from the available skills list in `skills_channel.md.j2` — it's unused and causes LLMs to pass it to workers
- Update the channel prompt to show the correct `spawn_worker(skill="...", task="...")` pattern
- Update `skills_worker.md.j2` to explicitly tell the worker not to look for skill files on disk — the content is already in its system prompt