### PR TITLE
fix: route MiniMax through OpenAI-compatible endpoint

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -230,7 +230,7 @@ const ANTHROPIC_PROVIDER_BASE_URL: &str = "https://api.anthropic.com";
 const OPENAI_PROVIDER_BASE_URL: &str = "https://api.openai.com";
 const OPENROUTER_PROVIDER_BASE_URL: &str = "https://openrouter.ai/api";
 const OPENCODE_ZEN_PROVIDER_BASE_URL: &str = "https://opencode.ai/zen";
-const MINIMAX_PROVIDER_BASE_URL: &str = "https://api.minimax.io/anthropic";
+const MINIMAX_PROVIDER_BASE_URL: &str = "https://api.minimax.io";
 const MINIMAX_CN_PROVIDER_BASE_URL: &str = "https://api.minimaxi.com/anthropic";
 const MOONSHOT_PROVIDER_BASE_URL: &str = "https://api.moonshot.ai";
 
@@ -2074,7 +2074,7 @@ impl Config {
             llm.providers
                 .entry("minimax".to_string())
                 .or_insert_with(|| ProviderConfig {
-                    api_type: ApiType::Anthropic,
+                    api_type: ApiType::OpenAiCompletions,
                     base_url: MINIMAX_PROVIDER_BASE_URL.to_string(),
                     api_key: minimax_key,
                     name: None,
@@ -2455,7 +2455,7 @@ impl Config {
             llm.providers
                 .entry("minimax".to_string())
                 .or_insert_with(|| ProviderConfig {
-                    api_type: ApiType::Anthropic,
+                    api_type: ApiType::OpenAiCompletions,
                     base_url: MINIMAX_PROVIDER_BASE_URL.to_string(),
                     api_key: minimax_key,
                     name: None,


### PR DESCRIPTION
MiniMax was configured as `ApiType::Anthropic`, causing requests to be sent to `api.anthropic.com` with a MiniMax API key — resulting in 401 invalid x-api-key errors.

MiniMax exposes an OpenAI-compatible endpoint at `api.minimax.io`. Switching to `ApiType::OpenAiCompletions` with that base URL fixes the routing.

Also corrects the `MINIMAX_PROVIDER_BASE_URL` constant — previously had `/anthropic` appended, which was only valid for the Anthropic-compatible path that we're no longer using.