### PR TITLE
fix: allow trustd mach service in macOS sandbox for TLS cert verification

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -719,7 +719,8 @@ impl Sandbox {
   (require-all (path "/dev/null") (vnode-type CHARACTER-DEVICE)))
 (allow sysctl-read)
 (allow mach-lookup
-  (global-name "com.apple.system.opendirectoryd.libinfo"))
+  (global-name "com.apple.system.opendirectoryd.libinfo")
+  (global-name "com.apple.trustd"))
 (allow ipc-posix-sem)
 (allow pseudo-tty)
 (allow network*)


### PR DESCRIPTION
## Summary

- Add `com.apple.trustd` to the macOS sandbox-exec SBPL Mach service allowlist so sandboxed workers can verify TLS certificates

The `(deny default)` SBPL profile only allowed `com.apple.system.opendirectoryd.libinfo` for Mach IPC. On macOS, TLS certificate chain verification goes through the `trustd` daemon via Mach, so any HTTPS connection from a sandboxed worker (e.g. `gh` CLI) failed with `x509: OSStatus -26276`. Network access was already unrestricted (`(allow network*)`), so this just lets TLS actually work.