### PR TITLE
feat(skills): workers discover skills on demand via read_skill tool

### DIFF
--- a/prompts/en/fragments/skills_channel.md.j2
+++ b/prompts/en/fragments/skills_channel.md.j2
@@ -1,15 +1,18 @@
 ## Available Skills
 
-You have access to the following skills. Skills contain specialized instructions for specific tasks. When a user's request matches a skill, spawn a worker to handle it and include the skill name in the task description so the worker knows which skill to follow.
+You have access to the following skills. When a user's request matches one or more skills, spawn a worker and pass the relevant skill names as `suggested_skills`. The worker will read the skills it needs automatically.
 
-To use a skill, spawn a worker with a task like: "Use the [skill-name] skill to [task]. Read the skill instructions at [path] first."
+**Do not include implementation details, tool invocations, or protocol instructions in the task description.** Describe *what* to do, not *how*. The worker reads the skill for the how.
+
+Example: `spawn_worker(task="Generate a 30-second downtempo track with these lyrics: ...", suggested_skills=["generate_music"])`
+
+You may suggest multiple skills if the task spans more than one: `suggested_skills=["github", "coding-agent"]`
 
 <available_skills>
 {%- for skill in skills %}
   <skill>
     <name>{{ skill.name }}</name>
     <description>{{ skill.description }}</description>
-    <location>{{ skill.location }}</location>
   </skill>
 {%- endfor %}
 </available_skills>

--- a/prompts/en/fragments/skills_worker.md.j2
+++ b/prompts/en/fragments/skills_worker.md.j2
@@ -1,5 +1,14 @@
-## Skill Instructions
+## Available Skills
 
-You are executing the **{{ skill_name }}** skill. Follow these instructions:
+You have access to the following skills. Before starting your task, scan the list and call `read_skill` for any skill that is relevant — you may read more than one.
 
-{{ skill_content }}
+Skills marked as **suggested** were recommended by the channel for this specific task. Read those first, then decide if any others apply.
+
+<available_skills>
+{%- for skill in skills %}
+  <skill{% if skill.suggested %} suggested="true"{% endif %}>
+    <name>{{ skill.name }}</name>
+    <description>{{ skill.description }}</description>
+  </skill>
+{%- endfor %}
+</available_skills>

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -204,6 +204,7 @@ impl Worker {
             self.deps.runtime_config.workspace_dir.clone(),
             self.deps.runtime_config.instance_dir.clone(),
             mcp_tools,
+            self.deps.runtime_config.clone(),
         );
 
         let routing = self.deps.runtime_config.routing.load();

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -242,13 +242,15 @@ impl PromptEngine {
         )
     }
 
-    /// Convenience method for rendering skills worker fragment.
-    pub fn render_skills_worker(&self, skill_name: &str, skill_content: &str) -> Result<String> {
+    /// Render the skills listing for a worker system prompt.
+    ///
+    /// Workers see all available skills with suggestions from the channel flagged.
+    /// They read whichever skills they need via the read_skill tool.
+    pub fn render_skills_worker(&self, skills: Vec<SkillInfo>) -> Result<String> {
         self.render(
             "fragments/skills_worker",
             context! {
-                skill_name => skill_name,
-                skill_content => skill_content,
+                skills => skills,
             },
         )
     }
@@ -429,6 +431,9 @@ pub struct SkillInfo {
     pub name: String,
     pub description: String,
     pub location: String,
+    /// Whether the spawning channel suggested this skill for the current task.
+    /// Workers should prioritise suggested skills but may read others too.
+    pub suggested: bool,
 }
 
 /// Information about a channel for template rendering.

--- a/src/tools/read_skill.rs
+++ b/src/tools/read_skill.rs
@@ -1,0 +1,85 @@
+//! Read skill tool — lets workers read the full content of a named skill.
+//!
+//! Workers see a listing of available skills (name + description) in their
+//! system prompt. When they decide a skill is relevant to their task, they
+//! call this tool to get the full instructions. This keeps the system prompt
+//! compact while still giving workers on-demand access to any skill.
+
+use crate::config::RuntimeConfig;
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Tool that lets a worker read the full content of a named skill.
+#[derive(Debug, Clone)]
+pub struct ReadSkillTool {
+    runtime_config: Arc<RuntimeConfig>,
+}
+
+impl ReadSkillTool {
+    pub fn new(runtime_config: Arc<RuntimeConfig>) -> Self {
+        Self { runtime_config }
+    }
+}
+
+/// Error type for read_skill tool.
+#[derive(Debug, thiserror::Error)]
+#[error("read_skill failed: {0}")]
+pub struct ReadSkillError(String);
+
+/// Arguments for read_skill tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReadSkillArgs {
+    /// Name of the skill to read. Must match a name from the <available_skills> listing.
+    pub name: String,
+}
+
+/// Output from read_skill tool.
+#[derive(Debug, Serialize)]
+pub struct ReadSkillOutput {
+    /// The full skill instructions.
+    pub content: String,
+}
+
+impl Tool for ReadSkillTool {
+    const NAME: &'static str = "read_skill";
+
+    type Error = ReadSkillError;
+    type Args = ReadSkillArgs;
+    type Output = ReadSkillOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Read the full instructions for a skill by name. \
+                Call this before starting any task that matches a skill in <available_skills>. \
+                You may read multiple skills if the task requires more than one."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The skill name to read, exactly as it appears in <available_skills>."
+                    }
+                },
+                "required": ["name"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let skills = self.runtime_config.skills.load();
+        match skills.get(&args.name) {
+            Some(skill) => Ok(ReadSkillOutput {
+                content: skill.content.clone(),
+            }),
+            None => Err(ReadSkillError(format!(
+                "skill '{}' not found. Available skills are listed in <available_skills> in your system prompt.",
+                args.name
+            ))),
+        }
+    }
+}

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -321,6 +321,7 @@ async fn dump_worker_context() {
         std::path::PathBuf::from("/tmp"),
         std::path::PathBuf::from("/tmp"),
         vec![],
+        deps.runtime_config.clone(),
     );
 
     let tool_defs = worker_tool_server
@@ -470,6 +471,7 @@ async fn dump_all_contexts() {
         std::path::PathBuf::from("/tmp"),
         std::path::PathBuf::from("/tmp"),
         vec![],
+        deps.runtime_config.clone(),
     );
     let worker_tool_defs = worker_tool_server.get_tool_defs(None).await.unwrap();
     let worker_tools_text = format_tool_defs(&worker_tool_defs);


### PR DESCRIPTION
Previously workers received a single skill's full content injected into their system prompt at spawn time (`skill="name"` on `spawn_worker`). Two problems with that approach:

1. Workers were locked to one skill chosen upfront by the channel
2. If a task turned out to need a different or additional skill, the worker had no way to get it

This replaces the `skill: Option<String>` parameter with `suggested_skills: Vec<String>` and adds a `read_skill` tool available to all workers. Workers now:

- See a listing of all available skills (with suggested ones flagged) in their system prompt
- Call `read_skill("name")` to fetch the full content of any skill on demand
- Can read multiple skills if the task turns out to need them

The `read_skill` tool reads directly from `RuntimeConfig.skills` (the in-memory ArcSwap), so it works within the worker's existing security boundary without needing file access.