### PR TITLE
fix: improve openai-chatgpt provider reliability for long-running Codex tasks

### DIFF
--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -129,8 +129,14 @@ pub fn is_retriable_error(error_message: &str) -> bool {
         || lower.contains("connection")
         // Empty/malformed responses are transient provider issues
         || lower.contains("empty response")
+        || lower.contains("empty output array")
         || lower.contains("failed to read response body")
         || lower.contains("error decoding response body")
+        // SSE stream failures (truncated, incomplete, server closed early)
+        || lower.contains("stream was empty")
+        || lower.contains("stream ended without")
+        || lower.contains("stream may have been truncated")
+        || lower.contains("model run incomplete")
 }
 
 /// Whether a completion error indicates context window overflow.


### PR DESCRIPTION
## Summary

Fixes user-reported failures where ChatGPT Pro OAuth (`openai-chatgpt` provider) returns empty responses or silently fails on longer coding tasks (reported by bergabman).

## Root Cause

Multiple compounding issues in the `openai-chatgpt` provider path:
- **120s global HTTP timeout** was killing SSE streams mid-response for long Codex tasks
- **No OAuth token refresh on 401** — if the token expired mid-session or was revoked server-side, requests would silently fail with "empty response" instead of refreshing and retrying
- **Brittle SSE parsing** — only looked for `response.completed`, gave opaque errors on truncated/failed/empty streams
- **Stream failures not retriable** — partial stream errors were treated as hard failures instead of being retried

## Changes

### 1. OAuth 401 → refresh → replay (`model.rs`, `manager.rs`)
- Added `force_refresh_openai_token()` to `LlmManager` that bypasses the expiry check
- `attempt_completion` now detects 401/403 auth errors from OAuth providers (`openai-chatgpt`, `anthropic`), force-refreshes the token, and replays the request once
- On refresh failure, returns a clear error directing the user to re-authenticate

### 2. Per-request 600s timeout for Codex SSE (`model.rs`)
- ChatGPT Codex requests now use a 600s per-request timeout (overriding the 120s client default) since coding tasks can run for several minutes
- Timeout errors now include the deadline value and a hint that the model may still be generating

### 3. Defensive SSE stream parsing (`model.rs`)
- Handles `response.failed` and `response.incomplete` events with server-side error extraction
- Falls back to the last response-bearing event when `response.completed` is missing (partial recovery)
- Distinguishes empty streams (0 events — likely auth/network) from truncated streams (events received but no terminal event)

### 4. Stream failures classified as retriable (`routing.rs`)
- Added patterns: `stream was empty`, `stream ended without`, `stream may have been truncated`, `model run incomplete`, `empty output array`

### 5. Better error messages for empty responses (`model.rs`)
- Distinguishes incomplete model runs (with reason), empty output arrays, and output items with no usable content
- Replaces the opaque "empty response from OpenAI Responses API" with actionable diagnostics

## Testing

- `cargo fmt` / `cargo check` / `cargo clippy` — clean
- All `llm::model` unit tests pass
- `gate-pr` passes (formatting, compile, clippy, lib tests)