### PR TITLE
fix: prevent Settings dialog deformation on long error messages

### DIFF
--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -509,7 +509,7 @@ export function Settings() {
 					</div>
 					{testResult && (
 						<div
-							className={`rounded-md border px-3 py-2 text-sm ${
+							className={`rounded-md border px-3 py-2 text-sm break-all ${
 								testResult.success
 									? "border-green-500/20 bg-green-500/10 text-green-400"
 									: "border-red-500/20 bg-red-500/10 text-red-400"
@@ -523,7 +523,7 @@ export function Settings() {
 					)}
 					{message && (
 						<div
-							className={`rounded-md border px-3 py-2 text-sm ${
+							className={`rounded-md border px-3 py-2 text-sm break-all ${
 								message.type === "success"
 									? "border-green-500/20 bg-green-500/10 text-green-400"
 									: "border-red-500/20 bg-red-500/10 text-red-400"


### PR DESCRIPTION
Title: fix: prevent error message overflow in API modal

Description: This PR fixes a UI bug where long error strings, such as billing URLs, were overflowing the modal's horizontal boundaries. By applying word-break: break-all, we ensure that the container respects its parent width regardless of the text length.

<img width="1065" height="654" alt="image" src="https://github.com/user-attachments/assets/427de7c1-aefb-4637-913f-470282ebdfec" />

<img width="853" height="698" alt="image" src="https://github.com/user-attachments/assets/0cd9d7c4-a79e-43e4-bb3c-ea3e497bc72b" />

> [!NOTE]
> Adds `break-all` CSS class to two message container elements in the Settings component to prevent long error messages from overflowing their parent container. This is a targeted fix that applies to both success and error message displays in the Settings dialog.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [d487269](https://github.com/spacedriveapp/spacebot/commit/d487269e2149e53d56e46d287f8955c398596a77).</sub>