### PR TITLE
fix: add reasoning_content field for opencode-go/kimi-k2.5 Moonshot compatibility

### DIFF
--- a/src/llm/model.rs
+++ b/src/llm/model.rs
@@ -1353,6 +1353,9 @@ fn convert_messages_to_openai(messages: &OneOrMany<Message>) -> Vec<serde_json::
                 }
                 if !tool_calls.is_empty() {
                     msg["tool_calls"] = serde_json::json!(tool_calls);
+                    // Moonshot AI requires reasoning_content field when thinking is enabled
+                    // and tool_calls are present. Add empty string to satisfy API requirement.
+                    msg["reasoning_content"] = serde_json::json!("");
                 }
                 result.push(msg);
             }


### PR DESCRIPTION
## Summary
Fix Moonshot AI API error when using the `opencode-go/kimi-k2.5` provider. The error occurs because OpenCode's Go API proxy strips the `reasoning_content` field required by Moonshot when thinking is enabled and tool calls are present.

The API returns:
```
400 Bad Request: Provider returned error (upstream provider Moonshot AI: {"error":{"message":"thinking is enabled but reasoning_content is missing in assistant tool call message at index 2","type":"invalid_request_error"}})
```

## Root Cause
When using `opencode-go` as the provider (which routes to Moonshot/Kimi models), the proxy:
1. Receives messages from Spacebot
2. Parses and re-serializes them for upstream forwarding
3. Strips unknown fields like `reasoning_content`
4. Forwards to Moonshot → API rejects the request

This affects workers and branches that make tool calls via the `opencode-go/kimi-k2.5` model when thinking is enabled.

## Key Changes
Add empty `reasoning_content` field to assistant messages containing tool calls in `convert_messages_to_openai()`. This ensures the field survives any intermediate proxy re-serialization and reaches Moonshot.

```rust
if !tool_calls.is_empty() {
    msg["tool_calls"] = serde_json::json!(tool_calls);
    // Moonshot AI requires reasoning_content field when thinking is enabled
    // and tool_calls are present. Add empty string to satisfy API requirement.
    msg["reasoning_content"] = serde_json::json!("");
}
```

## Files Changed

| File | What changed |
|------|-------------|
| `src/llm/model.rs` | Added `reasoning_content` field to assistant messages with tool calls in `convert_messages_to_openai()` |

## Testing

- `cargo check --all-targets` passes
- `cargo fmt --all` clean
- `cargo clippy --all-targets` passes (via `just gate-pr`)
- `just gate-pr` passed
- Tested with `opencode-go/kimi-k2.5` model in worker tool call scenarios

## Note

This fix ensures compatibility with Moonshot's API requirements when accessed through the OpenCode Go proxy. The empty `reasoning_content` field is ignored by OpenAI, OpenRouter, and other providers, making this change safe for all OpenAI-compatible endpoints while specifically fixing the Moonshot + OpenCode Go provider combination.
