### PR TITLE
add settings update controls and harden self-hosted update flow

### DIFF
--- a/docs/content/docs/(getting-started)/docker.mdx
+++ b/docs/content/docs/(getting-started)/docker.mdx
@@ -206,11 +206,23 @@ healthcheck:
 
 Spacebot checks for new releases on startup and every hour. When a new version is available, a banner appears in the web UI.
 
+You can also open **Settings → Updates** for update status, one-click apply controls (Docker), and manual command snippets.
+
+`latest` is supported and continues to receive updates (it tracks the rolling `full` image). Use explicit version tags only when you want controlled rollouts.
+
 ### Manual Update
 
 ```bash
-docker pull ghcr.io/spacedriveapp/spacebot:slim
-docker compose up -d
+docker compose pull spacebot
+docker compose up -d --force-recreate spacebot
+```
+
+If you're not using Compose:
+
+```bash
+docker pull ghcr.io/spacedriveapp/spacebot:latest
+docker stop spacebot && docker rm spacebot
+# re-run your original docker run command with the new image tag
 ```
 
 ### One-Click Update
@@ -235,6 +247,18 @@ services:
 When the socket is mounted, the update banner shows an **Update now** button that pulls the new image and recreates the container automatically. Your `/data` volume is preserved across updates.
 
 Without the socket mount, the banner still notifies you of new versions but you'll need to update manually.
+
+One-click updates are intended for containers running Spacebot release tags. If you're running a custom/self-built image, update by rebuilding your image and recreating the container.
+
+### Native / Source Builds
+
+If Spacebot is installed from source (`cargo install --path .` or a local release build), updates are manual:
+
+1. Pull latest source
+2. Rebuild/reinstall the binary
+3. Restart Spacebot
+
+The web UI still shows update availability, but it cannot rebuild binaries for native installs.
 
 ### Update API
 

--- a/docs/content/docs/(getting-started)/quickstart.mdx
+++ b/docs/content/docs/(getting-started)/quickstart.mdx
@@ -30,6 +30,17 @@ docker run -d \
 
 See [Docker deployment](/docs/docker) for image variants, compose files, and configuration options.
 
+To update Docker installs, pull and recreate the container:
+
+```bash
+docker pull ghcr.io/spacedriveapp/spacebot:latest
+docker stop spacebot && docker rm spacebot
+# re-run your docker run command
+```
+
+If you mount `/var/run/docker.sock`, the web UI can apply Docker updates directly from the update banner.
+You can also manage updates from **Settings → Updates** in the web UI.
+
 ## Build from source
 
 ### Prerequisites

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -197,6 +197,31 @@ healthcheck:
 - Graceful shutdown on `SIGTERM` (what `docker stop` sends). Drains active channels, closes database connections.
 - The PID file and Unix socket (used in daemon mode) are not created.
 
+## Updates
+
+Spacebot checks for new releases on startup and every hour. When a new version is available, a banner appears in the web UI.
+
+The web dashboard also includes **Settings → Updates** with status details, one-click controls (Docker), and manual command snippets.
+
+`latest` is supported and continues to receive updates (it tracks the rolling `full` image). Use explicit version tags only when you want controlled rollouts.
+
+### Manual Update
+
+```bash
+docker compose pull spacebot
+docker compose up -d --force-recreate spacebot
+```
+
+### One-Click Update
+
+Mount `/var/run/docker.sock` into the Spacebot container to enable the **Update now** button in the UI. Without the socket mount, update checks still work but apply is manual.
+
+One-click updates are intended for containers running Spacebot release tags. If you're running a custom/self-built image, rebuild your image and recreate the container.
+
+### Native / Source Builds
+
+If Spacebot is installed from source (`cargo install --path .` or a local release build), updates are manual: pull latest source, rebuild/reinstall, then restart.
+
 ## CI / Releases
 
 Images are built and pushed to `ghcr.io/spacedriveapp/spacebot` via GitHub Actions (`.github/workflows/release.yml`).

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -320,6 +320,8 @@ export interface UpdateStatus {
 	release_notes: string | null;
 	deployment: Deployment;
 	can_apply: boolean;
+	cannot_apply_reason: string | null;
+	docker_image: string | null;
 	checked_at: string | null;
 	error: string | null;
 }

