### PR TITLE
fix: infer default routing from configured provider

### DIFF
--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -387,6 +387,10 @@ pub(super) async fn update_agent_config(
 
     match crate::config::Config::load_from_path(&config_path) {
         Ok(new_config) => {
+            // Keep in-memory defaults fresh so newly created agents inherit
+            // the latest routing values.
+            state.set_defaults_config(new_config.defaults.clone()).await;
+
             let runtime_configs = state.runtime_configs.load();
             let mcp_managers = state.mcp_managers.load();
             if let (Some(rc), Some(mcp_manager)) = (

--- a/src/main.rs
+++ b/src/main.rs
@@ -1077,6 +1077,10 @@ async fn run(
                     Ok(new_config)
                         if has_provider_credentials(&new_config.llm, &new_config.instance_dir) =>
                     {
+                        // Refresh in-memory defaults so newly created agents
+                        // inherit the latest routing from the updated config.
+                        api_state.set_defaults_config(new_config.defaults.clone()).await;
+
                         // Rebuild LlmManager with the new keys
                         match spacebot::llm::LlmManager::with_instance_dir(
                             new_config.llm.clone(),


### PR DESCRIPTION
## Summary

- New agents created via the UI defaulted to `anthropic/claude-sonnet-4` regardless of which provider was actually configured, because `[defaults.routing]` was never written to `config.toml` unless the user went through the Settings UI provider setup flow.
- Adds `infer_routing_from_providers()` which detects the configured provider from `llm.providers` and calls `defaults_for_provider()` to pick the correct provider-prefixed models (e.g. `openrouter/anthropic/claude-sonnet-4-20250514`).
- Defense-in-depth: `create_agent()` now reads defaults from disk instead of the in-memory cache, and refreshes the cache as a side-effect.

## Root cause

When `[defaults.routing]` is absent from `config.toml`, `resolve_routing()` returned `RoutingConfig::default()` → hardcoded `anthropic/claude-sonnet-4`. This happened because the provider was configured manually (editing config.toml / env vars) rather than through `update_provider()`, which is the only path that calls `apply_model_routing()` to write `[defaults.routing]`.

## Changes

| File | What |
|------|------|
| `src/config.rs` | Add `infer_routing_from_providers()`, use it in `from_toml` when `[defaults.routing]` is absent and in `load_from_env` as the base routing |
| `src/api/agents.rs` | `create_agent()` reads defaults from disk via `Config::load_from_path` instead of the cached `defaults_config` |
| `src/api/providers.rs` | Add `refresh_defaults_config()` helper, call after `update_provider()` and `finalize_openai_oauth()` |
| `src/api/config.rs` | Refresh `defaults_config` cache after `update_agent_config()` writes to disk |
| `src/main.rs` | Refresh `defaults_config` in provider-setup event handler |