### PR TITLE
add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
   <a href="https://discord.gg/gTaF2Z44f5">
     <img src="https://img.shields.io/discord/949090953497567312?label=Discord&color=5865F2" />
   </a>
+
+  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/spacedriveapp/spacebot)
 </p>
 
 <p align="center">


### PR DESCRIPTION
badge provides auto-refresh for the deepwiki index to provide up-to-date documentation you can talk to