### PR TITLE
fix(worker): gate text-only exits on explicit outcome signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,7 +380,7 @@ Phase 6 — Hardening:
 
 These are validated patterns from research (see `docs/research/pattern-analysis.md`). Implement them when building the relevant module.
 
-**Tool nudging:** When an LLM responds with text instead of tool calls in the first 2 iterations, inject "Please proceed and use the available tools." Implement in `SpacebotHook.on_completion_response()`. Workers benefit most.
+**Tool nudging / outcome gate:** Workers cannot exit with a text-only response until they signal a terminal outcome via `set_status(kind: "outcome")`. If a worker returns text without an outcome signal, the hook fires `Terminate` and retries with a nudge prompt (up to 2 retries). After retries are exhausted the worker fails with `PromptCancelled`. See `docs/design-docs/tool-nudging.md`.
 
 **Fire-and-forget DB writes:** `tokio::spawn` for conversation history saves, memory writes, worker log persistence. User gets their response immediately.
 

--- a/docs/design-docs/tool-nudging.md
+++ b/docs/design-docs/tool-nudging.md
@@ -1,32 +1,42 @@
 # Tool Nudging
 
-Automatic retry mechanism that encourages workers to use tools when they respond with text-only instead of calling tools.
+Automatic retry mechanism that prevents workers from exiting with text-only responses before signaling a terminal outcome.
 
 ## Problem
 
-Workers sometimes respond with text like "I'll help you with that" without actually calling any tools. This is particularly common:
+Workers sometimes respond with text like "I'll help you with that" or "Let me create the email now..." without actually calling any tools. This is common:
 - At the start of a worker loop when the LLM is "thinking out loud"
 - When the task description is vague and the LLM wants clarification
 - With certain models that have a conversational tendency
+- **Mid-task**, after making a few tool calls (e.g. `read_skill`, `set_status`), the model returns narration instead of continuing with tools
 
-Without intervention, the worker wastes tokens on non-actionable responses and may never complete the task.
+Without intervention, the worker silently reaches `Done` state with no useful output. In Rig's agent loop, any text-only response (no tool calls) terminates the loop — the worker exits as if it completed successfully.
 
 ## Solution
 
-Tool nudging detects text-only responses early in the worker loop and automatically retries with a nudge prompt: "Please proceed and use the available tools."
+Workers must explicitly signal a terminal outcome via `set_status(kind: "outcome")` before they can exit with a text-only response. Until that signal is received, any text-only response triggers a nudge that sends the worker back to work.
 
 ### How It Works
 
 ```
 Worker loop starts
-  → First completion call
-  → If text-only response (no tool calls)
-    → Terminate with special "tool_nudge" reason
-    → Retry with nudge prompt
+  → LLM completion
+  → If response includes tool calls → continue normally
+  → If text-only response:
+    → Has outcome been signaled via set_status(kind: "outcome")? → allow exit
+    → No outcome signal? → Terminate with "tool_nudge" reason → retry with nudge prompt
     → Max 2 retries per prompt request
-  → If tool call present
-    → Continue normally
+    → If retries exhausted → worker fails (PromptCancelled)
 ```
+
+### Outcome Signaling
+
+The `set_status` tool has a `kind` field:
+
+- `kind: "progress"` (default) — intermediate status update, does not unlock exit
+- `kind: "outcome"` — terminal result signal, allows text-only exit
+
+Workers are instructed to call `set_status(kind: "outcome")` with a result summary before finishing. The hook detects this in `on_tool_call` by parsing the args.
 
 ### Policy Scoping
 
@@ -34,7 +44,7 @@ Tool nudging is scoped by process type:
 
 | Process Type | Default Policy | Reason |
 |--------------|----------------|--------|
-| Worker | Enabled | Workers must use tools to complete tasks |
+| Worker | Enabled | Workers must complete tasks before exiting |
 | Branch | Disabled | Branches are for thinking, not doing |
 | Channel | Disabled | Channels should be conversational |
 
@@ -47,23 +57,25 @@ let hook = SpacebotHook::new(...)
 
 ### Implementation Details
 
