### PR TITLE
feat: workspace filesystem explorer tab

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -819,6 +819,42 @@ export interface IngestDeleteResponse {
 	success: boolean;
 }
 
+// -- Filesystem Types --
+
+export interface FilesystemEntry {
+	name: string;
+	entry_type: "file" | "directory" | "other";
+	size: number;
+	modified_at: string | null;
+}
+
+export interface FileListResponse {
+	entries: FilesystemEntry[];
+	path: string;
+}
+
+export interface FileReadResponse {
+	content: string;
+	size: number;
+	truncated: boolean;
+}
+
+export interface FileWriteResponse {
+	success: boolean;
+}
+
+export interface FileDeleteResponse {
+	success: boolean;
+}
+
+export interface FileRenameResponse {
+	success: boolean;
+}
+
+export interface FileUploadResponse {
+	uploaded: string[];
+}
+
 // -- Skills Types --
 
 export interface SkillInfo {
@@ -1630,6 +1666,61 @@ export const api = {
 			throw new Error(`API error: ${response.status}`);
 		}
 		return response.json() as Promise<IngestDeleteResponse>;
+	},
+
+	// Filesystem API
+	filesystemList: (agentId: string, path = "") => {
+		const params = new URLSearchParams({ agent_id: agentId, path });
+		return fetchJson<FileListResponse>(`/agents/files/list?${params}`);
+	},
+
+	filesystemRead: (agentId: string, path: string) => {
+		const params = new URLSearchParams({ agent_id: agentId, path });
+		return fetchJson<FileReadResponse>(`/agents/files/read?${params}`);
+	},
+
+	filesystemDownloadUrl: (agentId: string, path: string) => {
+		const params = new URLSearchParams({ agent_id: agentId, path });
+		return `${API_BASE}/agents/files/download?${params}`;
+	},
+
+	filesystemWrite: async (agentId: string, path: string, content?: string, isDirectory = false) => {
+		const response = await fetch(`${API_BASE}/agents/files/write`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ agent_id: agentId, path, content, is_directory: isDirectory }),
+		});
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<FileWriteResponse>;
+	},
+
+	filesystemDelete: async (agentId: string, path: string) => {
+		const params = new URLSearchParams({ agent_id: agentId, path });
+		const response = await fetch(`${API_BASE}/agents/files/delete?${params}`, { method: "DELETE" });
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<FileDeleteResponse>;
+	},
+
+	filesystemRename: async (agentId: string, oldPath: string, newPath: string) => {
+		const response = await fetch(`${API_BASE}/agents/files/rename`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ agent_id: agentId, old_path: oldPath, new_path: newPath }),
+		});
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<FileRenameResponse>;
+	},
+
+	filesystemUpload: async (agentId: string, path: string, files: File[]) => {
+		const formData = new FormData();
+		for (const file of files) formData.append("files", file);
+		const params = new URLSearchParams({ agent_id: agentId, path });
+		const response = await fetch(`${API_BASE}/agents/files/upload?${params}`, {
+			method: "POST",
+			body: formData,
+		});
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<FileUploadResponse>;
 	},
 
 	// Messaging / Bindings API

--- a/interface/src/components/AgentTabs.tsx
+++ b/interface/src/components/AgentTabs.tsx
@@ -6,7 +6,7 @@ const tabs = [
 	{ label: "Chat", to: "/agents/$agentId/chat" as const, exact: false },
 	{ label: "Channels", to: "/agents/$agentId/channels" as const, exact: false },
 	{ label: "Memories", to: "/agents/$agentId/memories" as const, exact: false },
-	{ label: "Ingest", to: "/agents/$agentId/ingest" as const, exact: false },
+	{ label: "Files", to: "/agents/$agentId/files" as const, exact: false },
 	{ label: "Workers", to: "/agents/$agentId/workers" as const, exact: false },
 	{ label: "Tasks", to: "/agents/$agentId/tasks" as const, exact: false },
 	{ label: "Cortex", to: "/agents/$agentId/cortex" as const, exact: false },

--- a/interface/src/router.tsx
+++ b/interface/src/router.tsx
@@ -17,7 +17,7 @@ import {ChannelDetail} from "@/routes/ChannelDetail";
 import {AgentMemories} from "@/routes/AgentMemories";
 import {AgentConfig} from "@/routes/AgentConfig";
 import {AgentCron} from "@/routes/AgentCron";
-import {AgentIngest} from "@/routes/AgentIngest";
+import {AgentFiles} from "@/routes/AgentFiles";
 import {AgentSkills} from "@/routes/AgentSkills";
 import {AgentWorkers} from "@/routes/AgentWorkers";
 import {AgentTasks} from "@/routes/AgentTasks";
@@ -168,16 +168,19 @@ const agentMemoriesRoute = createRoute({
 	},
 });
 
