### PR TITLE
fix: log cross-channel messages to destination channel history

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -266,10 +266,18 @@ pub async fn add_channel_tools(
     handle.add_tool(SpawnWorkerTool::new(state.clone())).await?;
     handle.add_tool(RouteTool::new(state.clone())).await?;
     if let Some(messaging_manager) = &state.deps.messaging_manager {
+        let send_message_display_name = state
+            .deps
+            .agent_names
+            .get(state.deps.agent_id.as_ref())
+            .cloned()
+            .unwrap_or_else(|| state.deps.agent_id.to_string());
         handle
             .add_tool(SendMessageTool::new(
                 messaging_manager.clone(),
                 state.channel_store.clone(),
+                state.conversation_logger.clone(),
+                send_message_display_name,
             ))
             .await?;
     }


### PR DESCRIPTION
## Summary

- Messages sent via `send_message_to_another_channel` were delivered to the platform (Discord, Telegram, etc.) but never recorded in `conversation_messages` — so the bot couldn't see what it sent when it next processed that channel
- Pass `ConversationLogger` and agent display name into `SendMessageTool`, call `log_bot_message_with_name()` with the **destination channel's ID** after a successful broadcast
- Email targets are excluded since they don't map to a channel with a transcript

## What happened

The bot used `send_message_to_another_channel` to message James on Telegram about Abdul's AI experiment. When James replied, the bot had no record of what it had sent — the message wasn't in the Telegram channel's `conversation_messages` table. So it responded with zero context about the cross-channel message, couldn't relay the reply back to Abdul, and confabulated when confronted.

## Changes

### `src/tools/send_message_to_another_channel.rs`
- Added `ConversationLogger` and `agent_display_name` fields to `SendMessageTool`
- After successful broadcast to a channel target, log the message to the destination channel's conversation history (fire-and-forget, same pattern as the `reply` tool)
- `.clone()` on `args.message` before passing to broadcast so we can log it after

### `src/tools.rs`
- Updated `SendMessageTool::new()` call in `add_channel_tools()` to pass `state.conversation_logger` and resolved agent display name