-**Detection** (`src/hooks/spacebot.rs:should_nudge_tool_usage`):
-- Only active on first 2 completion calls (`TOOL_NUDGE_MAX_RETRIES = 2`)
-- Checks if response contains any `AssistantContent::ToolCall`
-- Ignores empty text responses
-- Stops nudging after any tool call is seen
+**Outcome detection** (`src/hooks/spacebot.rs:on_tool_call`):
+- When a `set_status` call has `kind: "outcome"` in its args, `outcome_signaled` is set to `true`
+- The flag persists for the rest of the prompt request
 
-**Retry Flow** (`prompt_with_tool_nudge_retry`):
-1. Reset nudge state at start of prompt
-2. Track completion call count via atomic counter
-3. On text-only response: terminate with `TOOL_NUDGE_REASON`
-4. Catch termination in retry loop, prune history, retry with nudge prompt
-5. On success: prune the nudge prompt from history to keep context clean
+**Nudge decision** (`src/hooks/spacebot.rs:should_nudge_tool_usage`):
+- Returns `true` when: policy enabled, nudge active, no outcome signaled, response is text-only
+- Returns `false` when: outcome signaled, response has tool calls, policy disabled
 
-**History Hygiene**:
+**Retry flow** (`prompt_with_tool_nudge_retry`):
+1. Reset nudge state at start of prompt (clears `outcome_signaled`)
+2. On text-only response without outcome: terminate with `TOOL_NUDGE_REASON`
+3. Catch termination in retry loop, prune history, retry with nudge prompt
+4. On success: prune the nudge prompt from history to keep context clean
+5. After `TOOL_NUDGE_MAX_RETRIES` (2) exhausted: `PromptCancelled` propagates to worker → `WorkerState::Failed`
+
+**History hygiene**:
 - Synthetic nudge prompts are removed from history on both success and retry
 - Failed assistant turns are pruned but user prompts are preserved
-- Prevents accumulation of "Please proceed..." noise in context
+- Prevents accumulation of nudge noise in context
 
 ### Configuration
 
@@ -86,23 +98,19 @@ let follow_up_hook = hook
 The nudging behavior has comprehensive test coverage:
 
 - **Unit tests** (`src/hooks/spacebot.rs`):
-  - `nudges_only_on_first_two_text_only_completion_calls`
+  - `nudges_on_every_text_only_response_without_outcome` — nudge fires on every text-only response
+  - `nudges_after_tool_calls_without_outcome` — the exact bug case (read_skill + progress status + text exit)
+  - `outcome_signal_allows_text_only_completion` — outcome signal unlocks exit
+  - `progress_status_does_not_signal_outcome` — explicit progress kind doesn't unlock
+  - `default_status_kind_does_not_signal_outcome` — omitted kind doesn't unlock
   - `does_not_nudge_when_completion_contains_tool_call`
-  - `does_not_nudge_after_any_tool_call_has_started`
   - `process_scoped_policy_*` variants for Branch/Channel/Worker
   - `tool_nudge_retry_history_hygiene_*` for history pruning
 
 - **Integration tests** (`tests/tool_nudge.rs`):
-  - End-to-end nudge flow with mock model
-  - Verification that branches/channels don't nudge
-  - History accumulation prevention
-
-### Metrics
-
-When the `metrics` feature is enabled:
-- `tool_calls_total` - Count of tool calls (existing)
-- `tool_call_duration_seconds` - Duration of tool calls (existing)
-- Nudge retry count is logged but not yet a dedicated metric
+  - Public API surface tests (constants, policy enum, hook creation)
+  - Event emission verification
+  - Process-type scoping
 
 ### Future Considerations
 

--- a/prompts/en/tools/set_status_description.md.j2
+++ b/prompts/en/tools/set_status_description.md.j2
@@ -1,1 +1,1 @@
-Report the current status of your work. Use this to update the channel on your progress. The status will appear in the channel's status block. Keep statuses concise (1-2 sentences) and informative.
+Report the current status of your work. The status appears in the channel's status block. Keep statuses concise (1-2 sentences) and informative. Use kind "progress" (default) for intermediate updates. Use kind "outcome" when the task has reached a terminal result — you must signal an outcome before finishing.

--- a/prompts/en/worker.md.j2
+++ b/prompts/en/worker.md.j2
@@ -41,7 +41,9 @@ Sandbox mode is **disabled**.
 
 ## Your Role
 
