### PR TITLE
feat: add Telegram message editing support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,15 @@ pub enum OutboundResponse {
     StreamStart,
     StreamChunk(String),
     StreamEnd,
+    /// Edit a previously sent message by ID.
+    /// Telegram: edits the text of a message using editMessageText.
+    /// Other platforms: falls back to sending a new message (no-op).
+    EditMessage {
+        /// The platform-specific message ID to edit.
+        message_id: String,
+        /// The new text content.
+        text: String,
+    },
     Status(StatusUpdate),
 }
 

--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -330,6 +330,11 @@ impl Messaging for DiscordAdapter {
             }
             // Slack-specific variants — graceful fallbacks for Discord
             OutboundResponse::RemoveReaction(_) => {} // no-op
+            // Telegram-specific: edit a previously sent message
+            OutboundResponse::EditMessage { .. } => {
+                // Discord doesn't support editing arbitrary messages via API in the same way
+                tracing::debug!("EditMessage not supported on Discord, message unchanged");
+            }
             OutboundResponse::Ephemeral { text, .. } => {
                 // Discord has no ephemeral equivalent here; send as regular text
                 if let Ok(channel_id) = self.extract_channel_id(message) {

--- a/src/messaging/slack.rs
+++ b/src/messaging/slack.rs
@@ -937,6 +937,12 @@ impl Messaging for SlackAdapter {
                     .context("failed to remove slack reaction")?;
             }
 
+            // Telegram-specific: edit a previously sent message
+            OutboundResponse::EditMessage { .. } => {
+                // Slack does not support editing arbitrary messages in the same way
+                tracing::debug!("EditMessage not supported on Slack, message unchanged");
+            }
+
             OutboundResponse::Ephemeral { text, user_id } => {
                 let thread_ts = extract_thread_ts(message);
                 let req = SlackApiChatPostEphemeralRequest::new(
@@ -1493,6 +1499,7 @@ fn variant_name(response: &OutboundResponse) -> &'static str {
         OutboundResponse::StreamStart => "StreamStart",
         OutboundResponse::StreamChunk(_) => "StreamChunk",
         OutboundResponse::StreamEnd => "StreamEnd",
+        OutboundResponse::EditMessage { .. } => "EditMessage",
         OutboundResponse::Status(_) => "Status",
     }
 }

--- a/src/messaging/twitch.rs
+++ b/src/messaging/twitch.rs
@@ -387,6 +387,10 @@ impl Messaging for TwitchAdapter {
             OutboundResponse::Reaction(_)
             | OutboundResponse::RemoveReaction(_)
             | OutboundResponse::Status(_) => {}
+            OutboundResponse::EditMessage { .. } => {
+                // Telegram-specific: edit a previously sent message
+                tracing::debug!("EditMessage not supported on Twitch");
+            }
             OutboundResponse::Ephemeral { text, .. } => {
                 // No ephemeral concept in Twitch — send as regular chat message
                 client

--- a/src/messaging/webchat.rs
+++ b/src/messaging/webchat.rs
@@ -92,7 +92,8 @@ impl Messaging for WebChatAdapter {
             | OutboundResponse::Ephemeral { .. }
             | OutboundResponse::ScheduledMessage { .. }
             | OutboundResponse::RichMessage { .. }
-            | OutboundResponse::Status(_) => return Ok(()),
+            | OutboundResponse::Status(_)
+            | OutboundResponse::EditMessage { .. } => return Ok(()),
         };
 
         let _ = tx.send(event).await;

--- a/src/messaging/webhook.rs
+++ b/src/messaging/webhook.rs
@@ -195,7 +195,8 @@ impl Messaging for WebhookAdapter {
             // Reactions, status updates, and remove-reaction aren't meaningful over webhook
             OutboundResponse::Reaction(_)
             | OutboundResponse::RemoveReaction(_)
-            | OutboundResponse::Status(_) => return Ok(()),
+            | OutboundResponse::Status(_)
+            | OutboundResponse::EditMessage { .. } => return Ok(()),
             // Slack-specific rich variants — fall back to plain text
             OutboundResponse::Ephemeral { text, .. } => WebhookResponse {
                 response_type: "text".into(),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -38,6 +38,7 @@ pub mod memory_save;
 pub mod react;
 pub mod read_skill;
 pub mod reply;
+pub mod edit_message;
 pub mod route;
 pub mod send_agent_message;
 pub mod send_file;
@@ -77,6 +78,7 @@ pub use memory_save::{
 pub use react::{ReactArgs, ReactError, ReactOutput, ReactTool};
 pub use read_skill::{ReadSkillArgs, ReadSkillError, ReadSkillOutput, ReadSkillTool};
 pub use reply::{RepliedFlag, ReplyArgs, ReplyError, ReplyOutput, ReplyTool, new_replied_flag};
+pub use edit_message::{EditedFlag, EditMessageArgs, EditMessageError, EditMessageOutput, EditMessageTool, new_edited_flag};
 pub use route::{RouteArgs, RouteError, RouteOutput, RouteTool};
 pub use send_agent_message::{
     SendAgentMessageArgs, SendAgentMessageError, SendAgentMessageOutput, SendAgentMessageTool,
@@ -233,9 +235,10 @@ pub async fn add_channel_tools(
     handle: &ToolServerHandle,
     state: ChannelState,
     response_tx: mpsc::Sender<OutboundResponse>,
-    conversation_id: impl Into<String>,
+    conversation_id: impl Into<String> + Clone,
     skip_flag: SkipFlag,
     replied_flag: RepliedFlag,
+    edited_flag: EditedFlag,
     cron_tool: Option<CronTool>,
     send_agent_message_tool: Option<SendAgentMessageTool>,
 ) -> Result<(), rig::tool::server::ToolServerError> {
@@ -255,6 +258,15 @@ pub async fn add_channel_tools(
             state.channel_id.clone(),
             replied_flag.clone(),
             agent_display_name,
+        ))
+        .await?;
+    handle
+        .add_tool(EditMessageTool::new(
+            response_tx.clone(),
+            conversation_id.clone(),
+            state.conversation_logger.clone(),
+            state.channel_id.clone(),
+            edited_flag.clone(),
         ))
         .await?;
     handle.add_tool(BranchTool::new(state.clone())).await?;

--- a/src/tools/edit_message.rs
+++ b/src/tools/edit_message.rs
@@ -1,0 +1,139 @@
+//! Tool for editing a previously sent Telegram message.
+
+use crate::conversation::ConversationLogger;
+use crate::{ChannelId, OutboundResponse};
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::mpsc;
+
+/// Shared flag between EditMessageTool and the channel event loop.
+pub type EditedFlag = Arc<AtomicBool>;
+
+/// Create a new edited flag (defaults to false).
+pub fn new_edited_flag() -> EditedFlag {
+    Arc::new(AtomicBool::new(false))
+}
+
+/// Tool for editing a previously sent Telegram message.
+///
+/// This tool allows the agent to edit a message it previously sent by specifying
+/// the message ID. Currently only supported on Telegram (uses editMessageText API).
+/// On other platforms, calls are logged but have no effect.
+#[derive(Debug, Clone)]
+pub struct EditMessageTool {
+    response_tx: mpsc::Sender<OutboundResponse>,
+    conversation_id: String,
+    conversation_logger: ConversationLogger,
+    channel_id: ChannelId,
+    edited_flag: EditedFlag,
+}
+
+impl EditMessageTool {
+    pub fn new(
+        response_tx: mpsc::Sender<OutboundResponse>,
+        conversation_id: impl Into<String>,
+        conversation_logger: ConversationLogger,
+        channel_id: ChannelId,
+        edited_flag: EditedFlag,
+    ) -> Self {
+        Self {
+            response_tx,
+            conversation_id: conversation_id.into(),
+            conversation_logger,
+            channel_id,
+            edited_flag,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Edit message failed: {0}")]
+pub struct EditMessageError(String);
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EditMessageArgs {
+    /// The message ID to edit. This is the Telegram message_id that was returned
+    /// when the original message was sent. You can find this in conversation logs
+    /// or by referencing a previous message.
+    pub message_id: String,
+    /// The new text content to replace the original message with.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EditMessageOutput {
+    pub success: bool,
+    pub conversation_id: String,
+    pub message_id: String,
+    pub content: String,
+}
+
+impl Tool for EditMessageTool {
+    const NAME: &'static str = "edit_message";
+
+    type Error = EditMessageError;
+    type Args = EditMessageArgs;
+    type Output = EditMessageOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        let parameters = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "message_id": {
+                    "type": "string",
+                    "description": "The Telegram message ID to edit. This is the numeric message_id from Telegram."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The new text content to replace the original message with. Supports markdown formatting."
+                }
+            },
+            "required": ["message_id", "content"]
+        });
+
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Edit a previously sent Telegram message by its message ID. Only works on Telegram; other platforms will log but not execute the edit.".to_string(),
+            parameters,
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        tracing::info!(
+            conversation_id = %self.conversation_id,
+            message_id = %args.message_id,
+            content_len = args.content.len(),
+            "edit_message tool called"
+        );
+
+        let response = OutboundResponse::EditMessage {
+            message_id: args.message_id.clone(),
+            text: args.content.clone(),
+        };
+
+        self.response_tx
+            .send(response)
+            .await
+            .map_err(|e| EditMessageError(format!("failed to send edit: {e}")))?;
+
+        // Mark the turn as handled so handle_agent_result skips any fallback
+        self.edited_flag.store(true, Ordering::Relaxed);
+
+        tracing::debug!(
+            conversation_id = %self.conversation_id,
+            message_id = %args.message_id,
+            "edit sent to outbound channel"
+        );
+
+        Ok(EditMessageOutput {
+            success: true,
+            conversation_id: self.conversation_id.clone(),
+            message_id: args.message_id,
+            content: args.content,
+        })
+    }
+}


### PR DESCRIPTION
This PR adds Telegram message editing support via editMessageText API. See: https://github.com/Marenz/spacebot/pull/new/feat/telegram-edit-message

> [!NOTE]
> ## Summary
> 
> This PR introduces message editing capability to Spacebot, enabling agents to modify previously sent Telegram messages. The implementation adds a new `edit_message` tool that allows agents to specify a message ID and new content, with Telegram-specific handling via the `editMessageText` API and graceful no-op fallbacks for other messaging platforms.
> 
> Key changes:
> A new `EditMessageTool` in `src/tools/edit_message.rs` that sends `OutboundResponse::EditMessage` events. A new `OutboundResponse::EditMessage` variant carrying `message_id` and `text` fields. Integration of an `edited_flag` through the channel event loop to track when a message edit occurs. Platform-specific implementations: Telegram uses `editMessageText` with automatic HTML fallback to plain text; Discord, Slack, Twitch, and Webhook adapters handle edits gracefully without errors. Updates to `src/agent/channel.rs` to thread the `edited_flag` through the agent turn and result handling.
> 
> <sub>Written by [Tembo](https://app.tembo.io) for commit [436fe39e](https://github.com/spacedriveapp/spacebot/commit/436fe39e826695f91794381fe3b7317a471cb129). This will update automatically on new commits.</sub>