--- a/interface/src/components/UpdateBanner.tsx
+++ b/interface/src/components/UpdateBanner.tsx
@@ -30,6 +30,8 @@ export function UpdateBanner() {
 	if (!data || !data.update_available || dismissed || data.deployment === "hosted") return null;
 
 	const isApplying = applyMutation.isPending;
+	const isDocker = data.deployment === "docker";
+	const isNative = data.deployment === "native";
 
 	return (
 		<div>
@@ -49,7 +51,7 @@ export function UpdateBanner() {
 					</a>
 				)}
 				<BannerActions>
-					{data.can_apply && (
+					{isDocker && data.can_apply && (
 						<Button
 							onClick={() => {
 								setApplyError(null);
@@ -62,9 +64,14 @@ export function UpdateBanner() {
 							Update now
 						</Button>
 					)}
-					{!data.can_apply && data.deployment === "docker" && (
+					{isDocker && !data.can_apply && (
 						<span className="text-xs text-ink-faint">
-							Mount docker.sock for one-click updates
+							{data.cannot_apply_reason ?? "Mount docker.sock for one-click updates"}
+						</span>
+					)}
+					{isNative && (
+						<span className="text-xs text-ink-faint">
+							{data.cannot_apply_reason ?? "Native/source installs update manually (rebuild + restart)"}
 						</span>
 					)}
 					<Button

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, type GlobalSettingsResponse } from "@/api/client";
+import { api, type GlobalSettingsResponse, type UpdateStatus } from "@/api/client";
 import { Button, Input, SettingSidebarButton, Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, Select, SelectTrigger, SelectValue, SelectContent, SelectItem, Toggle } from "@/ui";
 import { useSearch, useNavigate } from "@tanstack/react-router";
 import { ChannelSettingCard, DisabledChannelCard } from "@/components/ChannelSettingCard";
@@ -11,7 +11,7 @@ import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
 import { parse as parseToml } from "smol-toml";
 
-type SectionId = "providers" | "channels" | "api-keys" | "server" | "opencode" | "worker-logs" | "config-file";
+type SectionId = "providers" | "channels" | "api-keys" | "server" | "opencode" | "worker-logs" | "updates" | "config-file";
 
 const SECTIONS = [
 	{
@@ -49,6 +49,12 @@ const SECTIONS = [
 		label: "Worker Logs",
 		group: "system" as const,
 		description: "Worker execution logging",
+	},
+	{
+		id: "updates" as const,
+		label: "Updates",
+		group: "system" as const,
+		description: "Release checks and update controls",
 	},
 	{
 		id: "config-file" as const,
@@ -658,6 +664,8 @@ export function Settings() {
 						<OpenCodeSection settings={globalSettings} isLoading={globalSettingsLoading} />
 					) : activeSection === "worker-logs" ? (
 						<WorkerLogsSection settings={globalSettings} isLoading={globalSettingsLoading} />
+					) : activeSection === "updates" ? (
+						<UpdatesSection />
 					) : activeSection === "config-file" ? (
 						<ConfigFileSection />
 					) : null}
@@ -1418,6 +1426,309 @@ function OpenCodeSection({ settings, isLoading }: GlobalSettingsSectionProps) {
 					<Button onClick={handleSave} loading={updateMutation.isPending}>
 						Save Changes
 					</Button>
+				</div>
+			)}
+
+			{message && (
+				<div
+					className={`mt-4 rounded-md border px-3 py-2 text-sm ${message.type === "success"
+							? "border-green-500/20 bg-green-500/10 text-green-400"
+							: "border-red-500/20 bg-red-500/10 text-red-400"
+						}`}
+				>
+					{message.text}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function formatCheckedAt(checkedAt: string | null): string {
+	if (!checkedAt) return "Never";
+	const timestamp = new Date(checkedAt);
+	if (Number.isNaN(timestamp.getTime())) return checkedAt;
+	return timestamp.toLocaleString();
+}
+
+function pullableDockerImage(image: string | null): string {
+	if (!image) return "ghcr.io/spacedriveapp/spacebot:latest";
+	return image.split("@")[0] ?? image;
+}
+
+function UpdatesSection() {
+	const queryClient = useQueryClient();
+	const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+	const [copiedBlock, setCopiedBlock] = useState<string | null>(null);
+
+	const { data, isLoading, isFetching } = useQuery<UpdateStatus>({
+		queryKey: ["update-check"],
+		queryFn: api.updateCheck,
+		staleTime: 30_000,
+		refetchInterval: 300_000,
+	});
+
+	const checkNowMutation = useMutation({
+		mutationFn: api.updateCheckNow,
+		onSuccess: (status) => {
+			queryClient.setQueryData(["update-check"], status);
+			if (status.update_available && status.latest_version) {
+				setMessage({
+					text: `Update ${status.latest_version} is available.`,
+					type: "success",
+				});
+			} else {
+				setMessage({ text: "No newer release found.", type: "success" });
+			}
+		},
+		onError: (error) => {
+			setMessage({ text: `Failed to check updates: ${error.message}`, type: "error" });
+		},
+	});
+
+	const applyMutation = useMutation({
+		mutationFn: api.updateApply,
+		onSuccess: (result) => {
+			if (result.status === "updating") {
+				setMessage({
+					text: "Applying update. This instance will restart in a few seconds.",
+					type: "success",
+				});
+				setTimeout(() => {
+					queryClient.invalidateQueries({ queryKey: ["update-check"] });
+				}, 3000);
+				return;
+			}
+
+			setMessage({ text: result.error ?? "Update failed", type: "error" });
+		},
+		onError: (error) => {
+			setMessage({ text: `Failed to apply update: ${error.message}`, type: "error" });
+		},
+	});
+
+	const handleCopy = async (label: string, content: string) => {
+		try {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(content);
+			} else {
+				const textarea = document.createElement("textarea");
+				textarea.value = content;
+				textarea.setAttribute("readonly", "");
+				textarea.style.position = "absolute";
+				textarea.style.left = "-9999px";
+				document.body.appendChild(textarea);
+				textarea.select();
+				document.execCommand("copy");
+				document.body.removeChild(textarea);
+			}
+			setCopiedBlock(label);
+			setTimeout(() => setCopiedBlock((current) => (current === label ? null : current)), 1200);
+		} catch (error: any) {
+			setMessage({ text: `Failed to copy commands: ${error.message}`, type: "error" });
+		}
+	};
+
+	const deployment = data?.deployment ?? "native";
+	const deploymentLabel = deployment === "docker"
+		? "Docker"
+		: deployment === "hosted"
+			? "Hosted"
+			: "Native";
+
+	const dockerComposeCommands = [
+		"docker compose pull spacebot",
+		"docker compose up -d --force-recreate spacebot",
+	];
+
+	const dockerRunCommands = [
+		`docker pull ${pullableDockerImage(data?.docker_image ?? null)}`,
+		"docker stop spacebot && docker rm spacebot",
+		"# re-run your docker run command",
+	];
+
+	const nativeCommands = [
+		"git pull",
+		"cargo install --path . --force",
+		"spacebot restart",
+	];
+
+	return (
+		<div className="mx-auto max-w-2xl px-6 py-6">
+			<div className="mb-6">
+				<h2 className="font-plex text-sm font-semibold text-ink">Updates</h2>
+				<p className="mt-1 text-sm text-ink-dull">
+					Check release status, trigger one-click Docker updates, and copy manual update commands.
+				</p>
+			</div>
+
+			{isLoading ? (
+				<div className="flex items-center gap-2 text-ink-dull">
+					<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+					Loading update status...
+				</div>
+			) : (
+				<div className="flex flex-col gap-4">
+					<div className="rounded-lg border border-app-line bg-app-box p-4">
+						<div className="flex items-center justify-between gap-4">
+							<div>
+								<p className="text-sm font-medium text-ink">Release Status</p>
+								<p className="mt-0.5 text-sm text-ink-dull">
+									{data?.update_available
+										? `Update ${data.latest_version ?? ""} is available`
+										: "You're running the latest available release"}
+								</p>
+							</div>
+							<Button
+								onClick={() => {
+									setMessage(null);
+									checkNowMutation.mutate();
+								}}
+								loading={checkNowMutation.isPending || isFetching}
+								size="sm"
+								variant="outline"
+							>
+								Check now
+							</Button>
+						</div>
+
+						<div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+							<div>
+								<p className="text-ink-faint">Deployment</p>
+								<p className="text-ink">{deploymentLabel}</p>
+							</div>
+							<div>
+								<p className="text-ink-faint">Current version</p>
+								<p className="text-ink">{data?.current_version ?? "Unknown"}</p>
+							</div>
+							<div>
+								<p className="text-ink-faint">Latest release</p>
+								<p className="text-ink">{data?.latest_version ?? "Unknown"}</p>
+							</div>
+							<div>
+								<p className="text-ink-faint">Last checked</p>
+								<p className="text-ink">{formatCheckedAt(data?.checked_at ?? null)}</p>
+							</div>
+						</div>
+
+						{data?.docker_image && (
+							<div className="mt-3 rounded border border-app-line/70 bg-app-darkBox/30 px-3 py-2">
+								<p className="text-tiny text-ink-faint">Container image</p>
+								<p className="font-mono text-xs text-ink">{data.docker_image}</p>
+							</div>
+						)}
+
+						{data?.release_url && (
+							<a
+								href={data.release_url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="mt-3 inline-block text-sm text-accent hover:underline"
+							>
+								View release notes
+							</a>
+						)}
+					</div>
+
+					{deployment === "docker" && (
+						<div className="rounded-lg border border-app-line bg-app-box p-4">
+							<div className="flex items-center justify-between gap-3">
+								<div>
+									<p className="text-sm font-medium text-ink">One-Click Docker Update</p>
+									<p className="mt-0.5 text-sm text-ink-dull">
+										Pull and swap to the latest release image from the web UI.
+									</p>
+								</div>
+								<Button
+									onClick={() => {
+										setMessage(null);
+										applyMutation.mutate();
+									}}
+									disabled={!data?.can_apply || !data?.update_available}
+									loading={applyMutation.isPending}
+									size="sm"
+								>
+									Update now
+								</Button>
+							</div>
+							{!data?.update_available && (
+								<p className="mt-3 text-xs text-ink-faint">No update available yet.</p>
+							)}
+							{!data?.can_apply && data?.cannot_apply_reason && (
+								<p className="mt-3 text-xs text-yellow-300">{data.cannot_apply_reason}</p>
+							)}
+							{data?.can_apply && (
+								<p className="mt-3 text-xs text-ink-faint">
+									Applying an update restarts this instance. The UI should reconnect in 10-30 seconds.
+								</p>
+							)}
+						</div>
+					)}
+
+					<div className="rounded-lg border border-app-line bg-app-box p-4">
+						<p className="text-sm font-medium text-ink">Manual Update Commands</p>
+						<p className="mt-0.5 text-sm text-ink-dull">
+							Use these when one-click update is unavailable or when you prefer manual rollouts.
+						</p>
+
+						{deployment === "docker" && (
+							<div className="mt-3 flex flex-col gap-3">
+								<div className="rounded border border-app-line/70 bg-app-darkBox/30 p-3">
+									<div className="mb-2 flex items-center justify-between">
+										<p className="text-xs font-medium uppercase tracking-wider text-ink-faint">Docker Compose</p>
+										<Button
+											onClick={() => handleCopy("compose", dockerComposeCommands.join("\n"))}
+											variant="ghost"
+											size="sm"
+										>
+											{copiedBlock === "compose" ? "Copied" : "Copy"}
+										</Button>
+									</div>
+									<pre className="overflow-x-auto text-xs text-ink"><code>{dockerComposeCommands.join("\n")}</code></pre>
+								</div>
+								<div className="rounded border border-app-line/70 bg-app-darkBox/30 p-3">
+									<div className="mb-2 flex items-center justify-between">
+										<p className="text-xs font-medium uppercase tracking-wider text-ink-faint">docker run</p>
+										<Button
+											onClick={() => handleCopy("docker-run", dockerRunCommands.join("\n"))}
+											variant="ghost"
+											size="sm"
+										>
+											{copiedBlock === "docker-run" ? "Copied" : "Copy"}
+										</Button>
+									</div>
+									<pre className="overflow-x-auto text-xs text-ink"><code>{dockerRunCommands.join("\n")}</code></pre>
+								</div>
+							</div>
+						)}
+
+						{deployment === "native" && (
+							<div className="mt-3 rounded border border-app-line/70 bg-app-darkBox/30 p-3">
+								<div className="mb-2 flex items-center justify-between">
+									<p className="text-xs font-medium uppercase tracking-wider text-ink-faint">Source Install</p>
+									<Button
+										onClick={() => handleCopy("native", nativeCommands.join("\n"))}
+										variant="ghost"
+										size="sm"
+									>
+										{copiedBlock === "native" ? "Copied" : "Copy"}
+									</Button>
+								</div>
+								<pre className="overflow-x-auto text-xs text-ink"><code>{nativeCommands.join("\n")}</code></pre>
+							</div>
+						)}
+
+						{deployment === "hosted" && (
+							<p className="mt-3 text-sm text-ink-dull">
+								Hosted instances are updated through platform rollouts.
+							</p>
+						)}
+					</div>
+
+					{data?.error && (
+						<div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+							Update check error: {data.error}
+						</div>
+					)}
 				</div>
 			)}
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -34,7 +34,37 @@ impl Deployment {
         match std::env::var("SPACEBOT_DEPLOYMENT").as_deref() {
             Ok("docker") => Deployment::Docker,
             Ok("hosted") => Deployment::Hosted,
+            _ if is_running_in_container() => Deployment::Docker,
             _ => Deployment::Native,
+        }
+    }
+}
+
+fn is_running_in_container() -> bool {
+    if std::path::Path::new("/.dockerenv").exists() {
+        return true;
+    }
+
+    let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") else {
+        return false;
+    };
+
+    ["docker", "containerd", "kubepods", "podman"]
+        .iter()
+        .any(|marker| cgroup.contains(marker))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImageVariant {
+    Slim,
+    Full,
+}
+
+impl ImageVariant {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Slim => "slim",
+            Self::Full => "full",
         }
     }
 }
@@ -50,6 +80,10 @@ pub struct UpdateStatus {
     pub deployment: Deployment,
     /// Whether the Docker socket is accessible (enables one-click update).
     pub can_apply: bool,
+    /// Human-readable reason when one-click apply is unavailable.
+    pub cannot_apply_reason: Option<String>,
+    /// Current container image reference when running in Docker.
+    pub docker_image: Option<String>,
     pub checked_at: Option<chrono::DateTime<chrono::Utc>>,
     pub error: Option<String>,
 }
@@ -64,6 +98,8 @@ impl Default for UpdateStatus {
             release_notes: None,
             deployment: Deployment::detect(),
             can_apply: false,
+            cannot_apply_reason: None,
+            docker_image: None,
             checked_at: None,
             error: None,
         }
@@ -75,8 +111,24 @@ pub type SharedUpdateStatus = Arc<ArcSwap<UpdateStatus>>;
 
 pub fn new_shared_status() -> SharedUpdateStatus {
     let mut status = UpdateStatus::default();
-    // Probe Docker socket availability on init
-    status.can_apply = status.deployment == Deployment::Docker && docker_socket_available();
+    match status.deployment {
+        Deployment::Docker => {
+            status.can_apply = docker_socket_available();
+            if !status.can_apply {
+                status.cannot_apply_reason =
+                    Some("Mount /var/run/docker.sock to enable one-click updates.".to_string());
+            }
+        }
+        Deployment::Native => {
+            status.cannot_apply_reason =
+                Some("Native/source installs update manually (rebuild + restart).".to_string());
+        }
+        Deployment::Hosted => {
+            status.cannot_apply_reason = Some(
+                "Hosted instances are updated by platform rollout, not self-service.".to_string(),
+            );
+        }
+    }
     Arc::new(ArcSwap::from_pointee(status))
 }
 
@@ -93,10 +145,13 @@ pub async fn check_for_update(status: &SharedUpdateStatus) {
     let result = fetch_latest_release().await;
 
     let current = status.load();
+    let capability = detect_apply_capability(current.deployment).await;
     let mut next = UpdateStatus {
         current_version: CURRENT_VERSION.to_string(),
         deployment: current.deployment,
-        can_apply: current.can_apply,
+        can_apply: capability.can_apply,
+        cannot_apply_reason: capability.cannot_apply_reason,
+        docker_image: capability.docker_image,
         checked_at: Some(chrono::Utc::now()),
         ..Default::default()
     };
@@ -182,6 +237,90 @@ fn docker_socket_available() -> bool {
     std::path::Path::new("/var/run/docker.sock").exists()
 }
 
+#[derive(Debug, Clone)]
+struct ApplyCapability {
+    can_apply: bool,
+    cannot_apply_reason: Option<String>,
+    docker_image: Option<String>,
+}
+
+async fn detect_apply_capability(deployment: Deployment) -> ApplyCapability {
+    match deployment {
+        Deployment::Native => ApplyCapability {
+            can_apply: false,
+            cannot_apply_reason: Some(
+                "Native/source installs update manually (rebuild + restart).".to_string(),
+            ),
+            docker_image: None,
+        },
+        Deployment::Hosted => ApplyCapability {
+            can_apply: false,
+            cannot_apply_reason: Some(
+                "Hosted instances are updated by platform rollout, not self-service.".to_string(),
+            ),
+            docker_image: None,
+        },
+        Deployment::Docker => {
+            if !docker_socket_available() {
+                return ApplyCapability {
+                    can_apply: false,
+                    cannot_apply_reason: Some(
+                        "Mount /var/run/docker.sock to enable one-click updates.".to_string(),
+                    ),
+                    docker_image: None,
+                };
+            }
+
+            let docker = match bollard::Docker::connect_with_local_defaults() {
+                Ok(client) => client,
+                Err(error) => {
+                    return ApplyCapability {
+                        can_apply: false,
+                        cannot_apply_reason: Some(format!(
+                            "Docker socket is present but cannot be opened: {error}"
+                        )),
+                        docker_image: None,
+                    };
+                }
+            };
+
+            if let Err(error) = docker.ping().await {
+                return ApplyCapability {
+                    can_apply: false,
+                    cannot_apply_reason: Some(format!(
+                        "Docker socket is mounted but engine is not reachable: {error}"
+                    )),
+                    docker_image: None,
+                };
+            }
+
+            let docker_image = detect_current_docker_image(&docker).await.ok();
+
+            ApplyCapability {
+                can_apply: true,
+                cannot_apply_reason: None,
+                docker_image,
+            }
+        }
+    }
+}
+
+async fn detect_current_docker_image(docker: &bollard::Docker) -> anyhow::Result<String> {
+    let container_id = get_own_container_id()?;
+    let container_info = docker
+        .inspect_container(&container_id, None)
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to inspect container: {error}"))?;
+
+    let image = container_info
+        .config
+        .as_ref()
+        .and_then(|config| config.image.as_deref())
+        .ok_or_else(|| anyhow::anyhow!("could not determine current image"))?;
+
+    Ok(image.to_string())
+}
+
 /// Apply a Docker self-update: pull the new image, recreate this container.
 ///
 /// This function does not return on success — the current container is stopped
@@ -195,8 +334,14 @@ pub async fn apply_docker_update(status: &SharedUpdateStatus) -> anyhow::Result<
     if current.deployment != Deployment::Docker {
         anyhow::bail!("not running in Docker");
     }
-    if !current.can_apply {
-        anyhow::bail!("Docker socket not available");
+    let capability = detect_apply_capability(current.deployment).await;
+    if !capability.can_apply {
+        anyhow::bail!(
+            "{}",
+            capability
+                .cannot_apply_reason
+                .unwrap_or_else(|| "Docker socket not available".to_string())
+        );
     }
 
     let latest_version = current
@@ -229,7 +374,8 @@ pub async fn apply_docker_update(status: &SharedUpdateStatus) -> anyhow::Result<
 
     // Resolve the target image: same base name, new version tag.
     // e.g. ghcr.io/spacedriveapp/spacebot:v0.1.0-slim -> ghcr.io/spacedriveapp/spacebot:v0.2.0-slim
-    let target_image = resolve_target_image(&current_image, latest_version);
+    let runtime_variant = detect_runtime_image_variant();
+    let target_image = resolve_target_image(&current_image, latest_version, runtime_variant);
 
     tracing::info!(
         current_image = %current_image,
@@ -255,6 +401,15 @@ pub async fn apply_docker_update(status: &SharedUpdateStatus) -> anyhow::Result<
                 }
             }
             Err(error) => {
+                let error_text = error.to_string();
+                if error_text.contains("manifest unknown")
+                    || error_text.contains("not found")
+                    || error_text.contains("pull access denied")
+                {
+                    anyhow::bail!(
+                        "image pull failed for {target_image}. this image does not have Spacebot release tags; rebuild and redeploy manually"
+                    );
+                }
                 anyhow::bail!("image pull failed: {}", error);
             }
         }
@@ -412,17 +567,60 @@ fn get_own_container_id() -> anyhow::Result<String> {
 /// Examples:
 ///   - `ghcr.io/spacedriveapp/spacebot:v0.1.0-slim` + `0.2.0` -> `ghcr.io/spacedriveapp/spacebot:v0.2.0-slim`
 ///   - `ghcr.io/spacedriveapp/spacebot:slim` + `0.2.0` -> `ghcr.io/spacedriveapp/spacebot:v0.2.0-slim`
-///   - `ghcr.io/spacedriveapp/spacebot:latest` + `0.2.0` -> `ghcr.io/spacedriveapp/spacebot:v0.2.0-slim`
-fn resolve_target_image(current_image: &str, new_version: &str) -> String {
-    let (base, tag) = match current_image.rsplit_once(':') {
-        Some((b, t)) => (b, t),
-        None => (current_image, "latest"),
+///   - `ghcr.io/spacedriveapp/spacebot:latest` + `0.2.0` + full runtime -> `ghcr.io/spacedriveapp/spacebot:v0.2.0-full`
+fn resolve_target_image(
+    current_image: &str,
+    new_version: &str,
+    runtime_variant: Option<ImageVariant>,
+) -> String {
+    let image_without_digest = current_image
+        .split_once('@')
+        .map(|(name, _)| name)
+        .unwrap_or(current_image);
+
+    let last_slash = image_without_digest.rfind('/');
+    let last_colon = image_without_digest.rfind(':');
+
+    let (base, tag) = match last_colon {
+        Some(colon) if last_slash.map_or(true, |slash| colon > slash) => (
+            &image_without_digest[..colon],
+            &image_without_digest[colon + 1..],
+        ),
+        _ => (image_without_digest, "latest"),
     };
 
-    // Determine the variant suffix (slim, full, or default to slim)
-    let variant = if tag.contains("full") { "full" } else { "slim" };
+    let variant = detect_variant_from_tag(tag)
+        .or(runtime_variant)
+        .unwrap_or(ImageVariant::Slim);
 
-    format!("{}:v{}-{}", base, new_version, variant)
+    format!("{}:v{}-{}", base, new_version, variant.as_str())
+}
+
+fn detect_variant_from_tag(tag: &str) -> Option<ImageVariant> {
+    if tag.contains("full") {
+        Some(ImageVariant::Full)
+    } else if tag.contains("slim") {
+        Some(ImageVariant::Slim)
+    } else {
+        None
+    }
+}
+
+fn detect_runtime_image_variant() -> Option<ImageVariant> {
+    if let Ok(chrome_path) = std::env::var("CHROME_PATH")
+        && !chrome_path.is_empty()
+        && std::path::Path::new(&chrome_path).exists()
+    {
+        return Some(ImageVariant::Full);
+    }
+
+    if std::path::Path::new("/usr/bin/chromium").exists()
+        || std::path::Path::new("/usr/bin/chromium-browser").exists()
+    {
+        return Some(ImageVariant::Full);
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -440,20 +638,68 @@ mod tests {
     #[test]
     fn test_resolve_target_image() {
         assert_eq!(
-            resolve_target_image("ghcr.io/spacedriveapp/spacebot:v0.1.0-slim", "0.2.0"),
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:v0.1.0-slim",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
             "ghcr.io/spacedriveapp/spacebot:v0.2.0-slim"
         );
         assert_eq!(
-            resolve_target_image("ghcr.io/spacedriveapp/spacebot:v0.1.0-full", "0.2.0"),
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:v0.1.0-full",
+                "0.2.0",
+                Some(ImageVariant::Slim)
+            ),
             "ghcr.io/spacedriveapp/spacebot:v0.2.0-full"
         );
         assert_eq!(
-            resolve_target_image("ghcr.io/spacedriveapp/spacebot:latest", "0.2.0"),
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:latest",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
+            "ghcr.io/spacedriveapp/spacebot:v0.2.0-full"
+        );
+        assert_eq!(
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:latest",
+                "0.2.0",
+                Some(ImageVariant::Slim)
+            ),
             "ghcr.io/spacedriveapp/spacebot:v0.2.0-slim"
         );
         assert_eq!(
-            resolve_target_image("ghcr.io/spacedriveapp/spacebot:slim", "0.2.0"),
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:slim",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
             "ghcr.io/spacedriveapp/spacebot:v0.2.0-slim"
+        );
+        assert_eq!(
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot:v0.1.0",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
+            "ghcr.io/spacedriveapp/spacebot:v0.2.0-full"
+        );
+        assert_eq!(
+            resolve_target_image(
+                "registry.local:5000/spacebot",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
+            "registry.local:5000/spacebot:v0.2.0-full"
+        );
+        assert_eq!(
+            resolve_target_image(
+                "ghcr.io/spacedriveapp/spacebot@sha256:abcdef",
+                "0.2.0",
+                Some(ImageVariant::Full)
+            ),
+            "ghcr.io/spacedriveapp/spacebot:v0.2.0-full"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated **Settings → Updates** tab with release status, check-now, one-click apply (Docker), and copyable manual update commands by deployment type
- expand update status metadata with `cannot_apply_reason` and `docker_image` so UI messaging is explicit instead of guessy
- fix Docker update target resolution to preserve runtime variant (`full` vs `slim`) and improve apply-path checks/error reporting for socket/engine/tag issues
- update Docker + quickstart docs to clarify `latest` behavior and point users to the new Updates settings panel

## Code Example
```ts
export interface UpdateStatus {
  current_version: string;
  latest_version: string | null;
  update_available: boolean;
  can_apply: boolean;
  cannot_apply_reason: string | null;
  docker_image: string | null;
}
```

## Testing
- `cargo test update::tests`
- `bun run --cwd interface build`

> [!NOTE]
> A new **Updates** settings panel consolidates release checks and update controls in one place. The panel shows deployment type, current version, latest release, check timestamps, and one-click Docker apply when the socket is mounted. Docker Compose and `docker run` command snippets are copyable for manual rollouts. Native/source builds default to manual updates with clear messaging. Error reasons (missing socket, unreachable engine, custom images) are now explicit in the UI. Tests added for image variant detection and tag resolution.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [befde3c](https://github.com/spacedriveapp/spacebot/commit/befde3c57efdf0d829319ad76069a0602568ea39). This will update automatically on new commits.</sub>