-Execute the task you were given. Use your tools. Report your status as you make progress. Return the result when you're done.
+Execute the task you were given. Use your tools. Report your status as you make progress.
+
+**When the task is complete** (or you've reached a definitive result), call `set_status` with `kind: "outcome"` and a summary of what happened. Only then provide your final text response. If you try to finish without signaling an outcome, the system will send you back to keep working.
 
 ## Task
 
@@ -51,19 +53,27 @@ Your task is provided in the first message. It contains everything you need to k
 
 ### set_status
 
-Update your visible status. The channel sees this in its status block. Use it to report meaningful progress, not every micro-step.
+Update your visible status. The channel sees this in its status block. Has two modes:
 
-Good status updates:
+**Progress updates** (`kind: "progress"`, the default): Report meaningful intermediate progress, not every micro-step.
+
+Good progress updates:
 
 - "running tests, 3/7 passing"
 - "refactored auth module, updating imports"
 - "found 3 matching files, analyzing"
 
-Bad status updates:
+Bad progress updates:
 
 - "thinking..."
 - "starting"
 - "reading file"
+
+**Outcome** (`kind: "outcome"`): Signal that you have reached a terminal result. You **must** call `set_status` with `kind: "outcome"` before finishing your task. Include a concise summary of the result. Examples:
+
+- `set_status(status: "Email sent to jamie@spacedrive.com", kind: "outcome")`
+- `set_status(status: "Build failed: 3 type errors in auth module", kind: "outcome")`
+- `set_status(status: "Deployed v2.1.0 to staging", kind: "outcome")`
 
 ### shell
 
@@ -121,7 +131,7 @@ Do not log or echo the secret value after storing it.
 1. Do the work. Don't describe what you would do — use the tools and do it.
 2. Update your status at meaningful checkpoints. The channel is using your status to keep the user informed.
 3. If a tool call fails, try to recover. Read the error, adjust, and retry. Don't give up on the first failure.
-4. When you're done with the task, you'll be asked to produce a summary. That summary is the only thing the channel sees — your tool history stays here. Focus on doing the work first, summarizing second.
+4. **Signal your outcome.** When the task is done, call `set_status(kind: "outcome")` with a summary of the result before providing your final text. You cannot finish without this — the system will reject premature exits.
 5. Stay focused on the task. Don't explore tangential work unless it's necessary to complete what you were asked to do.
 6. If you receive follow-up messages (interactive mode), treat them as additional instructions building on your existing context.
 {% if tool_secret_names %}

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -36,13 +36,18 @@ pub struct SpacebotHook {
     event_tx: broadcast::Sender<ProcessEvent>,
     tool_nudge_policy: ToolNudgePolicy,
     completion_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-    saw_tool_call: std::sync::Arc<std::sync::atomic::AtomicBool>,
     nudge_request_active: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Set to `true` when the worker calls `set_status` with `kind: "outcome"`.
+    /// Once signaled, the nudge system allows text-only responses to pass
+    /// through as legitimate completions.
+    outcome_signaled: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl SpacebotHook {
     /// Prompt used to nudge tool-first behavior.
-    pub const TOOL_NUDGE_PROMPT: &str = "Please proceed and use the available tools.";
+    pub const TOOL_NUDGE_PROMPT: &str = "You have not completed the task yet. Continue working using the available tools. \
+         When you have reached a final result, call set_status with kind \"outcome\" \
+         before finishing.";
     /// PromptCancelled reason used internally for tool nudge retries.
     pub const TOOL_NUDGE_REASON: &str = "spacebot_tool_nudge_retry";
     /// Maximum nudge retries per prompt request.
@@ -64,8 +69,8 @@ impl SpacebotHook {
             event_tx,
             tool_nudge_policy: ToolNudgePolicy::for_process(process_type),
             completion_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            saw_tool_call: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             nudge_request_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            outcome_signaled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -80,11 +85,11 @@ impl SpacebotHook {
         self.tool_nudge_policy
     }
 
-    /// Reset per-prompt tool nudging state.
+    /// Reset per-prompt state (tool nudging and outcome tracking).
     pub fn reset_tool_nudge_state(&self) {
         self.completion_calls
             .store(0, std::sync::atomic::Ordering::Relaxed);
-        self.saw_tool_call
+        self.outcome_signaled
             .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
@@ -141,7 +146,7 @@ impl SpacebotHook {
                         process_id = %self.process_id,
                         process_type = %self.process_type,
                         attempt = nudge_attempts,
-                        "response lacked tool calls early in the loop, nudging tool usage"
+                        "text-only response without outcome signal, nudging tool usage"
                     );
                     current_prompt = std::borrow::Cow::Borrowed(Self::TOOL_NUDGE_PROMPT);
                     using_tool_nudge_prompt = true;
@@ -347,6 +352,13 @@ impl SpacebotHook {
         self.event_tx.send(event).ok();
     }
 
+    /// Decide whether a text-only response should be rejected and nudged back
+    /// into tool usage.
+    ///
+    /// Workers are not allowed to exit with a text-only response unless they
+    /// have first signaled a terminal outcome via `set_status(kind: "outcome")`.
+    /// This prevents workers from silently completing with narration instead of
+    /// actually doing the work.
     fn should_nudge_tool_usage<M>(&self, response: &CompletionResponse<M::Response>) -> bool
     where
         M: CompletionModel,
@@ -361,15 +373,10 @@ impl SpacebotHook {
             return false;
         }
 
-        let completion_calls = self
-            .completion_calls
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if completion_calls == 0 || completion_calls > Self::TOOL_NUDGE_MAX_RETRIES {
-            return false;
-        }
-
+        // If the worker already signaled a terminal outcome, allow text-only
+        // responses — the worker is legitimately finishing up.
         if self
-            .saw_tool_call
+            .outcome_signaled
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             return false;
@@ -383,6 +390,7 @@ impl SpacebotHook {
             return false;
         }
 
+        // Text-only response without a prior outcome signal — nudge.
         response.choice.iter().any(|content| {
             if let rig::message::AssistantContent::Text(text) = content {
                 !text.text.trim().is_empty()
@@ -465,9 +473,6 @@ where
         _internal_call_id: &str,
         args: &str,
     ) -> ToolCallHookAction {
-        self.saw_tool_call
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-
         // Leak blocking is enforced at channel egress (`reply`). Worker and
         // branch tool calls may legitimately handle secrets internally.
         if self.process_type == ProcessType::Channel
@@ -566,6 +571,20 @@ where
 
         self.record_tool_result_metrics(tool_name, internal_call_id);
 
+        // Detect terminal outcome signal from successful set_status results.
+        // We check the *result* (not the args) so the flag is only set after the
+        // tool actually executed successfully. A failed set_status call won't
+        // parse as a valid output with `success: true`.
+        if self.tool_nudge_policy.is_enabled()
+            && tool_name == "set_status"
+            && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(result)
+            && parsed.get("success").and_then(|v| v.as_bool()) == Some(true)
+            && parsed.get("kind").and_then(|v| v.as_str()) == Some("outcome")
+        {
+            self.outcome_signaled
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+
         // Channel turns should end immediately after a successful reply tool call.
         // This avoids extra post-reply LLM iterations that add latency, cost, and
         // noisy logs when providers return empty trailing responses.
@@ -633,58 +652,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nudges_only_on_first_two_text_only_completion_calls() {
+    async fn nudges_on_every_text_only_response_without_outcome() {
         let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
         let prompt = prompt_message();
         hook.reset_tool_nudge_state();
         hook.set_tool_nudge_request_active(true);
 
-        let first_call =
-            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
-                .await;
-        assert!(matches!(first_call, HookAction::Continue));
+        // Every text-only response should trigger a nudge when no outcome has
+        // been signaled, regardless of how many completions have occurred.
+        for i in 1..=5 {
+            let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(
+                &hook,
+                &prompt,
+                &[],
+            )
+            .await;
 
-        let first_response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
-            &hook,
-            &prompt,
-            &text_response("I can help with that."),
-        )
-        .await;
-        assert!(matches!(
-            first_response,
-            HookAction::Terminate { ref reason }
-            if reason == SpacebotHook::TOOL_NUDGE_REASON
-        ));
-
-        let second_call =
-            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
-                .await;
-        assert!(matches!(second_call, HookAction::Continue));
-
-        let second_response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
-            &hook,
-            &prompt,
-            &text_response("Still no tools."),
-        )
-        .await;
-        assert!(matches!(
-            second_response,
-            HookAction::Terminate { ref reason }
-            if reason == SpacebotHook::TOOL_NUDGE_REASON
-        ));
-
-        let third_call =
-            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
-                .await;
-        assert!(matches!(third_call, HookAction::Continue));
-
-        let third_response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
-            &hook,
-            &prompt,
-            &text_response("Third attempt should pass through."),
-        )
-        .await;
-        assert!(matches!(third_response, HookAction::Continue));
+            let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
+                &hook,
+                &prompt,
+                &text_response(&format!("text-only attempt {i}")),
+            )
+            .await;
+            assert!(
+                matches!(
+                    response,
+                    HookAction::Terminate { ref reason }
+                    if reason == SpacebotHook::TOOL_NUDGE_REASON
+                ),
+                "Expected nudge on text-only response #{i}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -708,36 +706,245 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn does_not_nudge_after_any_tool_call_has_started() {
+    async fn nudges_after_tool_calls_without_outcome() {
+        // This is the exact bug case: worker calls read_skill + set_status(progress),
+        // then returns text-only. The nudge must still fire.
         let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
         let prompt = prompt_message();
         hook.reset_tool_nudge_state();
         hook.set_tool_nudge_request_active(true);
 
+        // Simulate read_skill tool call
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "read_skill",
+            None,
+            "internal_1",
+            "{\"name\":\"proton-email\"}",
+        )
+        .await;
+
+        // Simulate set_status(progress) tool call
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "set_status",
+            None,
+            "internal_2",
+            "{\"status\":\"Researching...\"}",
+        )
+        .await;
+
+        // Now the model returns text-only — must still nudge
         let _ =
             <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
                 .await;
-
-        let tool_call_action = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
-            &hook,
-            "reply",
-            None,
-            "internal",
-            "{\"content\":\"hello\"}",
-        )
-        .await;
-        assert!(matches!(
-            tool_call_action,
-            rig::agent::ToolCallHookAction::Continue
-        ));
-
         let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
             &hook,
             &prompt,
-            &text_response("final answer"),
+            &text_response("Let me create the email now..."),
         )
         .await;
-        assert!(matches!(response, HookAction::Continue));
+        assert!(
+            matches!(
+                response,
+                HookAction::Terminate { ref reason }
+                if reason == SpacebotHook::TOOL_NUDGE_REASON
+            ),
+            "Expected nudge after tool calls without outcome signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn outcome_signal_allows_text_only_completion() {
+        let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
+        let prompt = prompt_message();
+        hook.reset_tool_nudge_state();
+        hook.set_tool_nudge_request_active(true);
+
+        // Simulate some work
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "shell",
+            None,
+            "internal_1",
+            "{\"command\":\"echo hello\"}",
+        )
+        .await;
+
+        // Signal outcome via set_status tool call + successful result
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "set_status",
+            None,
+            "internal_2",
+            "{\"status\":\"Email sent successfully\",\"kind\":\"outcome\"}",
+        )
+        .await;
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_2",
+            "{\"status\":\"Email sent successfully\",\"kind\":\"outcome\"}",
+            "{\"success\":true,\"worker_id\":1,\"status\":\"Email sent successfully\",\"kind\":\"outcome\"}",
+        )
+        .await;
+
+        // Now text-only response should be allowed
+        let _ =
+            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
+                .await;
+        let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
+            &hook,
+            &prompt,
+            &text_response("Email sent to jamie@spacedrive.com"),
+        )
+        .await;
+        assert!(
+            matches!(response, HookAction::Continue),
+            "Expected text-only to pass through after outcome signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn progress_status_does_not_signal_outcome() {
+        let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
+        let prompt = prompt_message();
+        hook.reset_tool_nudge_state();
+        hook.set_tool_nudge_request_active(true);
+
+        // set_status with kind "progress" should NOT signal outcome, even after
+        // successful execution.
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Working on it...\",\"kind\":\"progress\"}",
+        )
+        .await;
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Working on it...\",\"kind\":\"progress\"}",
+            "{\"success\":true,\"worker_id\":1,\"status\":\"Working on it...\",\"kind\":\"progress\"}",
+        )
+        .await;
+
+        let _ =
+            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
+                .await;
+        let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
+            &hook,
+            &prompt,
+            &text_response("I'll help with that"),
+        )
+        .await;
+        assert!(
+            matches!(
+                response,
+                HookAction::Terminate { ref reason }
+                if reason == SpacebotHook::TOOL_NUDGE_REASON
+            ),
+            "Expected nudge — progress status is not an outcome signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_status_kind_does_not_signal_outcome() {
+        let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
+        let prompt = prompt_message();
+        hook.reset_tool_nudge_state();
+        hook.set_tool_nudge_request_active(true);
+
+        // set_status without kind field — defaults to progress. Even after
+        // successful execution, this should NOT signal outcome.
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Working on it...\"}",
+        )
+        .await;
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Working on it...\"}",
+            "{\"success\":true,\"worker_id\":1,\"status\":\"Working on it...\",\"kind\":\"progress\"}",
+        )
+        .await;
+
+        let _ =
+            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
+                .await;
+        let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
+            &hook,
+            &prompt,
+            &text_response("done"),
+        )
+        .await;
+        assert!(
+            matches!(
+                response,
+                HookAction::Terminate { ref reason }
+                if reason == SpacebotHook::TOOL_NUDGE_REASON
+            ),
+            "Expected nudge — status without kind is not an outcome signal"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_set_status_does_not_signal_outcome() {
+        let hook = make_hook().with_tool_nudge_policy(ToolNudgePolicy::Enabled);
+        let prompt = prompt_message();
+        hook.reset_tool_nudge_state();
+        hook.set_tool_nudge_request_active(true);
+
+        // Simulate a set_status call with outcome kind that fails. Rig passes
+        // the error string as the result, which won't parse as valid JSON with
+        // success: true.
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_call(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Task complete\",\"kind\":\"outcome\"}",
+        )
+        .await;
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Task complete\",\"kind\":\"outcome\"}",
+            "Failed to set status: worker not found",
+        )
+        .await;
+
+        // Text-only response should still be nudged because the outcome tool
+        // call failed.
+        let _ =
+            <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_call(&hook, &prompt, &[])
+                .await;
+        let response = <SpacebotHook as PromptHook<SpacebotModel>>::on_completion_response(
+            &hook,
+            &prompt,
+            &text_response("All done!"),
+        )
+        .await;
+        assert!(
+            matches!(
+                response,
+                HookAction::Terminate { ref reason }
+                if reason == SpacebotHook::TOOL_NUDGE_REASON
+            ),
+            "Expected nudge — failed set_status should not signal outcome"
+        );
     }
 
     #[tokio::test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -98,7 +98,7 @@ pub use send_file::{SendFileArgs, SendFileError, SendFileOutput, SendFileTool};
 pub use send_message_to_another_channel::{
     SendMessageArgs, SendMessageError, SendMessageOutput, SendMessageTool,
 };