-const agentIngestRoute = createRoute({
+const agentFilesRoute = createRoute({
 	getParentRoute: () => rootRoute,
-	path: "/agents/$agentId/ingest",
-	component: function AgentIngestPage() {
-		const {agentId} = agentIngestRoute.useParams();
+	path: "/agents/$agentId/files",
+	validateSearch: (search: Record<string, unknown>): {path?: string} => ({
+		path: typeof search.path === "string" ? search.path : undefined,
+	}),
+	component: function AgentFilesPage() {
+		const {agentId} = agentFilesRoute.useParams();
 		return (
 			<div className="flex h-full flex-col">
 				<AgentHeader agentId={agentId} />
 				<div className="flex-1 overflow-hidden">
-					<AgentIngest agentId={agentId} />
+					<AgentFiles agentId={agentId} />
 				</div>
 			</div>
 		);
@@ -320,7 +323,7 @@ const routeTree = rootRoute.addChildren([
 	agentChatRoute,
 	agentChannelsRoute,
 	agentMemoriesRoute,
-	agentIngestRoute,
+	agentFilesRoute,
 	agentWorkersRoute,
 	agentTasksRoute,
 	agentCortexRoute,

--- a/interface/src/routes/AgentFiles.tsx
+++ b/interface/src/routes/AgentFiles.tsx
@@ -1,0 +1,948 @@
+import {useState, useRef, useCallback} from "react";
+import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
+import {useNavigate, useSearch} from "@tanstack/react-router";
+import {api, type FilesystemEntry, type IngestFileInfo} from "@/api/client";
+import {formatTimeAgo} from "@/lib/format";
+import {Button} from "@/ui";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogFooter,
+} from "@/ui";
+import {Badge} from "@/ui";
+import {clsx} from "clsx";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {
+	faFolder,
+	faFile,
+	faDownload,
+	faTrash,
+	faPen,
+	faPlus,
+	faFolderPlus,
+	faUpload,
+	faChevronRight,
+	faFloppyDisk,
+	faXmark,
+	faArrowLeft,
+	faLock,
+} from "@fortawesome/free-solid-svg-icons";
+
+function formatFileSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024)
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+const PROTECTED_ROOT_DIRS = ["ingest", "skills"];
+const PROTECTED_IDENTITY_FILES = [
+	"soul.md",
+	"identity.md",
+	"user.md",
+	"role.md",
+];
+
+function isProtectedRootDir(currentPath: string, name: string): boolean {
+	return (
+		currentPath === "" &&
+		PROTECTED_ROOT_DIRS.includes(name.toLowerCase())
+	);
+}
+
+function isProtectedIdentityFile(currentPath: string, name: string): boolean {
+	return (
+		currentPath === "" &&
+		PROTECTED_IDENTITY_FILES.includes(name.toLowerCase())
+	);
+}
+
+function isTextFile(name: string): boolean {
+	const textExtensions = [
+		"txt",
+		"md",
+		"markdown",
+		"json",
+		"jsonl",
+		"csv",
+		"tsv",
+		"xml",
+		"yaml",
+		"yml",
+		"toml",
+		"html",
+		"htm",
+		"css",
+		"js",
+		"ts",
+		"tsx",
+		"jsx",
+		"rs",
+		"py",
+		"rb",
+		"go",
+		"java",
+		"c",
+		"cpp",
+		"h",
+		"hpp",
+		"sh",
+		"bash",
+		"zsh",
+		"fish",
+		"sql",
+		"graphql",
+		"gql",
+		"env",
+		"ini",
+		"cfg",
+		"conf",
+		"log",
+		"rst",
+		"org",
+		"tex",
+		"diff",
+		"patch",
+		"makefile",
+		"dockerfile",
+		"gitignore",
+		"editorconfig",
+	];
+	const ext = name.split(".").pop()?.toLowerCase() ?? "";
+	const baseName = name.toLowerCase();
+	// Files with no extension or known text basenames
+	return (
+		textExtensions.includes(ext) ||
+		textExtensions.includes(baseName) ||
+		!name.includes(".")
+	);
+}
+
+function fileExtension(name: string): string {
+	const ext = name.split(".").pop()?.toUpperCase() ?? "";
+	if (ext === name.toUpperCase() || ext.length > 5) return "";
+	return ext;
+}
+
+// -- Ingest status components (reused from AgentIngest) --
+
+function IngestStatusBadge({status}: {status: IngestFileInfo["status"]}) {
+	const styles: Record<string, string> = {
+		queued: "bg-amber-500/20 text-amber-400",
+		processing: "bg-blue-500/20 text-blue-400",
+		completed: "bg-green-500/20 text-green-400",
+		failed: "bg-red-500/20 text-red-400",
+	};
+	return (
+		<span
+			className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${styles[status] ?? styles.queued}`}
+		>
+			{(status === "processing" || status === "queued") && (
+				<span
+					className={`mr-1.5 h-1.5 w-1.5 animate-pulse rounded-full ${status === "queued" ? "bg-amber-400" : "bg-blue-400"}`}
+				/>
+			)}
+			{status}
+		</span>
+	);
+}
+
+// -- Main component --
+
+interface AgentFilesProps {
+	agentId: string;
+}
+
+export function AgentFiles({agentId}: AgentFilesProps) {
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const search = useSearch({from: "/agents/$agentId/files"});
+	const currentPath = search.path ?? "";
+
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [selectedFile, setSelectedFile] = useState<string | null>(null);
+	const [editMode, setEditMode] = useState(false);
+	const [editContent, setEditContent] = useState("");
+	const [renamingEntry, setRenamingEntry] = useState<string | null>(null);
+	const [renameValue, setRenameValue] = useState("");
+	const [createDialog, setCreateDialog] = useState<
+		"file" | "folder" | null
+	>(null);
+	const [createName, setCreateName] = useState("");
+
+	// Navigate to a directory path
+	const navigateTo = useCallback(
+		(path: string) => {
+			setSelectedFile(null);
+			setEditMode(false);
+			navigate({
+				to: "/agents/$agentId/files",
+				params: {agentId},
+				search: path ? {path} : {},
+			});
+		},
+		[agentId, navigate],
+	);
+
+	// -- Queries --
+
+	const {data: listing, isLoading, error} = useQuery({
+		queryKey: ["files-list", agentId, currentPath],
+		queryFn: () => api.filesystemList(agentId, currentPath),
+		refetchInterval: 10_000,
+	});
+
+	const {data: filePreview, isLoading: previewLoading} = useQuery({
+		queryKey: ["files-read", agentId, selectedFile],
+		queryFn: () => api.filesystemRead(agentId, selectedFile!),
+		enabled: !!selectedFile,
+	});
+
+	// Show ingest status when browsing the ingest/ directory
+	const isIngestDir =
+		currentPath === "ingest" || currentPath.startsWith("ingest/");
+	const {data: ingestData} = useQuery({
+		queryKey: ["ingest-files", agentId],
+		queryFn: () => api.ingestFiles(agentId),
+		refetchInterval: 5_000,
+		enabled: isIngestDir,
+	});
+
+	// -- Mutations --
+
+	const writeMutation = useMutation({
+		mutationFn: ({
+			path,
+			content,
+			isDirectory,
+		}: {
+			path: string;
+			content?: string;
+			isDirectory?: boolean;
+		}) => api.filesystemWrite(agentId, path, content, isDirectory),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["files-list", agentId, currentPath],
+			});
+			setCreateDialog(null);
+			setCreateName("");
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: (path: string) => api.filesystemDelete(agentId, path),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["files-list", agentId, currentPath],
+			});
+			if (selectedFile) setSelectedFile(null);
+		},
+	});
+
+	const renameMutation = useMutation({
+		mutationFn: ({
+			oldPath,
+			newPath,
+		}: {
+			oldPath: string;
+			newPath: string;
+		}) => api.filesystemRename(agentId, oldPath, newPath),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["files-list", agentId, currentPath],
+			});
+			setRenamingEntry(null);
+		},
+	});
+
+	const uploadMutation = useMutation({
+		mutationFn: (files: File[]) =>
+			api.filesystemUpload(agentId, currentPath, files),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["files-list", agentId, currentPath],
+			});
+			if (isIngestDir) {
+				queryClient.invalidateQueries({
+					queryKey: ["ingest-files", agentId],
+				});
+			}
+		},
+	});
+
+	const saveFileMutation = useMutation({
+		mutationFn: ({path, content}: {path: string; content: string}) =>
+			api.filesystemWrite(agentId, path, content),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["files-read", agentId, selectedFile],
+			});
+			setEditMode(false);
+		},
+	});
+
+	// -- Event handlers --
+
+	const handleUpload = useCallback(
+		(files: FileList | File[]) => {
+			const fileArray = Array.from(files);
+			if (fileArray.length > 0) {
+				uploadMutation.mutate(fileArray);
+			}
+		},
+		[uploadMutation],
+	);
+
+	const handleCreate = useCallback(() => {
+		if (!createName.trim()) return;
+		const fullPath = currentPath
+			? `${currentPath}/${createName.trim()}`
+			: createName.trim();
+		writeMutation.mutate({
+			path: fullPath,
+			content: createDialog === "file" ? "" : undefined,
+			isDirectory: createDialog === "folder",
+		});
+	}, [createDialog, createName, currentPath, writeMutation]);
+
+	const handleRenameSubmit = useCallback(
+		(entry: string) => {
+			if (!renameValue.trim() || renameValue === entry) {
+				setRenamingEntry(null);
+				return;
+			}
+			const oldPath = currentPath ? `${currentPath}/${entry}` : entry;
+			const newPath = currentPath
+				? `${currentPath}/${renameValue.trim()}`
+				: renameValue.trim();
+			renameMutation.mutate({oldPath, newPath});
+		},
+		[currentPath, renameValue, renameMutation],
+	);
+
+	const handleEntryClick = useCallback(
+		(entry: FilesystemEntry) => {
+			if (entry.entry_type === "directory") {
+				const path = currentPath
+					? `${currentPath}/${entry.name}`
+					: entry.name;
+				navigateTo(path);
+			} else if (isTextFile(entry.name)) {
+				const path = currentPath
+					? `${currentPath}/${entry.name}`
+					: entry.name;
+				setSelectedFile(path);
+				setEditMode(false);
+			}
+		},
+		[currentPath, navigateTo],
+	);
+
+	// -- Breadcrumb segments --
+
+	const pathSegments = currentPath ? currentPath.split("/") : [];
+	const breadcrumbs = [
+		{label: "workspace", path: ""},
+		...pathSegments.map((segment, index) => ({
+			label: segment,
+			path: pathSegments.slice(0, index + 1).join("/"),
+		})),
+	];
+
+	const entries = listing?.entries ?? [];
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Toolbar */}
+			<div className="flex items-center gap-2 border-b border-app-line px-4 py-2">
+				{/* Breadcrumb */}
+				<div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto text-sm">
+					{breadcrumbs.map((crumb, index) => (
+						<span key={crumb.path} className="flex items-center gap-1 whitespace-nowrap">
+							{index > 0 && (
+								<FontAwesomeIcon
+									icon={faChevronRight}
+									className="h-2.5 w-2.5 text-ink-faint"
+								/>
+							)}
+							<button
+								type="button"
+								onClick={() => navigateTo(crumb.path)}
+								className={clsx(
+									"rounded px-1.5 py-0.5 transition-colors hover:bg-app-box/50",
+									index === breadcrumbs.length - 1
+										? "font-medium text-ink"
+										: "text-ink-dull hover:text-ink",
+								)}
+							>
+								{crumb.label}
+							</button>
+						</span>
+					))}
+				</div>
+
+				{/* Actions */}
+				<div className="flex items-center gap-1.5">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => {
+							setCreateDialog("file");
+							setCreateName("");
+						}}
+					>
+						<FontAwesomeIcon
+							icon={faPlus}
+							className="mr-1.5 h-3 w-3"
+						/>
+						New File
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => {
+							setCreateDialog("folder");
+							setCreateName("");
+						}}
+					>
+						<FontAwesomeIcon
+							icon={faFolderPlus}
+							className="mr-1.5 h-3 w-3"
+						/>
+						New Folder
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => fileInputRef.current?.click()}
+						loading={uploadMutation.isPending}
+					>
+						<FontAwesomeIcon
+							icon={faUpload}
+							className="mr-1.5 h-3 w-3"
+						/>
+						Upload
+					</Button>
+					<input
+						ref={fileInputRef}
+						type="file"
+						multiple
+						className="hidden"
+						onChange={(e) => {
+							if (e.target.files) {
+								handleUpload(e.target.files);
+								e.target.value = "";
+							}
+						}}
+					/>
+				</div>
+			</div>
+
+			{/* Main content area */}
+			<div className="flex flex-1 overflow-hidden">
+				{/* File listing */}
+				<div
+					className={clsx(
+						"flex flex-col overflow-auto border-r border-app-line",
+						selectedFile ? "w-1/2" : "w-full",
+					)}
+				>
+					{/* Back row when in a subdirectory */}
+					{currentPath && (
+						<button
+							type="button"
+							onClick={() => {
+								const parent = currentPath.includes("/")
+									? currentPath.substring(
+											0,
+											currentPath.lastIndexOf("/"),
+										)
+									: "";
+								navigateTo(parent);
+							}}
+							className="flex items-center gap-3 border-b border-app-line/50 px-4 py-2.5 text-sm text-ink-dull transition-colors hover:bg-app-box/20 hover:text-ink"
+						>
+							<FontAwesomeIcon
+								icon={faArrowLeft}
+								className="h-3 w-3 text-ink-faint"
+							/>
+							..
+						</button>
+					)}
+
+					{/* Loading state */}
+					{isLoading && (
+						<div className="flex flex-1 items-center justify-center py-12">
+							<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+						</div>
+					)}
+
+					{/* Error state */}
+					{error && (
+						<div className="m-4 rounded-xl bg-red-500/10 px-4 py-3 text-sm text-red-400">
+							Failed to load directory contents
+						</div>
+					)}
+
+					{/* Empty state */}
+					{!isLoading && !error && entries.length === 0 && (
+						<div className="flex flex-1 flex-col items-center justify-center py-12 text-center">
+							<FontAwesomeIcon
+								icon={faFolder}
+								className="mb-3 h-8 w-8 text-ink-faint/50"
+							/>
+							<p className="text-sm text-ink-dull">
+								Empty directory
+							</p>
+							<p className="mt-1 text-xs text-ink-faint">
+								Create a file or upload one to get started
+							</p>
+						</div>
+					)}
+
+					{/* File entries */}
+					{entries.map((entry) => {
+						const entryPath = currentPath
+							? `${currentPath}/${entry.name}`
+							: entry.name;
+						const isSelected = selectedFile === entryPath;
+						const isDir = entry.entry_type === "directory";
+						const protectedDir = isProtectedRootDir(
+							currentPath,
+							entry.name,
+						);
+						const protectedFile = isProtectedIdentityFile(
+							currentPath,
+							entry.name,
+						);
+						const isRenaming = renamingEntry === entry.name;
+
+						return (
+							<div
+								key={entry.name}
+								className={clsx(
+									"group flex items-center gap-3 border-b border-app-line/30 px-4 py-2.5 transition-colors",
+									isSelected
+										? "bg-accent/5"
+										: "hover:bg-app-box/20",
+									isDir ? "cursor-pointer" : "",
+								)}
+								onClick={() => handleEntryClick(entry)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter")
+										handleEntryClick(entry);
+								}}
+								role="button"
+								tabIndex={0}
+							>
+								{/* Icon */}
+								<FontAwesomeIcon
+									icon={isDir ? faFolder : faFile}
+									className={clsx(
+										"h-4 w-4 flex-shrink-0",
+										isDir
+											? "text-amber-400/70"
+											: "text-ink-faint",
+									)}
+								/>
+
+								{/* Name */}
+								<div className="flex min-w-0 flex-1 items-center gap-2">
+									{isRenaming ? (
+										<input
+											type="text"
+											value={renameValue}
+											onChange={(e) =>
+												setRenameValue(e.target.value)
+											}
+											onBlur={() =>
+												handleRenameSubmit(entry.name)
+											}
+											onKeyDown={(e) => {
+												if (e.key === "Enter")
+													handleRenameSubmit(
+														entry.name,
+													);
+												if (e.key === "Escape")
+													setRenamingEntry(null);
+												e.stopPropagation();
+											}}
+											onClick={(e) => e.stopPropagation()}
+											className="h-6 w-full rounded border border-accent/50 bg-app-darkBox px-2 text-sm text-ink outline-none"
+											autoFocus
+										/>
+									) : (
+										<span className="truncate text-sm text-ink">
+											{entry.name}
+											{isDir && "/"}
+										</span>
+									)}
+									{(protectedDir || protectedFile) && (
+										<FontAwesomeIcon
+											icon={faLock}
+											className="h-2.5 w-2.5 flex-shrink-0 text-ink-faint/50"
+											title={
+												protectedDir
+													? "Protected directory"
+													: "Identity file (edit via Config)"
+											}
+										/>
+									)}
+								</div>
+
+								{/* Extension badge for files */}
+								{!isDir && (
+									<span className="flex-shrink-0 text-xs text-ink-faint">
+										{fileExtension(entry.name)}
+									</span>
+								)}
+
+								{/* Size */}
+								<span className="w-16 flex-shrink-0 text-right text-xs tabular-nums text-ink-faint">
+									{isDir ? "--" : formatFileSize(entry.size)}
+								</span>
+
+								{/* Modified */}
+								<span className="w-16 flex-shrink-0 text-right text-xs text-ink-faint">
+									{entry.modified_at
+										? formatTimeAgo(entry.modified_at)
+										: "--"}
+								</span>
+
+								{/* Actions (visible on hover) */}
+								<div className="flex w-20 flex-shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+									{!isDir && (
+										<a
+											href={api.filesystemDownloadUrl(
+												agentId,
+												entryPath,
+											)}
+											onClick={(e) => e.stopPropagation()}
+											className="flex h-6 w-6 items-center justify-center rounded text-ink-faint transition-colors hover:bg-app-box hover:text-ink"
+											title="Download"
+										>
+											<FontAwesomeIcon
+												icon={faDownload}
+												className="h-3 w-3"
+											/>
+										</a>
+									)}
+									{!protectedDir && !protectedFile && (
+										<>
+											<button
+												type="button"
+												onClick={(e) => {
+													e.stopPropagation();
+													setRenamingEntry(
+														entry.name,
+													);
+													setRenameValue(entry.name);
+												}}
+												className="flex h-6 w-6 items-center justify-center rounded text-ink-faint transition-colors hover:bg-app-box hover:text-ink"
+												title="Rename"
+											>
+												<FontAwesomeIcon
+													icon={faPen}
+													className="h-3 w-3"
+												/>
+											</button>
+											<button
+												type="button"
+												onClick={(e) => {
+													e.stopPropagation();
+													if (
+														window.confirm(
+															`Delete ${entry.name}${isDir ? " and all its contents" : ""}?`,
+														)
+													) {
+														deleteMutation.mutate(
+															entryPath,
+														);
+													}
+												}}
+												className="flex h-6 w-6 items-center justify-center rounded text-ink-faint transition-colors hover:bg-red-500/10 hover:text-red-400"
+												title="Delete"
+											>
+												<FontAwesomeIcon
+													icon={faTrash}
+													className="h-3 w-3"
+												/>
+											</button>
+										</>
+									)}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+
+				{/* Preview panel */}
+				{selectedFile && (
+					<div className="flex w-1/2 flex-col overflow-hidden">
+						{/* Preview header */}
+						<div className="flex items-center gap-2 border-b border-app-line px-4 py-2">
+							<span className="min-w-0 flex-1 truncate text-sm font-medium text-ink">
+								{selectedFile.split("/").pop()}
+							</span>
+							{filePreview && (
+								<span className="text-xs text-ink-faint">
+									{formatFileSize(filePreview.size)}
+									{filePreview.truncated && " (truncated)"}
+								</span>
+							)}
+							<div className="flex items-center gap-1">
+								{!editMode && !isProtectedIdentityFile(
+									"",
+									selectedFile.split("/").pop() ?? "",
+								) && (
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											setEditContent(
+												filePreview?.content ?? "",
+											);
+											setEditMode(true);
+										}}
+										disabled={previewLoading}
+									>
+										<FontAwesomeIcon
+											icon={faPen}
+											className="mr-1.5 h-3 w-3"
+										/>
+										Edit
+									</Button>
+								)}
+								{editMode && (
+									<>
+										<Button
+											variant="default"
+											size="sm"
+											loading={
+												saveFileMutation.isPending
+											}
+											onClick={() => {
+												saveFileMutation.mutate({
+													path: selectedFile,
+													content: editContent,
+												});
+											}}
+										>
+											<FontAwesomeIcon
+												icon={faFloppyDisk}
+												className="mr-1.5 h-3 w-3"
+											/>
+											Save
+										</Button>
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => setEditMode(false)}
+										>
+											<FontAwesomeIcon
+												icon={faXmark}
+												className="mr-1.5 h-3 w-3"
+											/>
+											Cancel
+										</Button>
+									</>
+								)}
+								<a
+									href={api.filesystemDownloadUrl(
+										agentId,
+										selectedFile,
+									)}
+									className="inline-flex"
+								>
+									<Button variant="ghost" size="sm">
+										<FontAwesomeIcon
+											icon={faDownload}
+											className="mr-1.5 h-3 w-3"
+										/>
+										Download
+									</Button>
+								</a>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => {
+										setSelectedFile(null);
+										setEditMode(false);
+									}}
+								>
+									<FontAwesomeIcon
+										icon={faXmark}
+										className="h-3 w-3"
+									/>
+								</Button>
+							</div>
+						</div>
+
+						{/* Preview content */}
+						<div className="flex-1 overflow-auto">
+							{previewLoading && (
+								<div className="flex items-center justify-center py-12">
+									<div className="h-2 w-2 animate-pulse rounded-full bg-accent" />
+								</div>
+							)}
+							{!previewLoading && filePreview && (
+								<>
+									{editMode ? (
+										<textarea
+											value={editContent}
+											onChange={(e) =>
+												setEditContent(e.target.value)
+											}
+											className="h-full w-full resize-none bg-app-darkBox/30 p-4 font-mono text-xs leading-relaxed text-ink outline-none"
+											spellCheck={false}
+										/>
+									) : (
+										<pre className="whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-ink-dull">
+											{filePreview.content}
+										</pre>
+									)}
+								</>
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Ingest progress bar (only when browsing ingest/) */}
+			{isIngestDir && ingestData && ingestData.files.length > 0 && (
+				<IngestStatusBar files={ingestData.files} />
+			)}
+
+			{/* Create file/folder dialog */}
+			<Dialog
+				open={createDialog !== null}
+				onOpenChange={(open) => {
+					if (!open) setCreateDialog(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{createDialog === "folder"
+								? "New Folder"
+								: "New File"}
+						</DialogTitle>
+					</DialogHeader>
+					<input
+						type="text"
+						value={createName}
+						onChange={(e) => setCreateName(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleCreate();
+						}}
+						placeholder={
+							createDialog === "folder"
+								? "Folder name"
+								: "File name"
+						}
+						className="w-full rounded-lg border border-app-line bg-app-darkBox px-3 py-2 text-sm text-ink placeholder-ink-faint outline-none focus:border-accent/50"
+						autoFocus
+					/>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setCreateDialog(null)}
+						>
+							Cancel
+						</Button>
+						<Button
+							size="sm"
+							onClick={handleCreate}
+							disabled={
+								!createName.trim() ||
+								writeMutation.isPending
+							}
+							loading={writeMutation.isPending}
+						>
+							Create
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}
+
+// -- Ingest status bar --
+
+function IngestStatusBar({files}: {files: IngestFileInfo[]}) {
+	const active = files.filter(
+		(f) => f.status === "queued" || f.status === "processing",
+	);
+	const completed = files.filter((f) => f.status === "completed").length;
+	const failed = files.filter((f) => f.status === "failed").length;
+
+	return (
+		<div className="border-t border-app-line bg-app-darkBox/30 px-4 py-2">
+			<div className="mb-1.5 flex items-center gap-2">
+				<span className="text-xs font-medium text-ink-dull">
+					Ingestion
+				</span>
+				<Badge variant="green" size="md">
+					{completed} completed
+				</Badge>
+				{failed > 0 && (
+					<Badge variant="red" size="md">
+						{failed} failed
+					</Badge>
+				)}
+				{active.length > 0 && (
+					<Badge variant="accent" size="md">
+						{active.length} active
+					</Badge>
+				)}
+			</div>
+			{active.length > 0 && (
+				<div className="flex flex-col gap-1">
+					{active.map((file) => {
+						const progress =
+							file.total_chunks > 0
+								? Math.round(
+										(file.chunks_completed /
+											file.total_chunks) *
+											100,
+									)
+								: 0;
+						return (
+							<div
+								key={file.content_hash}
+								className="flex items-center gap-3 text-xs"
+							>
+								<span className="min-w-0 flex-1 truncate text-ink-dull">
+									{file.filename}
+								</span>
+								<IngestStatusBadge status={file.status} />
+								{file.status === "processing" &&
+									file.total_chunks > 0 && (
+										<div className="flex items-center gap-2">
+											<div className="h-1 w-24 overflow-hidden rounded-full bg-app-line">
+												<div
+													className="h-full rounded-full bg-blue-400 transition-all duration-500"
+													style={{
+														width: `${progress}%`,
+													}}
+												/>
+											</div>
+											<span className="tabular-nums text-ink-faint">
+												{file.chunks_completed}/
+												{file.total_chunks}
+											</span>
+										</div>
+									)}
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@ mod channels;
 mod config;
 mod cortex;
 mod cron;
+mod files;
 mod ingest;
 mod links;
 mod mcp;

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -1,0 +1,585 @@
+//! Workspace filesystem explorer API.
+//!
+//! Provides endpoints for browsing, reading, downloading, writing, deleting,
+//! renaming, and uploading files within an agent's workspace directory.
+
+use super::state::ApiState;
+use crate::tools::file::best_effort_canonicalize;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Names of root-level directories that cannot be renamed or deleted.
+const PROTECTED_DIRS: &[&str] = &["ingest", "skills"];
+
+/// Names of identity files that cannot be written or deleted via this API.
+const PROTECTED_IDENTITY_FILES: &[&str] = &["SOUL.md", "IDENTITY.md", "USER.md", "ROLE.md"];
+
+/// Maximum file size for text preview reads (1 MiB).
+const MAX_READ_BYTES: u64 = 1024 * 1024;
+
+// -- Query/request types --
+
+#[derive(Deserialize)]
+pub(super) struct FilesQuery {
+    agent_id: String,
+    #[serde(default)]
+    path: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct FileWriteRequest {
+    agent_id: String,
+    path: String,
+    /// File content (required for files, omitted for directories).
+    content: Option<String>,
+    /// When true, create a directory instead of a file.
+    #[serde(default)]
+    is_directory: bool,
+}
+
+#[derive(Deserialize)]
+pub(super) struct FileRenameRequest {
+    agent_id: String,
+    old_path: String,
+    new_path: String,
+}
+
+// -- Response types --
+
+#[derive(Serialize)]
+pub(super) struct FileEntry {
+    name: String,
+    entry_type: String,
+    size: u64,
+    modified_at: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileListResponse {
+    entries: Vec<FileEntry>,
+    path: String,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileReadResponse {
+    content: String,
+    size: u64,
+    truncated: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileWriteResponse {
+    success: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileDeleteResponse {
+    success: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileRenameResponse {
+    success: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct FileUploadResponse {
+    uploaded: Vec<String>,
+}
+
+// -- Path resolution --
+
+/// Resolve a user-supplied path relative to the workspace, ensuring it stays
+/// within the workspace boundary. Rejects symlinks and `..` traversal.
+fn resolve_workspace_path(workspace: &Path, raw: &str) -> Result<PathBuf, StatusCode> {
+    let cleaned = raw.trim_start_matches('/');
+    let path = if cleaned.is_empty() {
+        workspace.to_path_buf()
+    } else {
+        workspace.join(cleaned)
+    };
+
+    let canonical = best_effort_canonicalize(&path);
+    let workspace_canonical = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    if !canonical.starts_with(&workspace_canonical) {
+        tracing::warn!(
+            path = %raw,
+            workspace = %workspace.display(),
+            "files API: path escapes workspace boundary"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Reject symlinks within the resolved path to prevent TOCTOU races.
+    let mut check = workspace_canonical.clone();
+    if let Ok(relative) = canonical.strip_prefix(&workspace_canonical) {
+        for component in relative.components() {
+            check.push(component);
+            if let Ok(metadata) = std::fs::symlink_metadata(&check)
+                && metadata.file_type().is_symlink()
+            {
+                tracing::warn!(
+                    path = %check.display(),
+                    "files API: symlink in path rejected"
+                );
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+    }
+
+    Ok(canonical)
+}
+
+/// Check whether a path refers to a protected root directory (e.g. `ingest/`, `skills/`).
+fn is_protected_root_dir(workspace: &Path, path: &Path) -> bool {
+    let workspace_canonical = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    if let Ok(relative) = path.strip_prefix(&workspace_canonical) {
+        let components: Vec<_> = relative.components().collect();
+        if components.len() == 1 {
+            if let Some(name) = relative.file_name().and_then(|n| n.to_str()) {
+                return PROTECTED_DIRS.iter().any(|d| name.eq_ignore_ascii_case(d));
+            }
+        }
+    }
+    false
+}
+
+/// Check whether a path refers to a protected identity file at workspace root.
+fn is_protected_identity_file(workspace: &Path, path: &Path) -> bool {
+    let workspace_canonical = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    if let Ok(relative) = path.strip_prefix(&workspace_canonical) {
+        let components: Vec<_> = relative.components().collect();
+        if components.len() == 1 {
+            if let Some(name) = relative.file_name().and_then(|n| n.to_str()) {
+                return PROTECTED_IDENTITY_FILES
+                    .iter()
+                    .any(|f| name.eq_ignore_ascii_case(f));
+            }
+        }
+    }
+    false
+}
+
+fn format_system_time(time: std::time::SystemTime) -> String {
+    let duration = time
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    // Format as ISO 8601 UTC.
+    let datetime = chrono::DateTime::from_timestamp(secs as i64, 0).unwrap_or_default();
+    datetime.to_rfc3339()
+}
+
+fn get_workspace(state: &ApiState, agent_id: &str) -> Result<PathBuf, StatusCode> {
+    let workspaces = state.agent_workspaces.load();
+    workspaces
+        .get(agent_id)
+        .cloned()
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+// -- Handlers --
+
+/// List directory contents within the agent's workspace.
+pub(super) async fn list_files(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<FilesQuery>,
+) -> Result<Json<FileListResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &query.agent_id)?;
+    let path = resolve_workspace_path(&workspace, &query.path)?;
+
+    if !path.is_dir() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut entries = Vec::new();
+    let mut reader = tokio::fs::read_dir(&path).await.map_err(|error| {
+        tracing::warn!(%error, path = %path.display(), "files API: failed to read directory");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    while let Some(entry) = reader.next_entry().await.map_err(|error| {
+        tracing::warn!(%error, "files API: failed to read directory entry");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })? {
+        let metadata = entry.metadata().await.map_err(|error| {
+            tracing::warn!(%error, "files API: failed to read entry metadata");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        let entry_type = if metadata.is_dir() {
+            "directory"
+        } else if metadata.is_file() {
+            "file"
+        } else {
+            "other"
+        };
+
+        let modified_at = metadata.modified().ok().map(format_system_time);
+
+        entries.push(FileEntry {
+            name: entry.file_name().to_string_lossy().to_string(),
+            entry_type: entry_type.to_string(),
+            size: metadata.len(),
+            modified_at,
+        });
+    }
+
+    // Sort: directories first, then files, both alphabetically.
+    entries.sort_by(|a, b| {
+        let a_is_dir = a.entry_type == "directory";
+        let b_is_dir = b.entry_type == "directory";
+        match (a_is_dir, b_is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        }
+    });
+
+    Ok(Json(FileListResponse {
+        entries,
+        path: query.path,
+    }))
+}
+
+/// Read a text file's content for preview.
+pub(super) async fn read_file(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<FilesQuery>,
+) -> Result<Json<FileReadResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &query.agent_id)?;
+    let path = resolve_workspace_path(&workspace, &query.path)?;
+
+    if !path.is_file() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let metadata = tokio::fs::metadata(&path).await.map_err(|error| {
+        tracing::warn!(%error, path = %path.display(), "files API: failed to read file metadata");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let file_size = metadata.len();
+    let truncated = file_size > MAX_READ_BYTES;
+    let read_size = file_size.min(MAX_READ_BYTES) as usize;
+
+    let raw = tokio::fs::read(&path).await.map_err(|error| {
+        tracing::warn!(%error, path = %path.display(), "files API: failed to read file");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Take only up to the read limit and convert to string (lossy for binary files).
+    let slice = &raw[..read_size.min(raw.len())];
+    let content = String::from_utf8_lossy(slice).to_string();
+
+    Ok(Json(FileReadResponse {
+        content,
+        size: file_size,
+        truncated,
+    }))
+}
+
+/// Download a file with Content-Disposition attachment header.
+pub(super) async fn download_file(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<FilesQuery>,
+) -> Result<Response, StatusCode> {
+    let workspace = get_workspace(&state, &query.agent_id)?;
+    let path = resolve_workspace_path(&workspace, &query.path)?;
+
+    if !path.is_file() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let data = tokio::fs::read(&path).await.map_err(|error| {
+        tracing::warn!(%error, path = %path.display(), "files API: failed to read file for download");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("download");
+
+    let content_disposition = format!("attachment; filename=\"{}\"", filename);
+    let mime = mime_guess::from_path(&path)
+        .first_or_octet_stream()
+        .to_string();
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, mime),
+            (header::CONTENT_DISPOSITION, content_disposition),
+        ],
+        data,
+    )
+        .into_response())
+}
+
+/// Create a file or directory within the workspace.
+pub(super) async fn write_file(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<FileWriteRequest>,
+) -> Result<Json<FileWriteResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &request.agent_id)?;
+    let path = resolve_workspace_path(&workspace, &request.path)?;
+
+    // Block writes to protected identity files.
+    if is_protected_identity_file(&workspace, &path) {
+        tracing::warn!(
+            path = %request.path,
+            "files API: write rejected for protected identity file"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    if request.is_directory {
+        tokio::fs::create_dir_all(&path).await.map_err(|error| {
+            tracing::warn!(%error, path = %path.display(), "files API: failed to create directory");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    } else {
+        let content = request.content.unwrap_or_default();
+
+        // Ensure parent directory exists.
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|error| {
+                tracing::warn!(%error, path = %parent.display(), "files API: failed to create parent directory");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        }
+
+        tokio::fs::write(&path, content).await.map_err(|error| {
+            tracing::warn!(%error, path = %path.display(), "files API: failed to write file");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    }
+
+    Ok(Json(FileWriteResponse { success: true }))
+}
+
+/// Delete a file or empty directory within the workspace.
+pub(super) async fn delete_file(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<FilesQuery>,
+) -> Result<Json<FileDeleteResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &query.agent_id)?;
+    let path = resolve_workspace_path(&workspace, &query.path)?;
+
+    // Prevent deleting the workspace root itself.
+    let workspace_canonical = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    if path == workspace_canonical {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Prevent deleting protected root directories and identity files.
+    if is_protected_root_dir(&workspace, &path) {
+        tracing::warn!(
+            path = %query.path,
+            "files API: delete rejected for protected root directory"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if is_protected_identity_file(&workspace, &path) {
+        tracing::warn!(
+            path = %query.path,
+            "files API: delete rejected for protected identity file"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    if path.is_dir() {
+        tokio::fs::remove_dir_all(&path).await.map_err(|error| {
+            tracing::warn!(%error, path = %path.display(), "files API: failed to delete directory");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    } else if path.is_file() {
+        tokio::fs::remove_file(&path).await.map_err(|error| {
+            tracing::warn!(%error, path = %path.display(), "files API: failed to delete file");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    } else {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(Json(FileDeleteResponse { success: true }))
+}
+
+/// Rename or move a file/directory within the workspace.
+pub(super) async fn rename_file(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<FileRenameRequest>,
+) -> Result<Json<FileRenameResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &request.agent_id)?;
+    let old_path = resolve_workspace_path(&workspace, &request.old_path)?;
+    let new_path = resolve_workspace_path(&workspace, &request.new_path)?;
+
+    // Prevent renaming protected root directories.
+    if is_protected_root_dir(&workspace, &old_path) {
+        tracing::warn!(
+            path = %request.old_path,
+            "files API: rename rejected for protected root directory"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if is_protected_identity_file(&workspace, &old_path) {
+        tracing::warn!(
+            path = %request.old_path,
+            "files API: rename rejected for protected identity file"
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    if !old_path.exists() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    // Ensure the parent of the new path exists.
+    if let Some(parent) = new_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            tracing::warn!(%error, path = %parent.display(), "files API: failed to create parent for rename target");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    }
+
+    tokio::fs::rename(&old_path, &new_path)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                %error,
+                from = %old_path.display(),
+                to = %new_path.display(),
+                "files API: failed to rename"
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(FileRenameResponse { success: true }))
+}
+
+/// Upload files to a directory within the workspace via multipart form data.
+/// When uploading to the `ingest/` directory, ingestion tracking records are
+/// created so the background ingestion pipeline picks them up.
+pub(super) async fn upload_files(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<FilesQuery>,
+    mut multipart: axum::extract::Multipart,
+) -> Result<Json<FileUploadResponse>, StatusCode> {
+    let workspace = get_workspace(&state, &query.agent_id)?;
+    let target_dir = resolve_workspace_path(&workspace, &query.path)?;
+
+    tokio::fs::create_dir_all(&target_dir)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, path = %target_dir.display(), "files API: failed to create upload target directory");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Detect whether we're uploading into the ingest directory tree.
+    let workspace_canonical = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+    let ingest_dir = workspace_canonical.join("ingest");
+    let is_ingest = target_dir.starts_with(&ingest_dir) || target_dir == ingest_dir;
+
+    let mut uploaded = Vec::new();
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let filename = field
+            .file_name()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("upload-{}.txt", uuid::Uuid::new_v4()));
+
+        let data = field.bytes().await.map_err(|error| {
+            tracing::warn!(%error, "files API: failed to read upload field");
+            StatusCode::BAD_REQUEST
+        })?;
+
+        if data.is_empty() {
+            continue;
+        }
+
+        let safe_name = Path::new(&filename)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("upload.txt");
+
+        let mut target = target_dir.join(safe_name);
+
+        // Deduplicate filenames if the target already exists.
+        if target.exists() {
+            let stem = Path::new(safe_name)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("upload");
+            let ext = Path::new(safe_name)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("txt");
+            let unique = format!(
+                "{}-{}.{}",
+                stem,
+                &uuid::Uuid::new_v4().to_string()[..8],
+                ext
+            );
+            target = target_dir.join(unique);
+        }
+
+        tokio::fs::write(&target, &data).await.map_err(|error| {
+            tracing::warn!(%error, path = %target.display(), "files API: failed to write uploaded file");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+        // If uploading to ingest/, create an ingestion tracking record.
+        if is_ingest {
+            if let Ok(content) = std::str::from_utf8(&data) {
+                let hash = crate::agent::ingestion::content_hash(content);
+                let pools = state.agent_pools.load();
+                if let Some(pool) = pools.get(&query.agent_id) {
+                    let file_size = data.len() as i64;
+                    let _ = sqlx::query(
+                        r#"
+                        INSERT OR IGNORE INTO ingestion_files (content_hash, filename, file_size, total_chunks, status)
+                        VALUES (?, ?, ?, 0, 'queued')
+                        "#,
+                    )
+                    .bind(&hash)
+                    .bind(safe_name)
+                    .bind(file_size)
+                    .execute(pool)
+                    .await;
+                }
+            }
+        }
+
+        tracing::info!(
+            agent_id = %query.agent_id,
+            filename = %safe_name,
+            bytes = data.len(),
+            is_ingest,
+            "file uploaded via files API"
+        );
+
+        uploaded.push(safe_name.to_string());
+    }
+
+    Ok(Json(FileUploadResponse { uploaded }))
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -2,8 +2,9 @@
 
 use super::state::ApiState;
 use super::{
-    agents, bindings, channels, config, cortex, cron, ingest, links, mcp, memories, messaging,
-    models, providers, secrets, settings, skills, system, tasks, tools, webchat, workers,
+    agents, bindings, channels, config, cortex, cron, files, ingest, links, mcp, memories,
+    messaging, models, providers, secrets, settings, skills, system, tasks, tools, webchat,
+    workers,
 };
 
 use axum::Json;
@@ -136,6 +137,14 @@ pub async fn start_http_server(
             get(ingest::list_ingest_files).delete(ingest::delete_ingest_file),
         )
         .route("/agents/ingest/upload", post(ingest::upload_ingest_file))
+        // Workspace filesystem explorer
+        .route("/agents/files/list", get(files::list_files))
+        .route("/agents/files/read", get(files::read_file))
+        .route("/agents/files/download", get(files::download_file))
+        .route("/agents/files/write", post(files::write_file))
+        .route("/agents/files/delete", delete(files::delete_file))
+        .route("/agents/files/rename", put(files::rename_file))
+        .route("/agents/files/upload", post(files::upload_files))
         .route("/agents/skills", get(skills::list_skills))
         .route("/agents/skills/install", post(skills::install_skill))
         .route("/agents/skills/remove", delete(skills::remove_skill))

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -78,7 +78,7 @@ impl FileTool {
 /// Canonicalize as much of the path as possible. For paths where the final
 /// components don't exist yet (e.g. writing a new file), canonicalize the
 /// deepest existing ancestor and append the rest.
-fn best_effort_canonicalize(path: &Path) -> PathBuf {
+pub(crate) fn best_effort_canonicalize(path: &Path) -> PathBuf {
     if let Ok(canonical) = path.canonicalize() {
         return canonical;
     }


### PR DESCRIPTION
## Summary

- Replace the **Ingest** tab with a unified **Files** tab that provides a full filesystem explorer for the agent's workspace directory
- Add 7 new backend API endpoints (`/agents/files/*`) for list, read, download, write, delete, rename, and upload operations with workspace boundary enforcement
- Build a React frontend with breadcrumb navigation, directory listing, text file preview/editing, file CRUD operations, and inline ingest progress tracking

## Backend

New module `src/api/files.rs` with 7 endpoints:

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/agents/files/list` | GET | List directory entries (name, type, size, modified_at) |
| `/agents/files/read` | GET | Read text file content (capped at 1 MiB) |
| `/agents/files/download` | GET | Download file as binary attachment |
| `/agents/files/write` | POST | Create/overwrite file or create directory |
| `/agents/files/delete` | DELETE | Delete file or directory |
| `/agents/files/rename` | PUT | Rename/move within workspace |
| `/agents/files/upload` | POST | Multipart upload with ingest tracking for `ingest/` |

**Security:**
- Path resolution reuses `best_effort_canonicalize` from `tools/file.rs` (made `pub(crate)`)
- All paths validated to stay within agent workspace boundary
- Symlink traversal rejected
- Protected root directories (`ingest/`, `skills/`) cannot be renamed or deleted
- Protected identity files (`SOUL.md`, `IDENTITY.md`, `USER.md`, `ROLE.md`) read-only via this API
- Uploads to `ingest/` auto-create ingestion tracking records for the pipeline

## Frontend

New component `AgentFiles.tsx` replacing `AgentIngest.tsx` in the tab bar:

- **Breadcrumb navigation** — clickable path segments, URL state via `?path=` search param
- **Directory listing** — sorted dirs-first, with file type, size, and modified time columns
- **Hover actions** — download, rename (inline), delete per entry
- **Text file preview** — right split panel with edit mode and save
- **File creation** — New File / New Folder dialogs
- **Upload** — to current directory; ingest tracking when in `ingest/`
- **Ingest status bar** — shown at bottom when browsing `ingest/`, reuses existing ingest progress query
- **Protected entries** — lock icon on protected dirs/files, write/delete actions hidden

## Files Changed

| File | Change |
|------|--------|
| `src/api/files.rs` | **New** — 7 API endpoints (586 lines) |
| `src/api.rs` | Add `mod files` |
| `src/api/server.rs` | Import `files` module, wire 7 routes |
| `src/tools/file.rs` | `best_effort_canonicalize` → `pub(crate)` |
| `interface/src/routes/AgentFiles.tsx` | **New** — filesystem explorer component (948 lines) |
| `interface/src/api/client.ts` | Add 7 types + 7 API methods |
| `interface/src/components/AgentTabs.tsx` | Replace "Ingest" → "Files" tab |
| `interface/src/router.tsx` | Replace ingest route with files route |


> [!NOTE]
> This change introduces a comprehensive workspace filesystem explorer that replaces the ingest-only tab with a full-featured file browser. Backend adds 7 secure API endpoints with strict path validation and workspace boundary enforcement, while the frontend delivers a polished explorer with breadcrumb navigation, inline text editing, and file operations. Protected system files and directories are made read-only at the API layer, and ingest uploads automatically integrate with the existing ingestion pipeline. Total additions: 1,648 lines across backend (586) and frontend (948), with minimal deletions.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [451674d](https://github.com/spacedriveapp/spacebot/commit/451674dba2ebd7fe4c672d20e4683637b79d536f). This will update automatically on new commits.</sub>