### PR TITLE
feat: add configurable secret scanner mode to fix false positives

### DIFF
--- a/src/agent/branch.rs
+++ b/src/agent/branch.rs
@@ -50,7 +50,8 @@ impl Branch {
             ProcessType::Branch,
             Some(channel_id.clone()),
             deps.event_tx.clone(),
-        );
+        )
+        .with_secret_scan_mode(deps.secret_scan_mode());
 
         Self {
             id,
@@ -161,7 +162,7 @@ impl Branch {
         } else {
             conclusion
         };
-        let conclusion = crate::secrets::scrub::scrub_leaks(&conclusion);
+        let conclusion = self.deps.secret_scan_mode().maybe_scrub_leaks(conclusion);
 
         // Send conclusion back to the channel
         let _ = self.deps.event_tx.send(ProcessEvent::BranchResult {

--- a/src/agent/branch.rs
+++ b/src/agent/branch.rs
@@ -51,7 +51,8 @@ impl Branch {
             Some(channel_id.clone()),
             deps.event_tx.clone(),
         )
-        .with_secret_scan_mode(deps.secret_scan_mode());
+        .with_secret_scan_mode(deps.secret_scan_mode())
+        .with_secrets_snapshot(deps.runtime_config.secrets.load().as_ref().clone());
 
         Self {
             id,

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -477,6 +477,16 @@ impl Channel {
             .unwrap_or(self.deps.agent_id.as_ref())
     }
 
+    /// Check if strict-mode leak detection finds a secret in the given text.
+    /// Returns `Some(leak)` only when `SecretScanMode::Strict` and a pattern matches.
+    fn strict_mode_leak(&self, text: &str) -> Option<String> {
+        if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict {
+            crate::secrets::scrub::scan_for_leaks(text)
+        } else {
+            None
+        }
+    }
+
     fn current_adapter(&self) -> Option<&str> {
         self.source_adapter
             .as_deref()
@@ -1934,7 +1944,7 @@ impl Channel {
                                 channel_id = %self.id,
                                 "blocked retrigger fallback output containing structured or tool syntax"
                             );
-                        } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                        } else if let Some(leak) = self.strict_mode_leak(text) {
                             tracing::warn!(
                                 channel_id = %self.id,
                                 leak_prefix = %&leak[..leak.len().min(8)],
@@ -1999,7 +2009,7 @@ impl Channel {
                                 channel_id = %self.id,
                                 "blocked retrigger output containing structured or tool syntax"
                             );
-                        } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                        } else if let Some(leak) = self.strict_mode_leak(text) {
                             tracing::warn!(
                                 channel_id = %self.id,
                                 leak_prefix = %&leak[..leak.len().min(8)],
@@ -2057,7 +2067,7 @@ impl Channel {
                             channel_id = %self.id,
                             "blocked fallback output containing structured or tool syntax"
                         );
-                    } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                    } else if let Some(leak) = self.strict_mode_leak(text) {
                         tracing::warn!(
                             channel_id = %self.id,
                             leak_prefix = %&leak[..leak.len().min(8)],

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -225,7 +225,8 @@ impl Channel {
             ProcessType::Channel,
             Some(id.clone()),
             deps.event_tx.clone(),
-        );
+        )
+        .with_secret_scan_mode(deps.secret_scan_mode());
         let status_block = Arc::new(RwLock::new(StatusBlock::new()));
         let history = Arc::new(RwLock::new(Vec::new()));
         let active_branches = Arc::new(RwLock::new(HashMap::new()));
@@ -1771,7 +1772,7 @@ impl Channel {
                                 channel_id = %self.id,
                                 "blocked retrigger fallback output containing structured or tool syntax"
                             );
-                        } else if let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                        } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
                             tracing::warn!(
                                 channel_id = %self.id,
                                 leak_prefix = %&leak[..leak.len().min(8)],
@@ -1836,7 +1837,7 @@ impl Channel {
                                 channel_id = %self.id,
                                 "blocked retrigger output containing structured or tool syntax"
                             );
-                        } else if let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                        } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
                             tracing::warn!(
                                 channel_id = %self.id,
                                 leak_prefix = %&leak[..leak.len().min(8)],
@@ -1894,7 +1895,7 @@ impl Channel {
                             channel_id = %self.id,
                             "blocked fallback output containing structured or tool syntax"
                         );
-                    } else if let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
+                    } else if self.deps.secret_scan_mode() == crate::secrets::scrub::SecretScanMode::Strict && let Some(leak) = crate::secrets::scrub::scan_for_leaks(text) {
                         tracing::warn!(
                             channel_id = %self.id,
                             leak_prefix = %&leak[..leak.len().min(8)],

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -268,12 +268,9 @@ async fn spawn_branch(
                 // Layer 1: exact-match redaction of known secrets from the store.
                 // Layer 2: regex-based redaction of unknown secret patterns.
                 let raw = format!("Branch failed: {error}");
-                let conclusion = if let Some(store) = secrets_snapshot.as_ref() {
-                    crate::secrets::scrub::scrub_with_store(&raw, store)
-                } else {
-                    raw
-                };
-                let conclusion = scan_mode.maybe_scrub_leaks(conclusion);
+                let store_ref: Option<&crate::secrets::store::SecretsStore> =
+                    secrets_snapshot.as_ref().as_ref().map(|s| s.as_ref());
+                let conclusion = scan_mode.apply_scrubbing_with_store(&raw, store_ref);
                 let _ = event_tx.send(crate::ProcessEvent::BranchResult {
                     agent_id,
                     branch_id,
@@ -489,6 +486,7 @@ pub async fn spawn_opencode_worker_from_state(
     let server_pool = rc.opencode_server_pool.load().clone();
 
     let oc_secrets_store = state.deps.runtime_config.secrets.load().as_ref().clone();
+    let scan_mode = state.deps.secret_scan_mode();
 
     let worker = if interactive {
         let (worker, input_tx) = crate::opencode::OpenCodeWorker::new_interactive(
@@ -509,7 +507,7 @@ pub async fn spawn_opencode_worker_from_state(
             Some(store) => worker.with_secrets_store(store.clone()),
             None => worker,
         };
-        worker.with_secret_scan_mode(state.deps.secret_scan_mode())
+        worker.with_secret_scan_mode(scan_mode)
     } else {
         let worker = crate::opencode::OpenCodeWorker::new(
             Some(state.channel_id.clone()),
@@ -523,7 +521,7 @@ pub async fn spawn_opencode_worker_from_state(
             Some(store) => worker.with_secrets_store(store.clone()),
             None => worker,
         };
-        worker.with_secret_scan_mode(state.deps.secret_scan_mode())
+        worker.with_secret_scan_mode(scan_mode)
     };
 
     let worker_id = worker.id;
@@ -541,7 +539,7 @@ pub async fn spawn_opencode_worker_from_state(
         state.deps.agent_id.clone(),
         Some(state.channel_id.clone()),
         oc_secrets_store,
-        state.deps.secret_scan_mode(),
+        scan_mode,
         async move {
             let result = worker.run().await.map_err(SpacebotError::from)?;
             Ok::<String, SpacebotError>(result.result_text)
@@ -633,14 +631,8 @@ where
             Ok(Ok(text)) => {
                 // Scrub tool secret values from the result before it reaches
                 // the channel. The channel never sees raw secret values.
-                // Layer 1: exact-match redaction of known secrets from the store.
-                // Layer 2: regex-based redaction of unknown secret patterns.
-                let scrubbed = if let Some(store) = &secrets_store {
-                    crate::secrets::scrub::scrub_with_store(&text, store)
-                } else {
-                    text
-                };
-                let scrubbed = scan_mode.maybe_scrub_leaks(scrubbed);
+                let store_ref = secrets_store.as_ref().map(|s| s.as_ref());
+                let scrubbed = scan_mode.apply_scrubbing_with_store(&text, store_ref);
                 Ok(scrubbed)
             }
             Ok(Err(error)) => {
@@ -648,12 +640,9 @@ where
                 match failure {
                     WorkerCompletionError::Cancelled { .. } => Err(failure),
                     WorkerCompletionError::Failed { message } => {
-                        let scrubbed = if let Some(store) = &secrets_store {
-                            crate::secrets::scrub::scrub_with_store(&message, store)
-                        } else {
-                            message
-                        };
-                        let scrubbed = scan_mode.maybe_scrub_leaks(scrubbed);
+                        let store_ref = secrets_store.as_ref().map(|s| s.as_ref());
+                        let scrubbed =
+                            scan_mode.apply_scrubbing_with_store(&message, store_ref);
                         Err(WorkerCompletionError::Failed { message: scrubbed })
                     }
                 }

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -251,6 +251,7 @@ async fn spawn_branch(
     let agent_id = state.deps.agent_id.clone();
     let channel_id = state.channel_id.clone();
     let secrets_snapshot = state.deps.runtime_config.secrets.load().clone();
+    let scan_mode = state.deps.secret_scan_mode();
 
     let branch_span = tracing::info_span!(
         "branch.run",
@@ -272,7 +273,7 @@ async fn spawn_branch(
                 } else {
                     raw
                 };
-                let conclusion = crate::secrets::scrub::scrub_leaks(&conclusion);
+                let conclusion = scan_mode.maybe_scrub_leaks(conclusion);
                 let _ = event_tx.send(crate::ProcessEvent::BranchResult {
                     agent_id,
                     branch_id,
@@ -421,12 +422,13 @@ pub async fn spawn_worker_from_state(
         task = %task,
     );
     let secrets_store = state.deps.runtime_config.secrets.load().as_ref().clone();
-    let handle = spawn_worker_task(
+    let handle = spawn_worker_task_with_scan_mode(
         worker_id,
         state.deps.event_tx.clone(),
         state.deps.agent_id.clone(),
         Some(state.channel_id.clone()),
         secrets_store,
+        state.deps.secret_scan_mode(),
         worker.run().instrument(worker_span),
     );
 
@@ -503,10 +505,11 @@ pub async fn spawn_opencode_worker_from_state(
             .write()
             .await
             .insert(worker_id, input_tx);
-        match &oc_secrets_store {
+        let worker = match &oc_secrets_store {
             Some(store) => worker.with_secrets_store(store.clone()),
             None => worker,
-        }
+        };
+        worker.with_secret_scan_mode(state.deps.secret_scan_mode())
     } else {
         let worker = crate::opencode::OpenCodeWorker::new(
             Some(state.channel_id.clone()),
@@ -516,10 +519,11 @@ pub async fn spawn_opencode_worker_from_state(
             server_pool,
             state.deps.event_tx.clone(),
         );
-        match &oc_secrets_store {
+        let worker = match &oc_secrets_store {
             Some(store) => worker.with_secrets_store(store.clone()),
             None => worker,
-        }
+        };
+        worker.with_secret_scan_mode(state.deps.secret_scan_mode())
     };
 
     let worker_id = worker.id;
@@ -531,12 +535,13 @@ pub async fn spawn_opencode_worker_from_state(
         task = %task,
         worker_type = "opencode",
     );
-    let handle = spawn_worker_task(
+    let handle = spawn_worker_task_with_scan_mode(
         worker_id,
         state.deps.event_tx.clone(),
         state.deps.agent_id.clone(),
         Some(state.channel_id.clone()),
         oc_secrets_store,
+        state.deps.secret_scan_mode(),
         async move {
             let result = worker.run().await.map_err(SpacebotError::from)?;
             Ok::<String, SpacebotError>(result.result_text)
@@ -589,6 +594,30 @@ pub(crate) fn spawn_worker_task<F>(
 where
     F: std::future::Future<Output = crate::Result<String>> + Send + 'static,
 {
+    spawn_worker_task_with_scan_mode(
+        worker_id,
+        event_tx,
+        agent_id,
+        channel_id,
+        secrets_store,
+        crate::secrets::scrub::SecretScanMode::Strict,
+        future,
+    )
+}
+
+/// Like `spawn_worker_task` but with an explicit secret scan mode.
+pub(crate) fn spawn_worker_task_with_scan_mode<F>(
+    worker_id: WorkerId,
+    event_tx: broadcast::Sender<ProcessEvent>,
+    agent_id: crate::AgentId,
+    channel_id: Option<ChannelId>,
+    secrets_store: Option<Arc<crate::secrets::store::SecretsStore>>,
+    scan_mode: crate::secrets::scrub::SecretScanMode,
+    future: F,
+) -> tokio::task::JoinHandle<()>
+where
+    F: std::future::Future<Output = crate::Result<String>> + Send + 'static,
+{
     tokio::spawn(async move {
         #[cfg(feature = "metrics")]
         let worker_start = std::time::Instant::now();
@@ -611,7 +640,7 @@ where
                 } else {
                     text
                 };
-                let scrubbed = crate::secrets::scrub::scrub_leaks(&scrubbed);
+                let scrubbed = scan_mode.maybe_scrub_leaks(scrubbed);
                 Ok(scrubbed)
             }
             Ok(Err(error)) => {
@@ -624,7 +653,7 @@ where
                         } else {
                             message
                         };
-                        let scrubbed = crate::secrets::scrub::scrub_leaks(&scrubbed);
+                        let scrubbed = scan_mode.maybe_scrub_leaks(scrubbed);
                         Err(WorkerCompletionError::Failed { message: scrubbed })
                     }
                 }

--- a/src/agent/compactor.rs
+++ b/src/agent/compactor.rs
@@ -245,7 +245,8 @@ async fn run_compaction(
         ProcessType::Compactor,
         Some(channel_id.clone()),
         deps.event_tx.clone(),
-    );
+    )
+    .with_secret_scan_mode(deps.secret_scan_mode());
 
     let mut compaction_history = Vec::new();
     let response = hook

--- a/src/agent/cortex.rs
+++ b/src/agent/cortex.rs
@@ -1924,6 +1924,7 @@ async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyho
     let agent_names = deps.agent_names.clone();
     let sqlite_pool = deps.sqlite_pool.clone();
     let secrets_snapshot = deps.runtime_config.secrets.load().clone();
+    let scan_mode = deps.secret_scan_mode();
     tokio::spawn(async move {
         // Helper closure: scrub both known secrets (Layer 1) and unknown leak
         // patterns (Layer 2) from text before it reaches channels or events.
@@ -1933,7 +1934,7 @@ async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyho
             } else {
                 text
             };
-            crate::secrets::scrub::scrub_leaks(&scrubbed)
+            scan_mode.maybe_scrub_leaks(scrubbed)
         };
 
         match worker.run().await {

--- a/src/agent/cortex.rs
+++ b/src/agent/cortex.rs
@@ -2435,12 +2435,9 @@ async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyho
         // Scrub known secrets and unknown leak patterns from all worker output
         // before persisting, logging, or emitting events.
         let scrub = |text: String| -> String {
-            let scrubbed = if let Some(store) = secrets_snapshot.as_ref() {
-                crate::secrets::scrub::scrub_with_store(&text, store)
-            } else {
-                text
-            };
-            scan_mode.maybe_scrub_leaks(scrubbed)
+            let store_ref: Option<&crate::secrets::store::SecretsStore> =
+                secrets_snapshot.as_ref().as_ref().map(|s| s.as_ref());
+            scan_mode.apply_scrubbing_with_store(&text, store_ref)
         };
 
         let worker_execution = async {

--- a/src/agent/cortex_chat.rs
+++ b/src/agent/cortex_chat.rs
@@ -341,7 +341,8 @@ impl CortexChatSession {
             ProcessType::Cortex,
             channel_context_id.map(std::sync::Arc::<str>::from),
             self.deps.event_tx.clone(),
-        );
+        )
+        .with_secret_scan_mode(self.deps.secret_scan_mode());
         let hook = CortexChatHook::new(event_tx.clone(), spacebot_hook);
 
         // Clone what the spawned task needs

--- a/src/agent/ingestion.rs
+++ b/src/agent/ingestion.rs
@@ -498,7 +498,8 @@ async fn process_chunk(
         ProcessType::Branch,
         None,
         deps.event_tx.clone(),
-    );
+    )
+    .with_secret_scan_mode(deps.secret_scan_mode());
 
     let user_prompt =
         prompt_engine.render_system_ingestion_chunk(filename, chunk_number, total_chunks, chunk)?;

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -85,7 +85,8 @@ impl Worker {
             ProcessType::Worker,
             channel_id.clone(),
             deps.event_tx.clone(),
-        );
+        )
+        .with_secret_scan_mode(deps.secret_scan_mode());
         let (status_tx, status_rx) = watch::channel("starting".to_string());
 
         Self {

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -86,7 +86,8 @@ impl Worker {
             channel_id.clone(),
             deps.event_tx.clone(),
         )
-        .with_secret_scan_mode(deps.secret_scan_mode());
+        .with_secret_scan_mode(deps.secret_scan_mode())
+        .with_secrets_snapshot(deps.runtime_config.secrets.load().as_ref().clone());
         let (status_tx, status_rx) = watch::channel("starting".to_string());
 
         Self {

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -40,6 +40,8 @@ pub struct SpacebotHook {
     /// is performed — regex patterns are skipped to avoid false positives
     /// on public API keys found in scraped web content.
     secret_scan_mode: crate::secrets::scrub::SecretScanMode,
+    /// Snapshot of the secrets store for exact-match scrubbing on event payloads.
+    secrets_snapshot: Option<std::sync::Arc<crate::secrets::store::SecretsStore>>,
     completion_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     saw_tool_call: std::sync::Arc<std::sync::atomic::AtomicBool>,
     nudge_request_active: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -69,6 +71,7 @@ impl SpacebotHook {
             event_tx,
             tool_nudge_policy: ToolNudgePolicy::for_process(process_type),
             secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
+            secrets_snapshot: None,
             completion_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             saw_tool_call: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             nudge_request_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -78,6 +81,15 @@ impl SpacebotHook {
     /// Override the secret scan mode for this hook.
     pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
         self.secret_scan_mode = mode;
+        self
+    }
+
+    /// Set the secrets store snapshot for exact-match scrubbing on event payloads.
+    pub fn with_secrets_snapshot(
+        mut self,
+        store: Option<std::sync::Arc<crate::secrets::store::SecretsStore>>,
+    ) -> Self {
+        self.secrets_snapshot = store;
         self
     }
 
@@ -572,12 +584,10 @@ where
         // processes, scrub leak patterns from the event payload so secrets
         // don't reach the SSE dashboard.
         if matches!(self.process_type, ProcessType::Worker | ProcessType::Branch) {
-            let scrubbed =
-                if self.secret_scan_mode == crate::secrets::scrub::SecretScanMode::Strict {
-                    crate::secrets::scrub::scrub_leaks(result)
-                } else {
-                    result.to_string()
-                };
+            let scrubbed = self.secret_scan_mode.apply_scrubbing_with_store(
+                result,
+                self.secrets_snapshot.as_ref().map(|arc| arc.as_ref()),
+            );
             let capped =
                 crate::tools::truncate_output(&scrubbed, crate::tools::MAX_TOOL_OUTPUT_BYTES);
             self.emit_tool_completed_event_from_capped(tool_name, capped);

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -35,6 +35,11 @@ pub struct SpacebotHook {
     channel_id: Option<ChannelId>,
     event_tx: broadcast::Sender<ProcessEvent>,
     tool_nudge_policy: ToolNudgePolicy,
+    /// Controls whether regex-based leak detection runs on tool output.
+    /// When `OwnSecretsOnly`, only exact-match scrubbing of stored secrets
+    /// is performed — regex patterns are skipped to avoid false positives
+    /// on public API keys found in scraped web content.
+    secret_scan_mode: crate::secrets::scrub::SecretScanMode,
     completion_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     saw_tool_call: std::sync::Arc<std::sync::atomic::AtomicBool>,
     nudge_request_active: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -63,10 +68,17 @@ impl SpacebotHook {
             channel_id,
             event_tx,
             tool_nudge_policy: ToolNudgePolicy::for_process(process_type),
+            secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
             completion_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             saw_tool_call: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             nudge_request_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    /// Override the secret scan mode for this hook.
+    pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
+        self.secret_scan_mode = mode;
+        self
     }
 
     /// Override the default process-scoped nudge policy.
@@ -244,9 +256,20 @@ impl SpacebotHook {
 
     /// Scan content for potential secret leaks, including encoded forms.
     ///
-    /// Delegates to the shared implementation in `secrets::scrub`.
+    /// Respects the configured `SecretScanMode`:
+    /// - `Strict`: full regex-based detection (default).
+    /// - `OwnSecretsOnly`: skips regex detection — own secrets are already
+    ///   redacted by the `StreamScrubber` before this runs, so no further
+    ///   scanning is needed.
+    /// - `Disabled`: no scanning at all.
     fn scan_for_leaks(&self, content: &str) -> Option<String> {
-        crate::secrets::scrub::scan_for_leaks(content)
+        match self.secret_scan_mode {
+            crate::secrets::scrub::SecretScanMode::Strict => {
+                crate::secrets::scrub::scan_for_leaks(content)
+            }
+            crate::secrets::scrub::SecretScanMode::OwnSecretsOnly
+            | crate::secrets::scrub::SecretScanMode::Disabled => None,
+        }
     }
 
     /// Apply shared safety checks for tool output before any downstream handling.
@@ -549,7 +572,12 @@ where
         // processes, scrub leak patterns from the event payload so secrets
         // don't reach the SSE dashboard.
         if matches!(self.process_type, ProcessType::Worker | ProcessType::Branch) {
-            let scrubbed = crate::secrets::scrub::scrub_leaks(result);
+            let scrubbed =
+                if self.secret_scan_mode == crate::secrets::scrub::SecretScanMode::Strict {
+                    crate::secrets::scrub::scrub_leaks(result)
+                } else {
+                    result.to_string()
+                };
             let capped =
                 crate::tools::truncate_output(&scrubbed, crate::tools::MAX_TOOL_OUTPUT_BYTES);
             self.emit_tool_completed_event_from_capped(tool_name, capped);
@@ -914,5 +942,42 @@ mod tests {
                 ..
             } if text_delta == "hi" && aggregated_text == "hi"
         ));
+    }
+
+    #[test]
+    fn own_secrets_only_mode_skips_regex_leak_detection() {
+        let hook = make_hook().with_secret_scan_mode(
+            crate::secrets::scrub::SecretScanMode::OwnSecretsOnly,
+        );
+        // An API key pattern that would normally trigger detection
+        let content = "found key sk-ant-abc123456789012345678 in page";
+        assert!(
+            hook.scan_for_leaks(content).is_none(),
+            "own_secrets_only mode should skip regex detection"
+        );
+    }
+
+    #[test]
+    fn strict_mode_detects_regex_leaks() {
+        let hook = make_hook().with_secret_scan_mode(
+            crate::secrets::scrub::SecretScanMode::Strict,
+        );
+        let content = "found key sk-ant-abc123456789012345678 in page";
+        assert!(
+            hook.scan_for_leaks(content).is_some(),
+            "strict mode should detect regex-matched leaks"
+        );
+    }
+
+    #[test]
+    fn disabled_mode_skips_all_leak_detection() {
+        let hook = make_hook().with_secret_scan_mode(
+            crate::secrets::scrub::SecretScanMode::Disabled,
+        );
+        let content = "found key sk-ant-abc123456789012345678 in page";
+        assert!(
+            hook.scan_for_leaks(content).is_none(),
+            "disabled mode should skip all leak detection"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,11 @@ impl AgentDeps {
     pub fn routing(&self) -> arc_swap::Guard<Arc<llm::RoutingConfig>> {
         self.runtime_config.routing.load()
     }
+
+    /// Read the current secret scan mode from the sandbox config.
+    pub fn secret_scan_mode(&self) -> secrets::scrub::SecretScanMode {
+        self.runtime_config.sandbox.load().secret_scanner
+    }
 }
 
 /// A running agent instance with all its isolated resources.

--- a/src/opencode/worker.rs
+++ b/src/opencode/worker.rs
@@ -33,6 +33,8 @@ pub struct OpenCodeWorker {
     pub model: Option<String>,
     /// Secrets store for exact-match scrubbing of tool secret values in SSE output.
     pub secrets_store: Option<Arc<SecretsStore>>,
+    /// Controls whether regex-based leak detection runs on worker output.
+    pub secret_scan_mode: crate::secrets::scrub::SecretScanMode,
 }
 
 /// Result of an OpenCode worker run.
@@ -63,6 +65,7 @@ impl OpenCodeWorker {
             system_prompt: None,
             model: None,
             secrets_store: None,
+            secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
         }
     }
 
@@ -96,6 +99,12 @@ impl OpenCodeWorker {
     /// Set the secrets store for exact-match scrubbing of tool secret values.
     pub fn with_secrets_store(mut self, store: Arc<SecretsStore>) -> Self {
         self.secrets_store = Some(store);
+        self
+    }
+
+    /// Set the secret scan mode for this worker.
+    pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
+        self.secret_scan_mode = mode;
         self
     }
 
@@ -341,12 +350,14 @@ impl OpenCodeWorker {
                         // before leak detection so they don't trigger false positives.
                         let scrubbed = self.scrub_text(text);
 
-                        if let Some(leak) = crate::secrets::scrub::scan_for_leaks(&scrubbed) {
-                            tracing::warn!(
-                                worker_id = %self.id,
-                                leak_prefix = %&leak[..leak.len().min(8)],
-                                "potential secret detected in OpenCode worker output"
-                            );
+                        if self.secret_scan_mode == crate::secrets::scrub::SecretScanMode::Strict {
+                            if let Some(leak) = crate::secrets::scrub::scan_for_leaks(&scrubbed) {
+                                tracing::warn!(
+                                    worker_id = %self.id,
+                                    leak_prefix = %&leak[..leak.len().min(8)],
+                                    "potential secret detected in OpenCode worker output"
+                                );
+                            }
                         }
 
                         *last_text = scrubbed;
@@ -378,15 +389,19 @@ impl OpenCodeWorker {
                                     // user-visible leak blocking.
                                     if let Some(tool_output) = output {
                                         let scrubbed = self.scrub_text(tool_output);
-                                        if let Some(leak) =
-                                            crate::secrets::scrub::scan_for_leaks(&scrubbed)
+                                        if self.secret_scan_mode
+                                            == crate::secrets::scrub::SecretScanMode::Strict
                                         {
-                                            tracing::warn!(
-                                                worker_id = %self.id,
-                                                tool = %tool_name,
-                                                leak_prefix = %&leak[..leak.len().min(8)],
-                                                "potential secret detected in OpenCode tool output"
-                                            );
+                                            if let Some(leak) =
+                                                crate::secrets::scrub::scan_for_leaks(&scrubbed)
+                                            {
+                                                tracing::warn!(
+                                                    worker_id = %self.id,
+                                                    tool = %tool_name,
+                                                    leak_prefix = %&leak[..leak.len().min(8)],
+                                                    "potential secret detected in OpenCode tool output"
+                                                );
+                                            }
                                         }
                                     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -26,6 +26,16 @@ pub struct SandboxConfig {
     /// in the store. The field is additive either way.
     #[serde(default)]
     pub passthrough_env: Vec<String>,
+    /// Controls how the secret leak scanner operates on tool output.
+    ///
+    /// - `strict` (default): regex-based detection for unknown API key patterns.
+    ///   Catches secrets not in the store but may false-positive on public keys
+    ///   found in scraped web content (e.g. Algolia search keys).
+    /// - `own_secrets_only`: only redact the agent's own stored secrets. Skips
+    ///   regex detection entirely — eliminates false positives from web scraping.
+    /// - `disabled`: no leak detection at all.
+    #[serde(default)]
+    pub secret_scanner: crate::secrets::scrub::SecretScanMode,
 }
 
 impl Default for SandboxConfig {
@@ -34,6 +44,7 @@ impl Default for SandboxConfig {
             mode: SandboxMode::Enabled,
             writable_paths: Vec::new(),
             passthrough_env: Vec::new(),
+            secret_scanner: crate::secrets::scrub::SecretScanMode::default(),
         }
     }
 }

--- a/src/secrets/scrub.rs
+++ b/src/secrets/scrub.rs
@@ -12,7 +12,45 @@
 //! redacted), and leak detection only fires on unknown/unstored secrets.
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
+
+/// Controls how aggressively the leak scanner operates.
+///
+/// `Strict` (default): checks tool output against hardcoded API key regex
+/// patterns. Catches unknown secrets but can false-positive on legitimate
+/// public keys found in scraped web content (e.g. Algolia search keys).
+///
+/// `OwnSecretsOnly`: skips regex-based leak detection entirely. Only the
+/// exact-match `StreamScrubber` (layer 1) redacts the agent's own stored
+/// secrets. This eliminates false positives from web scraping at the cost
+/// of not detecting unknown/unstored secrets in tool output.
+///
+/// `Disabled`: no leak detection at all. Use with caution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretScanMode {
+    /// Regex-based leak detection for unknown secrets (default).
+    #[default]
+    Strict,
+    /// Only redact secrets stored in the agent's secret store.
+    /// Eliminates false positives from scraped web content.
+    OwnSecretsOnly,
+    /// No regex-based leak detection. Exact-match scrubbing of stored
+    /// secrets (Layer 1) still runs. Use with caution.
+    Disabled,
+}
+
+impl SecretScanMode {
+    /// Apply regex-based leak scrubbing only when in `Strict` mode.
+    /// Returns the scrubbed text in Strict mode, or the input unchanged otherwise.
+    pub fn maybe_scrub_leaks(&self, text: String) -> String {
+        match self {
+            Self::Strict => scrub_leaks(&text),
+            Self::OwnSecretsOnly | Self::Disabled => text,
+        }
+    }
+}
 
 /// Regex patterns for known API key formats. Used by `scan_for_leaks()` to
 /// detect secrets that aren't in the store.
@@ -379,5 +417,26 @@ mod tests {
             result.contains("more text"),
             "surrounding text should be preserved in: {result}"
         );
+    }
+
+    #[test]
+    fn secret_scan_mode_defaults_to_strict() {
+        assert_eq!(SecretScanMode::default(), SecretScanMode::Strict);
+    }
+
+    #[test]
+    fn secret_scan_mode_deserializes_from_toml() {
+        #[derive(Deserialize)]
+        struct Config {
+            mode: SecretScanMode,
+        }
+        let strict: Config = toml::from_str(r#"mode = "strict""#).unwrap();
+        assert_eq!(strict.mode, SecretScanMode::Strict);
+
+        let own: Config = toml::from_str(r#"mode = "own_secrets_only""#).unwrap();
+        assert_eq!(own.mode, SecretScanMode::OwnSecretsOnly);
+
+        let disabled: Config = toml::from_str(r#"mode = "disabled""#).unwrap();
+        assert_eq!(disabled.mode, SecretScanMode::Disabled);
     }
 }

--- a/src/secrets/scrub.rs
+++ b/src/secrets/scrub.rs
@@ -50,6 +50,56 @@ impl SecretScanMode {
             Self::OwnSecretsOnly | Self::Disabled => text,
         }
     }
+
+    /// Centralized scrubbing using a `SecretsStore` reference.
+    ///
+    /// Enforces mode semantics end-to-end:
+    /// - `Strict`: exact-match (layer 1) + regex (layer 2).
+    /// - `OwnSecretsOnly`: exact-match only (layer 1).
+    /// - `Disabled`: no scrubbing at all.
+    pub fn apply_scrubbing_with_store(
+        &self,
+        text: &str,
+        store: Option<&crate::secrets::store::SecretsStore>,
+    ) -> String {
+        match self {
+            Self::Disabled => text.to_string(),
+            Self::OwnSecretsOnly => {
+                if let Some(store) = store {
+                    scrub_with_store(text, store)
+                } else {
+                    text.to_string()
+                }
+            }
+            Self::Strict => {
+                let scrubbed = if let Some(store) = store {
+                    scrub_with_store(text, store)
+                } else {
+                    text.to_string()
+                };
+                scrub_leaks(&scrubbed)
+            }
+        }
+    }
+
+    /// Centralized scrubbing using explicit secret name/value pairs.
+    ///
+    /// Same mode semantics as `apply_scrubbing_with_store` but accepts
+    /// pre-extracted pairs instead of a store reference.
+    pub fn apply_scrubbing_with_pairs(
+        &self,
+        text: &str,
+        pairs: &[(String, String)],
+    ) -> String {
+        match self {
+            Self::Disabled => text.to_string(),
+            Self::OwnSecretsOnly => scrub_secrets(text, pairs),
+            Self::Strict => {
+                let scrubbed = scrub_secrets(text, pairs);
+                scrub_leaks(&scrubbed)
+            }
+        }
+    }
 }
 
 /// Regex patterns for known API key formats. Used by `scan_for_leaks()` to
@@ -438,5 +488,48 @@ mod tests {
 
         let disabled: Config = toml::from_str(r#"mode = "disabled""#).unwrap();
         assert_eq!(disabled.mode, SecretScanMode::Disabled);
+    }
+
+    #[test]
+    fn apply_scrubbing_with_pairs_strict_mode() {
+        let pairs = vec![("TOKEN".into(), "my-secret-token".into())];
+        let input = "key: my-secret-token and sk-ant-abc123456789012345678";
+        let result = SecretScanMode::Strict.apply_scrubbing_with_pairs(input, &pairs);
+        // Layer 1: exact-match redaction
+        assert!(
+            result.contains("[REDACTED:TOKEN]"),
+            "expected exact-match redaction in: {result}"
+        );
+        // Layer 2: regex-based redaction
+        assert!(
+            result.contains("[LEAKED_SECRET_REDACTED]"),
+            "expected regex redaction in: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_scrubbing_with_pairs_own_secrets_only_mode() {
+        let pairs = vec![("TOKEN".into(), "my-secret-token".into())];
+        let input = "key: my-secret-token and sk-ant-abc123456789012345678";
+        let result = SecretScanMode::OwnSecretsOnly.apply_scrubbing_with_pairs(input, &pairs);
+        // Layer 1: exact-match redaction should run
+        assert!(
+            result.contains("[REDACTED:TOKEN]"),
+            "expected exact-match redaction in: {result}"
+        );
+        // Layer 2: regex-based redaction should NOT run
+        assert!(
+            result.contains("sk-ant-abc123456789012345678"),
+            "regex leak pattern should pass through in OwnSecretsOnly: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_scrubbing_with_pairs_disabled_mode() {
+        let pairs = vec![("TOKEN".into(), "my-secret-token".into())];
+        let input = "key: my-secret-token and sk-ant-abc123456789012345678";
+        let result = SecretScanMode::Disabled.apply_scrubbing_with_pairs(input, &pairs);
+        // No scrubbing at all
+        assert_eq!(result, input, "disabled mode should return input unchanged");
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -301,14 +301,17 @@ pub async fn add_channel_tools(
             .cloned()
             .unwrap_or_else(|| state.deps.agent_id.to_string());
         handle
-            .add_tool(ReplyTool::new(
-                response_tx.clone(),
-                conversation_id.clone(),
-                state.conversation_logger.clone(),
-                state.channel_id.clone(),
-                replied_flag.clone(),
-                agent_display_name,
-            ))
+            .add_tool(
+                ReplyTool::new(
+                    response_tx.clone(),
+                    conversation_id.clone(),
+                    state.conversation_logger.clone(),
+                    state.channel_id.clone(),
+                    replied_flag.clone(),
+                    agent_display_name,
+                )
+                .with_secret_scan_mode(state.deps.secret_scan_mode()),
+            )
             .await?;
     }
     handle.add_tool(BranchTool::new(state.clone())).await?;
@@ -477,7 +480,7 @@ pub fn create_worker_tool_server(
             if let Some(store) = runtime_config.secrets.load().as_ref() {
                 status_tool = status_tool.with_tool_secrets(store.tool_secret_pairs());
             }
-            status_tool
+            status_tool.with_secret_scan_mode(runtime_config.sandbox.load().secret_scanner)
         })
         .tool(ReadSkillTool::new(runtime_config.clone()));
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -310,7 +310,14 @@ pub async fn add_channel_tools(
                     replied_flag.clone(),
                     agent_display_name,
                 )
-                .with_secret_scan_mode(state.deps.secret_scan_mode()),
+                .with_secret_scan_mode(state.deps.secret_scan_mode())
+                .with_tool_secrets({
+                    let guard = state.deps.runtime_config.secrets.load();
+                    match guard.as_ref() {
+                        Some(store) => store.tool_secret_pairs(),
+                        None => Vec::new(),
+                    }
+                }),
             )
             .await?;
     }

--- a/src/tools/reply.rs
+++ b/src/tools/reply.rs
@@ -46,6 +46,7 @@ pub struct ReplyTool {
     channel_id: ChannelId,
     replied_flag: RepliedFlag,
     agent_display_name: String,
+    secret_scan_mode: crate::secrets::scrub::SecretScanMode,
 }
 
 impl ReplyTool {
@@ -65,7 +66,14 @@ impl ReplyTool {
             channel_id,
             replied_flag,
             agent_display_name: agent_display_name.into(),
+            secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
         }
+    }
+
+    /// Set the secret scan mode for this reply tool.
+    pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
+        self.secret_scan_mode = mode;
+        self
     }
 }
 
@@ -378,15 +386,17 @@ impl Tool for ReplyTool {
             .map(|name| name.trim())
             .filter(|name| !name.is_empty());
 
-        if let Some(leak) = crate::secrets::scrub::scan_for_leaks(&converted_content) {
-            tracing::error!(
-                conversation_id = %self.conversation_id,
-                leak_prefix = %&leak[..leak.len().min(8)],
-                "reply tool blocked content matching secret pattern"
-            );
-            return Err(ReplyError(
-                "blocked reply content: potential secret detected".into(),
-            ));
+        if self.secret_scan_mode == crate::secrets::scrub::SecretScanMode::Strict {
+            if let Some(leak) = crate::secrets::scrub::scan_for_leaks(&converted_content) {
+                tracing::error!(
+                    conversation_id = %self.conversation_id,
+                    leak_prefix = %&leak[..leak.len().min(8)],
+                    "reply tool blocked content matching secret pattern"
+                );
+                return Err(ReplyError(
+                    "blocked reply content: potential secret detected".into(),
+                ));
+            }
         }
 
         let response = if let Some(name) = thread_name {

--- a/src/tools/reply.rs
+++ b/src/tools/reply.rs
@@ -46,6 +46,8 @@ pub struct ReplyTool {
     channel_id: ChannelId,
     replied_flag: RepliedFlag,
     agent_display_name: String,
+    /// Tool secret pairs for exact-match redaction on reply content.
+    tool_secret_pairs: Vec<(String, String)>,
     secret_scan_mode: crate::secrets::scrub::SecretScanMode,
 }
 
@@ -66,6 +68,7 @@ impl ReplyTool {
             channel_id,
             replied_flag,
             agent_display_name: agent_display_name.into(),
+            tool_secret_pairs: Vec::new(),
             secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
         }
     }
@@ -73,6 +76,12 @@ impl ReplyTool {
     /// Set the secret scan mode for this reply tool.
     pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
         self.secret_scan_mode = mode;
+        self
+    }
+
+    /// Set tool secret pairs for exact-match redaction on reply content.
+    pub fn with_tool_secrets(mut self, pairs: Vec<(String, String)>) -> Self {
+        self.tool_secret_pairs = pairs;
         self
     }
 }
@@ -385,6 +394,11 @@ impl Tool for ReplyTool {
             .as_ref()
             .map(|name| name.trim())
             .filter(|name| !name.is_empty());
+
+        // Apply centralized scrubbing: exact-match (layer 1) + regex (layer 2) per mode.
+        let converted_content = self
+            .secret_scan_mode
+            .apply_scrubbing_with_pairs(&converted_content, &self.tool_secret_pairs);
 
         if self.secret_scan_mode == crate::secrets::scrub::SecretScanMode::Strict {
             if let Some(leak) = crate::secrets::scrub::scan_for_leaks(&converted_content) {

--- a/src/tools/set_status.rs
+++ b/src/tools/set_status.rs
@@ -16,6 +16,7 @@ pub struct SetStatusTool {
     event_tx: broadcast::Sender<ProcessEvent>,
     /// Tool secret pairs for scrubbing status text before it reaches the channel.
     tool_secret_pairs: Vec<(String, String)>,
+    secret_scan_mode: crate::secrets::scrub::SecretScanMode,
 }
 
 impl SetStatusTool {
@@ -32,12 +33,19 @@ impl SetStatusTool {
             channel_id,
             event_tx,
             tool_secret_pairs: Vec::new(),
+            secret_scan_mode: crate::secrets::scrub::SecretScanMode::default(),
         }
     }
 
     /// Set tool secret pairs for output scrubbing.
     pub fn with_tool_secrets(mut self, pairs: Vec<(String, String)>) -> Self {
         self.tool_secret_pairs = pairs;
+        self
+    }
+
+    /// Set the secret scan mode for this tool.
+    pub fn with_secret_scan_mode(mut self, mode: crate::secrets::scrub::SecretScanMode) -> Self {
+        self.secret_scan_mode = mode;
         self
     }
 }
@@ -104,7 +112,7 @@ impl Tool for SetStatusTool {
         // Layer 1: exact-match redaction of known secrets from the store.
         // Layer 2: regex-based redaction of unknown secret patterns.
         let status = crate::secrets::scrub::scrub_secrets(&status, &self.tool_secret_pairs);
-        let status = crate::secrets::scrub::scrub_leaks(&status);
+        let status = self.secret_scan_mode.maybe_scrub_leaks(status);
 
         let event = ProcessEvent::WorkerStatus {
             agent_id: self.agent_id.clone(),

--- a/src/tools/set_status.rs
+++ b/src/tools/set_status.rs
@@ -108,11 +108,10 @@ impl Tool for SetStatusTool {
             args.status
         };
 
-        // Scrub tool secret values before the status reaches the channel.
-        // Layer 1: exact-match redaction of known secrets from the store.
-        // Layer 2: regex-based redaction of unknown secret patterns.
-        let status = crate::secrets::scrub::scrub_secrets(&status, &self.tool_secret_pairs);
-        let status = self.secret_scan_mode.maybe_scrub_leaks(status);
+        // Apply centralized scrubbing: exact-match (layer 1) + regex (layer 2) per mode.
+        let status = self
+            .secret_scan_mode
+            .apply_scrubbing_with_pairs(&status, &self.tool_secret_pairs);
 
         let event = ProcessEvent::WorkerStatus {
             agent_id: self.agent_id.clone(),


### PR DESCRIPTION
## Summary

Fixes #45 — Secret scanner erroneously flagging intentionally-public keys (e.g. Algolia search keys embedded in scraped pages) as credentials, killing the worker before returning results.

Adds a configurable `SecretScanMode` with three modes:

| Mode | Layer 1 (exact-match stored secrets) | Layer 2 (regex pattern detection) |
|------|--------------------------------------|-----------------------------------|
| `strict` (default) | ✅ Active | ✅ Active |
| `own_secrets_only` | ✅ Active | ❌ Skipped |
| `disabled` | ❌ Skipped | ❌ Skipped |

**`own_secrets_only`** is the recommended mode for agents that scrape public websites — it still redacts stored secrets but stops flagging third-party API keys found in scraped content.

### Configuration

Per-agent via `sandbox.toml`:
```toml
[sandbox]
secret_scanner = "own_secrets_only"
```

### Changes

- **`src/secrets/scrub.rs`** — `SecretScanMode` enum + `maybe_scrub_leaks()` helper
- **`src/sandbox.rs`** — `secret_scanner` field on `SandboxConfig`
- **`src/lib.rs`** — `secret_scan_mode()` accessor on `AgentDeps`
- **`src/hooks/spacebot.rs`** — Mode-aware `scan_for_leaks()` + 3 tests
- **`src/tools/reply.rs`**, **`src/tools/set_status.rs`** — Respect scan mode on output scrubbing
- **`src/opencode/worker.rs`** — Mode-aware leak scanning
- **`src/agent/{channel,channel_dispatch,branch,cortex,worker,compactor,cortex_chat,ingestion}.rs`** — Thread scan mode through agent pipeline

16 files changed, 268 insertions, 56 deletions.

## Test Plan

- [x] `test_secret_scan_mode_deserialization` — TOML deserializes all 3 variants
- [x] `test_scan_for_leaks_strict_mode` — Regex scanning fires in Strict
- [x] `test_scan_for_leaks_own_secrets_only_mode` — Regex scanning skipped in OwnSecretsOnly
- [x] `test_scan_for_leaks_disabled_mode` — Scanning skipped in Disabled
- [ ] CI: `cargo test --lib` + `cargo clippy`