-pub use set_status::{SetStatusArgs, SetStatusError, SetStatusOutput, SetStatusTool};
+pub use set_status::{SetStatusArgs, SetStatusError, SetStatusOutput, SetStatusTool, StatusKind};
 pub use shell::{ShellArgs, ShellError, ShellOutput, ShellResult, ShellTool};
 pub use skip::{SkipArgs, SkipError, SkipFlag, SkipOutput, SkipTool, new_skip_flag};
 pub use spacebot_docs::{

--- a/src/tools/set_status.rs
+++ b/src/tools/set_status.rs
@@ -47,11 +47,32 @@ impl SetStatusTool {
 #[error("Failed to set status: {0}")]
 pub struct SetStatusError(String);
 
+/// The kind of status update.
+///
+/// `progress` (default) reports intermediate progress. `outcome` signals that
+/// the worker has reached a terminal result — the task is done (or failed in a
+/// way the worker can describe). Workers **must** emit an `outcome` status
+/// before finishing; the system will nudge them back to work if they try to
+/// stop without one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusKind {
+    /// Intermediate progress update (default).
+    #[default]
+    Progress,
+    /// Terminal outcome — the task is complete or has a definitive result.
+    Outcome,
+}
+
 /// Arguments for set status tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SetStatusArgs {
     /// The status message to report.
     pub status: String,
+    /// The kind of status update: "progress" (default) for intermediate
+    /// updates, "outcome" when the task has reached a terminal result.
+    #[serde(default)]
+    pub kind: StatusKind,
 }
 
 /// Output from set status tool.
@@ -63,6 +84,8 @@ pub struct SetStatusOutput {
     pub worker_id: WorkerId,
     /// The status that was set.
     pub status: String,
+    /// The kind of status that was set.
+    pub kind: StatusKind,
 }
 
 impl Tool for SetStatusTool {
@@ -81,7 +104,13 @@ impl Tool for SetStatusTool {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "description": "A concise status message describing your current progress (1-2 sentences)"
+                        "description": "A concise status message describing your current progress or final result (1-2 sentences)"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["progress", "outcome"],
+                        "default": "progress",
+                        "description": "Use \"progress\" for intermediate updates. Use \"outcome\" when the task has reached a terminal result (success or failure) and you are ready to finish."
                     }
                 },
                 "required": ["status"]
@@ -119,6 +148,7 @@ impl Tool for SetStatusTool {
             success: true,
             worker_id: self.worker_id,
             status,
+            kind: args.kind,
         })
     }
 }

--- a/tests/tool_nudge.rs
+++ b/tests/tool_nudge.rs
@@ -13,9 +13,10 @@ fn tool_nudge_reason_constant_is_valid() {
         spacebot::hooks::SpacebotHook::TOOL_NUDGE_REASON,
         "spacebot_tool_nudge_retry"
     );
-    assert_eq!(
-        spacebot::hooks::SpacebotHook::TOOL_NUDGE_PROMPT,
-        "Please proceed and use the available tools."
+    // Prompt should instruct the worker to continue and signal outcome.
+    assert!(
+        spacebot::hooks::SpacebotHook::TOOL_NUDGE_PROMPT.contains("set_status"),
+        "Nudge prompt should reference set_status for outcome signaling"
     );
     assert_eq!(spacebot::hooks::SpacebotHook::TOOL_NUDGE_MAX_RETRIES, 2);
 }


### PR DESCRIPTION
## Summary

- Workers could silently reach `Done` state without completing their task — the model would return text-only after a few tool calls and the system accepted it as a legitimate completion
- The tool nudge system only protected against cold-start text responses (`saw_tool_call` permanently disabled it after the first tool call), leaving workers unprotected mid-task
- Replace the broken `saw_tool_call`/`completion_calls` guards with an **outcome gate**: workers must call `set_status(kind: "outcome")` before the system allows a text-only exit

## Problem

Observed in production: workers spawned for email-sending tasks would call `read_skill` + `set_status("Researching...")` then return narration text like "Let me create the email now..." — and the worker would exit as `Done` with `success: true`. The email was never sent. This happened 7+ times in a row on the same task.

Root cause: Rig's agent loop treats any text-only response (no tool calls) as the termination signal. The `should_nudge_tool_usage` hook was supposed to catch this, but it had two guards that disabled nudging too early:
1. `saw_tool_call` — any tool call ever → nudge permanently disabled
2. `completion_calls > 2` — more than 2 LLM completions → nudge disabled

Both meant the nudge only worked on the very first 1-2 LLM calls when the model had never touched a tool.

## Changes

**`src/hooks/spacebot.rs`** — Core fix
- Removed `saw_tool_call` field entirely
- Removed `completion_calls` guard from `should_nudge_tool_usage`
- Added `outcome_signaled` atomic flag, set when `set_status(kind: "outcome")` is detected in `on_tool_call` args
- Nudge now fires on **every** text-only worker response unless outcome has been signaled
- Updated nudge prompt to instruct workers about outcome signaling
- Rewrote 3 stale tests, added 4 new tests covering the exact bug case

**`src/tools/set_status.rs`** — Outcome signal mechanism
- Added `StatusKind` enum (`Progress` | `Outcome`) with `#[serde(default)]`
- Added `kind` field to `SetStatusArgs` and tool schema
- Backward compatible: omitting `kind` defaults to `Progress`

**`prompts/en/worker.md.j2`** — Worker instructions
- Workers must call `set_status(kind: "outcome")` with a result summary before finishing
- Updated rules and set_status documentation with examples

**`docs/design-docs/tool-nudging.md`** — Full rewrite reflecting outcome-gated design

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Worker returns text after `read_skill` + `set_status(progress)` | Exits as `Done` | Nudged back to work |
| Worker returns text without any tool calls | Nudged (2 retries) | Nudged (2 retries) |
| Worker calls `set_status(kind: "outcome")` then returns text | N/A | Exits as `Done` |
| Worker exhausts nudge retries without outcome | N/A (exits as Done) | Fails with `PromptCancelled` |

## Testing

- 421 lib tests pass (15 hook tests, 7 new/rewritten)
- 12 integration tests pass
- `cargo fmt` clean, `cargo clippy` zero warnings
- `gate-pr.sh` all green