### PR TITLE
fix(api): harden admin config and secret handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,7 @@
 //! managing agents, viewing status, and interacting with the system.
 //! Includes an SSE endpoint for realtime event streaming.
 
+mod admin;
 pub mod agents;
 mod bindings;
 mod channels;

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -59,10 +59,18 @@ pub(super) async fn reload_runtime_configs(
     state: &Arc<ApiState>,
     config_path: &Path,
 ) -> Result<crate::config::Config, StatusCode> {
-    let new_config = crate::config::Config::load_from_path(config_path).map_err(|error| {
-        tracing::warn!(%error, "config.toml written but failed to reload immediately");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let config_path = config_path.to_path_buf();
+    let new_config =
+        tokio::task::spawn_blocking(move || crate::config::Config::load_from_path(&config_path))
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "config reload task failed");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+            .map_err(|error| {
+                tracing::warn!(%error, "config.toml written but failed to reload immediately");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
     state
         .set_api_auth_token(new_config.api.auth_token.clone())
@@ -107,7 +115,10 @@ pub(super) fn secrets_store(state: &ApiState) -> Result<Arc<SecretsStore>, Statu
 
 pub(super) async fn require_api_auth_token(state: &ApiState) -> Result<(), StatusCode> {
     let auth_token = state.auth_token.read().await;
-    if auth_token.is_some() {
+    if auth_token
+        .as_deref()
+        .is_some_and(|token| !token.trim().is_empty())
+    {
         Ok(())
     } else {
         Err(StatusCode::FORBIDDEN)

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -1,0 +1,162 @@
+//! Shared admin-plane helpers for config mutation and secret persistence.
+
+use super::state::ApiState;
+use crate::secrets::store::{SecretField, SecretsStore, SystemSecrets};
+
+use axum::http::StatusCode;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub(super) async fn load_config_doc<'a>(
+    state: &'a Arc<ApiState>,
+) -> Result<
+    (
+        tokio::sync::MutexGuard<'a, ()>,
+        PathBuf,
+        toml_edit::DocumentMut,
+    ),
+    StatusCode,
+> {
+    let config_guard = state.config_write_mutex.lock().await;
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        tracing::error!("config_path not set in ApiState");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "failed to read config.toml");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
+    } else {
+        String::new()
+    };
+
+    let doc = content.parse().map_err(|error| {
+        tracing::warn!(%error, "failed to parse config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((config_guard, config_path, doc))
+}
+
+pub(super) async fn write_config_doc(
+    config_path: &Path,
+    doc: &toml_edit::DocumentMut,
+) -> Result<(), StatusCode> {
+    tokio::fs::write(config_path, doc.to_string())
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, path = %config_path.display(), "failed to write config.toml");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+}
+
+pub(super) async fn reload_runtime_configs(
+    state: &Arc<ApiState>,
+    config_path: &Path,
+) -> Result<crate::config::Config, StatusCode> {
+    let new_config = crate::config::Config::load_from_path(config_path).map_err(|error| {
+        tracing::warn!(%error, "config.toml written but failed to reload immediately");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    state
+        .set_api_auth_token(new_config.api.auth_token.clone())
+        .await;
+
+    let runtime_configs = state.runtime_configs.load();
+    let mcp_managers = state.mcp_managers.load();
+    let reload_targets = runtime_configs
+        .iter()
+        .filter_map(|(agent_id, runtime_config)| {
+            mcp_managers.get(agent_id).map(|mcp_manager| {
+                (
+                    agent_id.clone(),
+                    runtime_config.clone(),
+                    mcp_manager.clone(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    drop(runtime_configs);
+    drop(mcp_managers);
+
+    for (agent_id, runtime_config, mcp_manager) in reload_targets {
+        runtime_config
+            .reload_config(&new_config, &agent_id, &mcp_manager)
+            .await;
+    }
+
+    Ok(new_config)
+}
+
+pub(super) fn secrets_store(state: &ApiState) -> Result<Arc<SecretsStore>, StatusCode> {
+    let guard = state.secrets_store.load();
+    match (*guard).as_ref() {
+        Some(store) => Ok(store.clone()),
+        None => {
+            tracing::warn!("secrets store not initialized");
+            Err(StatusCode::SERVICE_UNAVAILABLE)
+        }
+    }
+}
+
+pub(super) async fn require_api_auth_token(state: &ApiState) -> Result<(), StatusCode> {
+    let auth_token = state.auth_token.read().await;
+    if auth_token.is_some() {
+        Ok(())
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+pub(super) fn secret_reference<T: SystemSecrets>(
+    store: &SecretsStore,
+    toml_key: &str,
+    instance_name: Option<&str>,
+    value: &str,
+) -> Result<String, StatusCode> {
+    let field = T::secret_fields()
+        .iter()
+        .find(|field| field.toml_key == toml_key)
+        .ok_or_else(|| {
+            tracing::error!(section = T::section(), toml_key, "unknown secret field");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    secret_reference_for_field(store, field, instance_name, value)
+}
+
+pub(super) fn secret_reference_for_field(
+    store: &SecretsStore,
+    field: &SecretField,
+    instance_name: Option<&str>,
+    value: &str,
+) -> Result<String, StatusCode> {
+    let trimmed_value = value.trim();
+    if trimmed_value.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let secret_name = match instance_name {
+        Some(instance_name) => field.instance_name(instance_name).ok_or_else(|| {
+            tracing::error!(toml_key = field.toml_key, "missing instance naming pattern");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?,
+        None => field.secret_name.to_string(),
+    };
+
+    let category = crate::secrets::store::auto_categorize(&secret_name);
+    store
+        .set(&secret_name, trimmed_value, category)
+        .map_err(|error| {
+            tracing::warn!(%error, secret_name, "failed to persist secret");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(format!("secret:{secret_name}"))
+}

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -59,6 +59,10 @@ pub(super) async fn reload_runtime_configs(
     state: &Arc<ApiState>,
     config_path: &Path,
 ) -> Result<crate::config::Config, StatusCode> {
+    if let Ok(store) = secrets_store(state) {
+        crate::config::set_resolve_secrets_store(store);
+    }
+
     let config_path = config_path.to_path_buf();
     let new_config =
         tokio::task::spawn_blocking(move || crate::config::Config::load_from_path(&config_path))

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -152,8 +152,7 @@ pub(super) fn secret_reference_for_field(
     instance_name: Option<&str>,
     value: &str,
 ) -> Result<String, StatusCode> {
-    let trimmed_value = value.trim();
-    if trimmed_value.is_empty() {
+    if value.trim().is_empty() {
         return Err(StatusCode::BAD_REQUEST);
     }
 
@@ -166,12 +165,16 @@ pub(super) fn secret_reference_for_field(
     };
 
     let category = crate::secrets::store::auto_categorize(&secret_name);
-    store
-        .set(&secret_name, trimmed_value, category)
-        .map_err(|error| {
-            tracing::warn!(%error, secret_name, "failed to persist secret");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    store.set(&secret_name, value, category).map_err(|error| {
+        tracing::warn!(%error, secret_name, "failed to persist secret");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(format!("secret:{secret_name}"))
+}
+
+#[cfg(test)]
+pub(crate) fn config_resolution_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }

--- a/src/api/bindings.rs
+++ b/src/api/bindings.rs
@@ -500,186 +500,174 @@ pub(super) async fn create_binding(
         "binding created via API"
     );
 
-    if let Ok(new_config) = reload_runtime_configs(&state, &config_path).await {
-        let bindings_guard = state.bindings.read().await;
-        if let Some(bindings_swap) = bindings_guard.as_ref() {
-            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
-        }
-        drop(bindings_guard);
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    let bindings_guard = state.bindings.read().await;
+    if let Some(bindings_swap) = bindings_guard.as_ref() {
+        bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
+    }
+    drop(bindings_guard);
 
-        if let Some(discord_config) = &new_config.messaging.discord {
-            let new_perms = crate::config::DiscordPermissions::from_config(
-                discord_config,
-                &new_config.bindings,
+    if let Some(discord_config) = &new_config.messaging.discord {
+        let new_perms =
+            crate::config::DiscordPermissions::from_config(discord_config, &new_config.bindings);
+        let perms = state.discord_permissions.read().await;
+        if let Some(arc_swap) = perms.as_ref() {
+            arc_swap.store(std::sync::Arc::new(new_perms));
+        }
+    }
+
+    if let Some(slack_config) = &new_config.messaging.slack {
+        let new_perms =
+            crate::config::SlackPermissions::from_config(slack_config, &new_config.bindings);
+        let perms = state.slack_permissions.read().await;
+        if let Some(arc_swap) = perms.as_ref() {
+            arc_swap.store(std::sync::Arc::new(new_perms));
+        }
+    }
+
+    let manager_guard = state.messaging_manager.read().await;
+    if let Some(manager) = manager_guard.as_ref() {
+        if let Some(token) = new_discord_token {
+            let discord_perms = {
+                let perms_guard = state.discord_permissions.read().await;
+                match perms_guard.as_ref() {
+                    Some(existing) => existing.clone(),
+                    None => {
+                        drop(perms_guard);
+                        let Some(discord_config) = new_config.messaging.discord.as_ref() else {
+                            tracing::error!("discord config missing despite token being provided");
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                        };
+                        let perms = crate::config::DiscordPermissions::from_config(
+                            discord_config,
+                            &new_config.bindings,
+                        );
+                        let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                        state.set_discord_permissions(arc_swap.clone()).await;
+                        arc_swap
+                    }
+                }
+            };
+            let adapter =
+                crate::messaging::discord::DiscordAdapter::new("discord", &token, discord_perms);
+            if let Err(error) = manager.register_and_start(adapter).await {
+                tracing::error!(%error, "failed to hot-start discord adapter");
+            }
+        }
+
+        if let Some((bot_token, app_token)) = new_slack_tokens {
+            let slack_perms = {
+                let perms_guard = state.slack_permissions.read().await;
+                match perms_guard.as_ref() {
+                    Some(existing) => existing.clone(),
+                    None => {
+                        drop(perms_guard);
+                        let Some(slack_config) = new_config.messaging.slack.as_ref() else {
+                            tracing::error!("slack config missing despite tokens being provided");
+                            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                        };
+                        let perms = crate::config::SlackPermissions::from_config(
+                            slack_config,
+                            &new_config.bindings,
+                        );
+                        let arc_swap = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
+                        state.set_slack_permissions(arc_swap.clone()).await;
+                        arc_swap
+                    }
+                }
+            };
+            let slack_commands = new_config
+                .messaging
+                .slack
+                .as_ref()
+                .map(|s| s.commands.clone())
+                .unwrap_or_default();
+            match crate::messaging::slack::SlackAdapter::new(
+                "slack",
+                &bot_token,
+                &app_token,
+                slack_perms,
+                slack_commands,
+            ) {
+                Ok(adapter) => {
+                    if let Err(error) = manager.register_and_start(adapter).await {
+                        tracing::error!(%error, "failed to hot-start slack adapter");
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build slack adapter");
+                }
+            }
+        }
+
+        if let Some(token) = new_telegram_token {
+            let telegram_perms = {
+                let Some(telegram_config) = new_config.messaging.telegram.as_ref() else {
+                    tracing::error!("telegram config missing despite token being provided");
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                };
+                let perms = crate::config::TelegramPermissions::from_config(
+                    telegram_config,
+                    &new_config.bindings,
+                );
+                std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms))
+            };
+            let adapter = crate::messaging::telegram::TelegramAdapter::new(
+                "telegram",
+                &token,
+                telegram_perms,
             );
-            let perms = state.discord_permissions.read().await;
-            if let Some(arc_swap) = perms.as_ref() {
-                arc_swap.store(std::sync::Arc::new(new_perms));
+            if let Err(error) = manager.register_and_start(adapter).await {
+                tracing::error!(%error, "failed to hot-start telegram adapter");
             }
         }
 
-        if let Some(slack_config) = &new_config.messaging.slack {
-            let new_perms =
-                crate::config::SlackPermissions::from_config(slack_config, &new_config.bindings);
-            let perms = state.slack_permissions.read().await;
-            if let Some(arc_swap) = perms.as_ref() {
-                arc_swap.store(std::sync::Arc::new(new_perms));
+        if new_email_configured {
+            let Some(email_config) = new_config.messaging.email.as_ref() else {
+                tracing::error!("email config missing despite credentials being provided");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            };
+
+            match crate::messaging::email::EmailAdapter::from_config(email_config) {
+                Ok(adapter) => {
+                    if let Err(error) = manager.register_and_start(adapter).await {
+                        tracing::error!(%error, "failed to hot-start email adapter");
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to build email adapter");
+                }
             }
         }
 
-        let manager_guard = state.messaging_manager.read().await;
-        if let Some(manager) = manager_guard.as_ref() {
-            if let Some(token) = new_discord_token {
-                let discord_perms = {
-                    let perms_guard = state.discord_permissions.read().await;
-                    match perms_guard.as_ref() {
-                        Some(existing) => existing.clone(),
-                        None => {
-                            drop(perms_guard);
-                            let Some(discord_config) = new_config.messaging.discord.as_ref() else {
-                                tracing::error!(
-                                    "discord config missing despite token being provided"
-                                );
-                                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                            };
-                            let perms = crate::config::DiscordPermissions::from_config(
-                                discord_config,
-                                &new_config.bindings,
-                            );
-                            let arc_swap =
-                                std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
-                            state.set_discord_permissions(arc_swap.clone()).await;
-                            arc_swap
-                        }
-                    }
-                };
-                let adapter = crate::messaging::discord::DiscordAdapter::new(
-                    "discord",
-                    &token,
-                    discord_perms,
+        if let Some((username, oauth_token)) = new_twitch_creds {
+            let Some(twitch_config) = new_config.messaging.twitch.as_ref() else {
+                tracing::error!("twitch config missing despite credentials being provided");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            };
+            let twitch_perms = {
+                let perms = crate::config::TwitchPermissions::from_config(
+                    twitch_config,
+                    &new_config.bindings,
                 );
-                if let Err(error) = manager.register_and_start(adapter).await {
-                    tracing::error!(%error, "failed to hot-start discord adapter");
-                }
-            }
-
-            if let Some((bot_token, app_token)) = new_slack_tokens {
-                let slack_perms = {
-                    let perms_guard = state.slack_permissions.read().await;
-                    match perms_guard.as_ref() {
-                        Some(existing) => existing.clone(),
-                        None => {
-                            drop(perms_guard);
-                            let Some(slack_config) = new_config.messaging.slack.as_ref() else {
-                                tracing::error!(
-                                    "slack config missing despite tokens being provided"
-                                );
-                                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                            };
-                            let perms = crate::config::SlackPermissions::from_config(
-                                slack_config,
-                                &new_config.bindings,
-                            );
-                            let arc_swap =
-                                std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms));
-                            state.set_slack_permissions(arc_swap.clone()).await;
-                            arc_swap
-                        }
-                    }
-                };
-                let slack_commands = new_config
-                    .messaging
-                    .slack
-                    .as_ref()
-                    .map(|s| s.commands.clone())
-                    .unwrap_or_default();
-                match crate::messaging::slack::SlackAdapter::new(
-                    "slack",
-                    &bot_token,
-                    &app_token,
-                    slack_perms,
-                    slack_commands,
-                ) {
-                    Ok(adapter) => {
-                        if let Err(error) = manager.register_and_start(adapter).await {
-                            tracing::error!(%error, "failed to hot-start slack adapter");
-                        }
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "failed to build slack adapter");
-                    }
-                }
-            }
-
-            if let Some(token) = new_telegram_token {
-                let telegram_perms = {
-                    let Some(telegram_config) = new_config.messaging.telegram.as_ref() else {
-                        tracing::error!("telegram config missing despite token being provided");
-                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                    };
-                    let perms = crate::config::TelegramPermissions::from_config(
-                        telegram_config,
-                        &new_config.bindings,
-                    );
-                    std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms))
-                };
-                let adapter = crate::messaging::telegram::TelegramAdapter::new(
-                    "telegram",
-                    &token,
-                    telegram_perms,
-                );
-                if let Err(error) = manager.register_and_start(adapter).await {
-                    tracing::error!(%error, "failed to hot-start telegram adapter");
-                }
-            }
-
-            if new_email_configured {
-                let Some(email_config) = new_config.messaging.email.as_ref() else {
-                    tracing::error!("email config missing despite credentials being provided");
-                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                };
-
-                match crate::messaging::email::EmailAdapter::from_config(email_config) {
-                    Ok(adapter) => {
-                        if let Err(error) = manager.register_and_start(adapter).await {
-                            tracing::error!(%error, "failed to hot-start email adapter");
-                        }
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "failed to build email adapter");
-                    }
-                }
-            }
-
-            if let Some((username, oauth_token)) = new_twitch_creds {
-                let Some(twitch_config) = new_config.messaging.twitch.as_ref() else {
-                    tracing::error!("twitch config missing despite credentials being provided");
-                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                };
-                let twitch_perms = {
-                    let perms = crate::config::TwitchPermissions::from_config(
-                        twitch_config,
-                        &new_config.bindings,
-                    );
-                    std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms))
-                };
-                let instance_dir = state.instance_dir.load();
-                let token_path = instance_dir.join("twitch_token.json");
-                let adapter = crate::messaging::twitch::TwitchAdapter::new(
-                    "twitch",
-                    &username,
-                    &oauth_token,
-                    twitch_config.client_id.clone(),
-                    twitch_config.client_secret.clone(),
-                    twitch_config.refresh_token.clone(),
-                    Some(token_path),
-                    twitch_config.channels.clone(),
-                    twitch_config.trigger_prefix.clone(),
-                    twitch_perms,
-                );
-                if let Err(error) = manager.register_and_start(adapter).await {
-                    tracing::error!(%error, "failed to hot-start twitch adapter");
-                }
+                std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(perms))
+            };
+            let instance_dir = state.instance_dir.load();
+            let token_path = instance_dir.join("twitch_token.json");
+            let adapter = crate::messaging::twitch::TwitchAdapter::new(
+                "twitch",
+                &username,
+                &oauth_token,
+                twitch_config.client_id.clone(),
+                twitch_config.client_secret.clone(),
+                twitch_config.refresh_token.clone(),
+                Some(token_path),
+                twitch_config.channels.clone(),
+                twitch_config.trigger_prefix.clone(),
+                twitch_perms,
+            );
+            if let Err(error) = manager.register_and_start(adapter).await {
+                tracing::error!(%error, "failed to hot-start twitch adapter");
             }
         }
     }

--- a/src/api/bindings.rs
+++ b/src/api/bindings.rs
@@ -204,7 +204,7 @@ pub(super) async fn create_binding(
     axum::Json(request): axum::Json<CreateBindingRequest>,
 ) -> Result<Json<CreateBindingResponse>, StatusCode> {
     let store = secrets_store(&state)?;
-    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
+    let (config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     let mut new_discord_token: Option<String> = None;
     let mut new_slack_tokens: Option<(String, String)> = None;
@@ -525,6 +525,9 @@ pub(super) async fn create_binding(
         }
     }
 
+    drop(config_guard);
+
+    let mut activation_warning = None;
     let manager_guard = state.messaging_manager.read().await;
     if let Some(manager) = manager_guard.as_ref() {
         if let Some(token) = new_discord_token {
@@ -552,6 +555,9 @@ pub(super) async fn create_binding(
                 crate::messaging::discord::DiscordAdapter::new("discord", &token, discord_perms);
             if let Err(error) = manager.register_and_start(adapter).await {
                 tracing::error!(%error, "failed to hot-start discord adapter");
+                activation_warning = Some(format!(
+                    "binding saved, but discord adapter failed to start: {error}"
+                ));
             }
         }
 
@@ -592,10 +598,16 @@ pub(super) async fn create_binding(
                 Ok(adapter) => {
                     if let Err(error) = manager.register_and_start(adapter).await {
                         tracing::error!(%error, "failed to hot-start slack adapter");
+                        activation_warning = Some(format!(
+                            "binding saved, but slack adapter failed to start: {error}"
+                        ));
                     }
                 }
                 Err(error) => {
                     tracing::error!(%error, "failed to build slack adapter");
+                    activation_warning = Some(format!(
+                        "binding saved, but slack adapter failed to build: {error}"
+                    ));
                 }
             }
         }
@@ -619,6 +631,9 @@ pub(super) async fn create_binding(
             );
             if let Err(error) = manager.register_and_start(adapter).await {
                 tracing::error!(%error, "failed to hot-start telegram adapter");
+                activation_warning = Some(format!(
+                    "binding saved, but telegram adapter failed to start: {error}"
+                ));
             }
         }
 
@@ -632,10 +647,16 @@ pub(super) async fn create_binding(
                 Ok(adapter) => {
                     if let Err(error) = manager.register_and_start(adapter).await {
                         tracing::error!(%error, "failed to hot-start email adapter");
+                        activation_warning = Some(format!(
+                            "binding saved, but email adapter failed to start: {error}"
+                        ));
                     }
                 }
                 Err(error) => {
                     tracing::error!(%error, "failed to build email adapter");
+                    activation_warning = Some(format!(
+                        "binding saved, but email adapter failed to build: {error}"
+                    ));
                 }
             }
         }
@@ -668,14 +689,20 @@ pub(super) async fn create_binding(
             );
             if let Err(error) = manager.register_and_start(adapter).await {
                 tracing::error!(%error, "failed to hot-start twitch adapter");
+                activation_warning = Some(format!(
+                    "binding saved, but twitch adapter failed to start: {error}"
+                ));
             }
         }
     }
 
+    let restart_required = activation_warning.is_some();
+    let message = activation_warning.unwrap_or_else(|| "Binding created and active.".to_string());
+
     Ok(Json(CreateBindingResponse {
         success: true,
-        restart_required: false,
-        message: "Binding created and active.".to_string(),
+        restart_required,
+        message,
     }))
 }
 
@@ -1032,6 +1059,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_binding_moves_platform_credentials_into_secret_store() {
+        let _lock = crate::api::admin::config_resolution_test_lock()
+            .lock()
+            .await;
         let state = test_api_state();
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config_path = tempdir.path().join("config.toml");
@@ -1044,6 +1074,7 @@ mod tests {
         let store =
             Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
         state.set_secrets_store(store.clone());
+        crate::config::set_resolve_secrets_store(store.clone());
 
         let response = create_binding(
             State(state),

--- a/src/api/bindings.rs
+++ b/src/api/bindings.rs
@@ -1,4 +1,8 @@
+use super::admin::{
+    load_config_doc, reload_runtime_configs, secret_reference, secrets_store, write_config_doc,
+};
 use super::state::ApiState;
+use crate::config::{DiscordConfig, EmailConfig, SlackConfig, TelegramConfig, TwitchConfig};
 
 use axum::Json;
 use axum::extract::{Query, State};
@@ -199,26 +203,8 @@ pub(super) async fn create_binding(
     State(state): State<Arc<ApiState>>,
     axum::Json(request): axum::Json<CreateBindingRequest>,
 ) -> Result<Json<CreateBindingResponse>, StatusCode> {
-    let config_path = state.config_path.read().await.clone();
-    if config_path.as_os_str().is_empty() {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    let content = if config_path.exists() {
-        tokio::fs::read_to_string(&config_path)
-            .await
-            .map_err(|error| {
-                tracing::warn!(%error, "failed to read config.toml");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?
-    } else {
-        String::new()
-    };
-
-    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
-        tracing::warn!(%error, "failed to parse config.toml");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let store = secrets_store(&state)?;
+    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     let mut new_discord_token: Option<String> = None;
     let mut new_slack_tokens: Option<(String, String)> = None;
@@ -243,7 +229,9 @@ pub(super) async fn create_binding(
                 .as_table_mut()
                 .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
             discord["enabled"] = toml_edit::value(true);
-            discord["token"] = toml_edit::value(token.as_str());
+            discord["token"] = toml_edit::value(secret_reference::<DiscordConfig>(
+                &store, "token", None, token,
+            )?);
             new_discord_token = Some(token.clone());
         }
         if let Some(bot_token) = &credentials.slack_bot_token {
@@ -262,8 +250,18 @@ pub(super) async fn create_binding(
                     .as_table_mut()
                     .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
                 slack["enabled"] = toml_edit::value(true);
-                slack["bot_token"] = toml_edit::value(bot_token.as_str());
-                slack["app_token"] = toml_edit::value(app_token);
+                slack["bot_token"] = toml_edit::value(secret_reference::<SlackConfig>(
+                    &store,
+                    "bot_token",
+                    None,
+                    bot_token,
+                )?);
+                slack["app_token"] = toml_edit::value(secret_reference::<SlackConfig>(
+                    &store,
+                    "app_token",
+                    None,
+                    app_token,
+                )?);
                 new_slack_tokens = Some((bot_token.clone(), app_token.to_string()));
             }
         }
@@ -283,7 +281,9 @@ pub(super) async fn create_binding(
                 .as_table_mut()
                 .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
             telegram["enabled"] = toml_edit::value(true);
-            telegram["token"] = toml_edit::value(token.as_str());
+            telegram["token"] = toml_edit::value(secret_reference::<TelegramConfig>(
+                &store, "token", None, token,
+            )?);
             new_telegram_token = Some(token.clone());
         }
 
@@ -352,13 +352,33 @@ pub(super) async fn create_binding(
             email["imap_host"] = toml_edit::value(email_imap_host);
             email["imap_port"] =
                 toml_edit::value(i64::from(credentials.email_imap_port.unwrap_or(993)));
-            email["imap_username"] = toml_edit::value(email_imap_username);
-            email["imap_password"] = toml_edit::value(email_imap_password);
+            email["imap_username"] = toml_edit::value(secret_reference::<EmailConfig>(
+                &store,
+                "imap_username",
+                None,
+                &email_imap_username,
+            )?);
+            email["imap_password"] = toml_edit::value(secret_reference::<EmailConfig>(
+                &store,
+                "imap_password",
+                None,
+                &email_imap_password,
+            )?);
             email["smtp_host"] = toml_edit::value(email_smtp_host);
             email["smtp_port"] =
                 toml_edit::value(i64::from(credentials.email_smtp_port.unwrap_or(587)));
-            email["smtp_username"] = toml_edit::value(email_smtp_username);
-            email["smtp_password"] = toml_edit::value(email_smtp_password);
+            email["smtp_username"] = toml_edit::value(secret_reference::<EmailConfig>(
+                &store,
+                "smtp_username",
+                None,
+                &email_smtp_username,
+            )?);
+            email["smtp_password"] = toml_edit::value(secret_reference::<EmailConfig>(
+                &store,
+                "smtp_password",
+                None,
+                &email_smtp_password,
+            )?);
             email["from_address"] = toml_edit::value(email_from_address);
 
             if let Some(from_name) = &credentials.email_from_name {
@@ -391,15 +411,35 @@ pub(super) async fn create_binding(
                     .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
                 twitch["enabled"] = toml_edit::value(true);
                 twitch["username"] = toml_edit::value(username.as_str());
-                twitch["oauth_token"] = toml_edit::value(oauth_token);
+                twitch["oauth_token"] = toml_edit::value(secret_reference::<TwitchConfig>(
+                    &store,
+                    "oauth_token",
+                    None,
+                    oauth_token,
+                )?);
                 if !client_id.is_empty() {
-                    twitch["client_id"] = toml_edit::value(client_id);
+                    twitch["client_id"] = toml_edit::value(secret_reference::<TwitchConfig>(
+                        &store,
+                        "client_id",
+                        None,
+                        client_id,
+                    )?);
                 }
                 if !client_secret.is_empty() {
-                    twitch["client_secret"] = toml_edit::value(client_secret);
+                    twitch["client_secret"] = toml_edit::value(secret_reference::<TwitchConfig>(
+                        &store,
+                        "client_secret",
+                        None,
+                        client_secret,
+                    )?);
                 }
                 if !refresh_token.is_empty() {
-                    twitch["refresh_token"] = toml_edit::value(refresh_token);
+                    twitch["refresh_token"] = toml_edit::value(secret_reference::<TwitchConfig>(
+                        &store,
+                        "refresh_token",
+                        None,
+                        refresh_token,
+                    )?);
                 }
                 new_twitch_creds = Some((username.clone(), oauth_token.to_string()));
             }
@@ -452,12 +492,7 @@ pub(super) async fn create_binding(
     }
     bindings_array.push(binding_table);
 
-    tokio::fs::write(&config_path, doc.to_string())
-        .await
-        .map_err(|error| {
-            tracing::warn!(%error, "failed to write config.toml");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    write_config_doc(&config_path, &doc).await?;
 
     tracing::info!(
         agent_id = %request.agent_id,
@@ -465,7 +500,7 @@ pub(super) async fn create_binding(
         "binding created via API"
     );
 
-    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+    if let Ok(new_config) = reload_runtime_configs(&state, &config_path).await {
         let bindings_guard = state.bindings.read().await;
         if let Some(bindings_swap) = bindings_guard.as_ref() {
             bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
@@ -980,4 +1015,98 @@ pub(super) async fn delete_binding(
         success: true,
         message: "Binding deleted.".to_string(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateBindingRequest, PlatformCredentials, create_binding};
+    use crate::api::ApiState;
+    use axum::extract::State;
+    use std::sync::Arc;
+
+    fn test_api_state() -> Arc<ApiState> {
+        let (provider_setup_tx, _provider_setup_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _agent_remove_rx) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _injection_rx) = tokio::sync::mpsc::channel(1);
+        let task_store_registry = Arc::new(arc_swap::ArcSwap::from_pointee(
+            std::collections::HashMap::new(),
+        ));
+
+        Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+            task_store_registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn create_binding_moves_platform_credentials_into_secret_store() {
+        let state = test_api_state();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        tokio::fs::write(&config_path, "\n")
+            .await
+            .expect("write config");
+        *state.config_path.write().await = config_path.clone();
+
+        let secrets_path = tempdir.path().join("secrets.redb");
+        let store =
+            Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
+        state.set_secrets_store(store.clone());
+
+        let response = create_binding(
+            State(state),
+            axum::Json(CreateBindingRequest {
+                agent_id: "alpha".to_string(),
+                channel: "discord".to_string(),
+                adapter: None,
+                guild_id: None,
+                workspace_id: None,
+                chat_id: None,
+                channel_ids: Vec::new(),
+                require_mention: false,
+                dm_allowed_users: Vec::new(),
+                platform_credentials: Some(PlatformCredentials {
+                    discord_token: Some("discord-secret".to_string()),
+                    slack_bot_token: None,
+                    slack_app_token: None,
+                    telegram_token: None,
+                    email_imap_host: None,
+                    email_imap_port: None,
+                    email_imap_username: None,
+                    email_imap_password: None,
+                    email_smtp_host: None,
+                    email_smtp_port: None,
+                    email_smtp_username: None,
+                    email_smtp_password: None,
+                    email_from_address: None,
+                    email_from_name: None,
+                    twitch_username: None,
+                    twitch_oauth_token: None,
+                    twitch_client_id: None,
+                    twitch_client_secret: None,
+                    twitch_refresh_token: None,
+                }),
+            }),
+        )
+        .await
+        .expect("create binding");
+
+        assert!(response.0.success);
+
+        let config = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read config");
+        assert!(config.contains("secret:DISCORD_BOT_TOKEN"));
+        assert_eq!(
+            store
+                .get("DISCORD_BOT_TOKEN")
+                .expect("secret stored")
+                .expose(),
+            "discord-secret"
+        );
+    }
 }

--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -689,11 +689,7 @@ pub(super) async fn disconnect_platform(
     if platform == "twitch" {
         let instance_dir = state.instance_dir.load();
         if let Some(name) = adapter_name {
-            let safe_name: String = name
-                .chars()
-                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                .collect();
-            let token_path = instance_dir.join(format!("twitch_token_{safe_name}.json"));
+            let token_path = instance_dir.join(crate::config::named_twitch_token_file_name(name));
             match tokio::fs::remove_file(&token_path).await {
                 Ok(()) => {
                     tracing::info!(path = %token_path.display(), "twitch token file deleted");
@@ -1058,14 +1054,8 @@ pub(super) async fn toggle_platform(
                                 "twitch",
                                 Some(instance.name.as_str()),
                             );
-                            let token_file_name = format!(
-                                "twitch_token_{}.json",
-                                instance
-                                    .name
-                                    .chars()
-                                    .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                                    .collect::<String>()
-                            );
+                            let token_file_name =
+                                crate::config::named_twitch_token_file_name(&instance.name);
                             let instance_dir = state.instance_dir.load();
                             let token_path = instance_dir.join(token_file_name);
                             let perms = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(
@@ -1744,11 +1734,7 @@ pub(super) async fn delete_messaging_instance(
     if platform == "twitch" {
         let instance_dir = state.instance_dir.load();
         let token_path = if let Some(name) = adapter_name {
-            let safe_name: String = name
-                .chars()
-                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                .collect();
-            instance_dir.join(format!("twitch_token_{safe_name}.json"))
+            instance_dir.join(crate::config::named_twitch_token_file_name(name))
         } else {
             instance_dir.join("twitch_token.json")
         };
@@ -1803,6 +1789,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_messaging_instance_persists_secret_references() {
+        let _lock = crate::api::admin::config_resolution_test_lock()
+            .lock()
+            .await;
         let state = test_api_state();
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config_path = tempdir.path().join("config.toml");
@@ -1815,6 +1804,7 @@ mod tests {
         let store =
             Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
         state.set_secrets_store(store.clone());
+        crate::config::set_resolve_secrets_store(store.clone());
 
         let response = create_messaging_instance(
             State(state),

--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -1548,11 +1548,10 @@ pub(super) async fn create_messaging_instance(
     write_config_doc(&config_path, &doc).await?;
 
     // Reload config and hot-start the new adapter
-    if let Ok(new_config) = reload_runtime_configs(&state, &config_path).await {
-        let bindings_guard = state.bindings.read().await;
-        if let Some(bindings_swap) = bindings_guard.as_ref() {
-            bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
-        }
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    let bindings_guard = state.bindings.read().await;
+    if let Some(bindings_swap) = bindings_guard.as_ref() {
+        bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
     }
 
     // The file watcher will pick up the change and start the adapter.

--- a/src/api/messaging.rs
+++ b/src/api/messaging.rs
@@ -1,4 +1,10 @@
+use super::admin::{
+    load_config_doc, reload_runtime_configs, secret_reference, secrets_store, write_config_doc,
+};
 use super::state::ApiState;
+use crate::config::{
+    DiscordConfig, EmailConfig, SlackConfig, TelegramConfig, TwitchConfig, WebhookConfig,
+};
 
 use axum::Json;
 use axum::extract::State;
@@ -1153,17 +1159,8 @@ pub(super) async fn create_messaging_instance(
         }
     }
 
-    let config_path = state.config_path.read().await.clone();
-    let content = tokio::fs::read_to_string(&config_path)
-        .await
-        .map_err(|error| {
-            tracing::warn!(%error, "failed to read config.toml");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    let mut doc: toml_edit::DocumentMut = content.parse().map_err(|error| {
-        tracing::warn!(%error, "failed to parse config.toml");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let store = secrets_store(&state)?;
+    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     // Ensure [messaging] and [messaging.<platform>] tables exist
     if doc.get("messaging").is_none() {
@@ -1196,20 +1193,38 @@ pub(super) async fn create_messaging_instance(
             match platform.as_str() {
                 "discord" => {
                     if let Some(token) = &credentials.discord_token {
-                        platform_table["token"] = toml_edit::value(token.as_str());
+                        platform_table["token"] =
+                            toml_edit::value(secret_reference::<DiscordConfig>(
+                                &store, "token", None, token,
+                            )?);
                     }
                 }
                 "slack" => {
                     if let Some(token) = &credentials.slack_bot_token {
-                        platform_table["bot_token"] = toml_edit::value(token.as_str());
+                        platform_table["bot_token"] =
+                            toml_edit::value(secret_reference::<SlackConfig>(
+                                &store,
+                                "bot_token",
+                                None,
+                                token,
+                            )?);
                     }
                     if let Some(token) = &credentials.slack_app_token {
-                        platform_table["app_token"] = toml_edit::value(token.as_str());
+                        platform_table["app_token"] =
+                            toml_edit::value(secret_reference::<SlackConfig>(
+                                &store,
+                                "app_token",
+                                None,
+                                token,
+                            )?);
                     }
                 }
                 "telegram" => {
                     if let Some(token) = &credentials.telegram_token {
-                        platform_table["token"] = toml_edit::value(token.as_str());
+                        platform_table["token"] =
+                            toml_edit::value(secret_reference::<TelegramConfig>(
+                                &store, "token", None, token,
+                            )?);
                     }
                 }
                 "twitch" => {
@@ -1217,16 +1232,40 @@ pub(super) async fn create_messaging_instance(
                         platform_table["username"] = toml_edit::value(username.as_str());
                     }
                     if let Some(token) = &credentials.twitch_oauth_token {
-                        platform_table["oauth_token"] = toml_edit::value(token.as_str());
+                        platform_table["oauth_token"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "oauth_token",
+                                None,
+                                token,
+                            )?);
                     }
                     if let Some(client_id) = &credentials.twitch_client_id {
-                        platform_table["client_id"] = toml_edit::value(client_id.as_str());
+                        platform_table["client_id"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "client_id",
+                                None,
+                                client_id,
+                            )?);
                     }
                     if let Some(client_secret) = &credentials.twitch_client_secret {
-                        platform_table["client_secret"] = toml_edit::value(client_secret.as_str());
+                        platform_table["client_secret"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "client_secret",
+                                None,
+                                client_secret,
+                            )?);
                     }
                     if let Some(refresh) = &credentials.twitch_refresh_token {
-                        platform_table["refresh_token"] = toml_edit::value(refresh.as_str());
+                        platform_table["refresh_token"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "refresh_token",
+                                None,
+                                refresh,
+                            )?);
                     }
                 }
                 "email" => {
@@ -1237,10 +1276,22 @@ pub(super) async fn create_messaging_instance(
                         platform_table["imap_port"] = toml_edit::value(i64::from(port));
                     }
                     if let Some(username) = &credentials.email_imap_username {
-                        platform_table["imap_username"] = toml_edit::value(username.as_str());
+                        platform_table["imap_username"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "imap_username",
+                                None,
+                                username,
+                            )?);
                     }
                     if let Some(password) = &credentials.email_imap_password {
-                        platform_table["imap_password"] = toml_edit::value(password.as_str());
+                        platform_table["imap_password"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "imap_password",
+                                None,
+                                password,
+                            )?);
                     }
                     if let Some(host) = &credentials.email_smtp_host {
                         platform_table["smtp_host"] = toml_edit::value(host.as_str());
@@ -1249,10 +1300,22 @@ pub(super) async fn create_messaging_instance(
                         platform_table["smtp_port"] = toml_edit::value(i64::from(port));
                     }
                     if let Some(username) = &credentials.email_smtp_username {
-                        platform_table["smtp_username"] = toml_edit::value(username.as_str());
+                        platform_table["smtp_username"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "smtp_username",
+                                None,
+                                username,
+                            )?);
                     }
                     if let Some(password) = &credentials.email_smtp_password {
-                        platform_table["smtp_password"] = toml_edit::value(password.as_str());
+                        platform_table["smtp_password"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "smtp_password",
+                                None,
+                                password,
+                            )?);
                     }
                     if let Some(from) = &credentials.email_from_address {
                         platform_table["from_address"] = toml_edit::value(from.as_str());
@@ -1266,7 +1329,13 @@ pub(super) async fn create_messaging_instance(
                         platform_table["bind"] = toml_edit::value(bind.as_str());
                     }
                     if let Some(token) = &credentials.webhook_auth_token {
-                        platform_table["auth_token"] = toml_edit::value(token.as_str());
+                        platform_table["auth_token"] =
+                            toml_edit::value(secret_reference::<WebhookConfig>(
+                                &store,
+                                "auth_token",
+                                None,
+                                token,
+                            )?);
                     }
                 }
                 _ => {}
@@ -1305,20 +1374,44 @@ pub(super) async fn create_messaging_instance(
             match platform.as_str() {
                 "discord" => {
                     if let Some(token) = &credentials.discord_token {
-                        instance_table["token"] = toml_edit::value(token.as_str());
+                        instance_table["token"] =
+                            toml_edit::value(secret_reference::<DiscordConfig>(
+                                &store,
+                                "token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                 }
                 "slack" => {
                     if let Some(token) = &credentials.slack_bot_token {
-                        instance_table["bot_token"] = toml_edit::value(token.as_str());
+                        instance_table["bot_token"] =
+                            toml_edit::value(secret_reference::<SlackConfig>(
+                                &store,
+                                "bot_token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                     if let Some(token) = &credentials.slack_app_token {
-                        instance_table["app_token"] = toml_edit::value(token.as_str());
+                        instance_table["app_token"] =
+                            toml_edit::value(secret_reference::<SlackConfig>(
+                                &store,
+                                "app_token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                 }
                 "telegram" => {
                     if let Some(token) = &credentials.telegram_token {
-                        instance_table["token"] = toml_edit::value(token.as_str());
+                        instance_table["token"] =
+                            toml_edit::value(secret_reference::<TelegramConfig>(
+                                &store,
+                                "token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                 }
                 "twitch" => {
@@ -1326,16 +1419,40 @@ pub(super) async fn create_messaging_instance(
                         instance_table["username"] = toml_edit::value(username.as_str());
                     }
                     if let Some(token) = &credentials.twitch_oauth_token {
-                        instance_table["oauth_token"] = toml_edit::value(token.as_str());
+                        instance_table["oauth_token"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "oauth_token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                     if let Some(client_id) = &credentials.twitch_client_id {
-                        instance_table["client_id"] = toml_edit::value(client_id.as_str());
+                        instance_table["client_id"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "client_id",
+                                Some(&instance_name),
+                                client_id,
+                            )?);
                     }
                     if let Some(client_secret) = &credentials.twitch_client_secret {
-                        instance_table["client_secret"] = toml_edit::value(client_secret.as_str());
+                        instance_table["client_secret"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "client_secret",
+                                Some(&instance_name),
+                                client_secret,
+                            )?);
                     }
                     if let Some(refresh) = &credentials.twitch_refresh_token {
-                        instance_table["refresh_token"] = toml_edit::value(refresh.as_str());
+                        instance_table["refresh_token"] =
+                            toml_edit::value(secret_reference::<TwitchConfig>(
+                                &store,
+                                "refresh_token",
+                                Some(&instance_name),
+                                refresh,
+                            )?);
                     }
                 }
                 "email" => {
@@ -1346,10 +1463,22 @@ pub(super) async fn create_messaging_instance(
                         instance_table["imap_port"] = toml_edit::value(i64::from(port));
                     }
                     if let Some(username) = &credentials.email_imap_username {
-                        instance_table["imap_username"] = toml_edit::value(username.as_str());
+                        instance_table["imap_username"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "imap_username",
+                                Some(&instance_name),
+                                username,
+                            )?);
                     }
                     if let Some(password) = &credentials.email_imap_password {
-                        instance_table["imap_password"] = toml_edit::value(password.as_str());
+                        instance_table["imap_password"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "imap_password",
+                                Some(&instance_name),
+                                password,
+                            )?);
                     }
                     if let Some(host) = &credentials.email_smtp_host {
                         instance_table["smtp_host"] = toml_edit::value(host.as_str());
@@ -1358,10 +1487,22 @@ pub(super) async fn create_messaging_instance(
                         instance_table["smtp_port"] = toml_edit::value(i64::from(port));
                     }
                     if let Some(username) = &credentials.email_smtp_username {
-                        instance_table["smtp_username"] = toml_edit::value(username.as_str());
+                        instance_table["smtp_username"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "smtp_username",
+                                Some(&instance_name),
+                                username,
+                            )?);
                     }
                     if let Some(password) = &credentials.email_smtp_password {
-                        instance_table["smtp_password"] = toml_edit::value(password.as_str());
+                        instance_table["smtp_password"] =
+                            toml_edit::value(secret_reference::<EmailConfig>(
+                                &store,
+                                "smtp_password",
+                                Some(&instance_name),
+                                password,
+                            )?);
                     }
                     if let Some(from) = &credentials.email_from_address {
                         instance_table["from_address"] = toml_edit::value(from.as_str());
@@ -1375,7 +1516,13 @@ pub(super) async fn create_messaging_instance(
                         instance_table["bind"] = toml_edit::value(bind.as_str());
                     }
                     if let Some(token) = &credentials.webhook_auth_token {
-                        instance_table["auth_token"] = toml_edit::value(token.as_str());
+                        instance_table["auth_token"] =
+                            toml_edit::value(secret_reference::<WebhookConfig>(
+                                &store,
+                                "auth_token",
+                                Some(&instance_name),
+                                token,
+                            )?);
                     }
                 }
                 _ => {}
@@ -1398,15 +1545,10 @@ pub(super) async fn create_messaging_instance(
     }
 
     // Write updated config
-    tokio::fs::write(&config_path, doc.to_string())
-        .await
-        .map_err(|error| {
-            tracing::warn!(%error, "failed to write config.toml");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    write_config_doc(&config_path, &doc).await?;
 
     // Reload config and hot-start the new adapter
-    if let Ok(new_config) = crate::config::Config::load_from_path(&config_path) {
+    if let Ok(new_config) = reload_runtime_configs(&state, &config_path).await {
         let bindings_guard = state.bindings.read().await;
         if let Some(bindings_swap) = bindings_guard.as_ref() {
             bindings_swap.store(std::sync::Arc::new(new_config.bindings.clone()));
@@ -1632,4 +1774,85 @@ pub(super) async fn delete_messaging_instance(
         success: true,
         message: format!("{runtime_key} instance deleted"),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CreateMessagingInstanceRequest, InstanceCredentials, create_messaging_instance};
+    use crate::api::ApiState;
+    use axum::Json;
+    use axum::extract::State;
+    use std::sync::Arc;
+
+    fn test_api_state() -> Arc<ApiState> {
+        let (provider_setup_tx, _provider_setup_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _agent_remove_rx) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _injection_rx) = tokio::sync::mpsc::channel(1);
+        let task_store_registry = Arc::new(arc_swap::ArcSwap::from_pointee(
+            std::collections::HashMap::new(),
+        ));
+
+        Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+            task_store_registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn create_messaging_instance_persists_secret_references() {
+        let state = test_api_state();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        tokio::fs::write(&config_path, "\n")
+            .await
+            .expect("write config");
+        *state.config_path.write().await = config_path.clone();
+
+        let secrets_path = tempdir.path().join("secrets.redb");
+        let store =
+            Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
+        state.set_secrets_store(store.clone());
+
+        let response = create_messaging_instance(
+            State(state),
+            Json(CreateMessagingInstanceRequest {
+                platform: "slack".to_string(),
+                name: Some("alerts".to_string()),
+                enabled: Some(true),
+                credentials: InstanceCredentials {
+                    slack_bot_token: Some("xoxb-secret".to_string()),
+                    slack_app_token: Some("xapp-secret".to_string()),
+                    ..Default::default()
+                },
+            }),
+        )
+        .await
+        .expect("create messaging instance");
+
+        assert!(response.0.success);
+
+        let config = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read config");
+        assert!(config.contains("secret:SLACK_ALERTS_BOT_TOKEN"));
+        assert!(config.contains("secret:SLACK_ALERTS_APP_TOKEN"));
+        assert_eq!(
+            store
+                .get("SLACK_ALERTS_BOT_TOKEN")
+                .expect("bot token stored")
+                .expose(),
+            "xoxb-secret"
+        );
+        assert_eq!(
+            store
+                .get("SLACK_ALERTS_APP_TOKEN")
+                .expect("app token stored")
+                .expose(),
+            "xapp-secret"
+        );
+    }
 }

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -156,24 +156,6 @@ fn model_matches_provider(provider: &str, model: &str) -> bool {
     crate::llm::routing::provider_from_model(model) == provider
 }
 
-/// Reload the in-memory defaults config from disk so that newly created agents
-/// inherit the latest routing values rather than stale startup defaults.
-async fn refresh_defaults_config(state: &Arc<ApiState>) {
-    let config_path = state.config_path.read().await.clone();
-    if config_path.as_os_str().is_empty() || !config_path.exists() {
-        return;
-    }
-    match crate::config::Config::load_from_path(&config_path) {
-        Ok(new_config) => {
-            state.set_defaults_config(new_config.defaults).await;
-            tracing::debug!("defaults_config refreshed from config.toml");
-        }
-        Err(error) => {
-            tracing::warn!(%error, "failed to refresh defaults_config from config.toml");
-        }
-    }
-}
-
 fn normalize_openai_chatgpt_model(model: &str) -> Option<String> {
     let trimmed = model.trim();
     let (provider, model_name) = trimmed.split_once('/')?;
@@ -324,8 +306,10 @@ async fn finalize_openai_oauth(
         .await
         .map_err(|status| anyhow::anyhow!("failed to write config.toml: {status}"))?;
 
-    let _ = reload_runtime_configs(state, &config_path).await;
-    refresh_defaults_config(state).await;
+    let new_config = reload_runtime_configs(state, &config_path)
+        .await
+        .map_err(|status| anyhow::anyhow!("failed to reload runtime config: {status}"))?;
+    state.set_defaults_config(new_config.defaults.clone()).await;
 
     state
         .provider_setup_tx
@@ -775,10 +759,8 @@ pub(super) async fn update_provider(
     apply_model_routing(&mut doc, normalized_model);
 
     write_config_doc(&config_path, &doc).await?;
-    let _ = reload_runtime_configs(&state, &config_path).await;
-
-    // Refresh in-memory defaults so newly created agents inherit the updated routing.
-    refresh_defaults_config(&state).await;
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    state.set_defaults_config(new_config.defaults.clone()).await;
 
     state
         .provider_setup_tx
@@ -927,7 +909,8 @@ pub(super) async fn delete_provider(
     }
 
     write_config_doc(&config_path, &doc).await?;
-    let _ = reload_runtime_configs(&state, &config_path).await;
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    state.set_defaults_config(new_config.defaults.clone()).await;
 
     Ok(Json(ProviderUpdateResponse {
         success: true,

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1,4 +1,6 @@
+use super::admin::{load_config_doc, reload_runtime_configs, secret_reference, write_config_doc};
 use super::state::ApiState;
+use crate::config::LlmConfig;
 use crate::openai_auth::DeviceTokenPollResult;
 
 use anyhow::Context as _;
@@ -314,22 +316,15 @@ async fn finalize_openai_oauth(
             .await;
     }
 
-    let config_path = state.config_path.read().await.clone();
-    let content = if config_path.exists() {
-        tokio::fs::read_to_string(&config_path)
-            .await
-            .context("failed to read config.toml")?
-    } else {
-        String::new()
-    };
-
-    let mut doc: toml_edit::DocumentMut = content.parse().context("failed to parse config.toml")?;
-    apply_model_routing(&mut doc, model);
-    tokio::fs::write(&config_path, doc.to_string())
+    let (_config_guard, config_path, mut doc) = load_config_doc(state)
         .await
-        .context("failed to write config.toml")?;
+        .map_err(|status| anyhow::anyhow!("failed to load config.toml: {status}"))?;
+    apply_model_routing(&mut doc, model);
+    write_config_doc(&config_path, &doc)
+        .await
+        .map_err(|status| anyhow::anyhow!("failed to write config.toml: {status}"))?;
 
-    // Refresh in-memory defaults so newly created agents inherit the updated routing.
+    let _ = reload_runtime_configs(state, &config_path).await;
     refresh_defaults_config(state).await;
 
     state
@@ -763,30 +758,24 @@ pub(super) async fn update_provider(
         }));
     }
 
-    let config_path = state.config_path.read().await.clone();
-
-    let content = if config_path.exists() {
-        tokio::fs::read_to_string(&config_path)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    } else {
-        String::new()
-    };
-
-    let mut doc: toml_edit::DocumentMut = content
-        .parse()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let store = super::admin::secrets_store(&state)?;
+    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     if doc.get("llm").is_none() {
         doc["llm"] = toml_edit::Item::Table(toml_edit::Table::new());
     }
 
-    doc["llm"][key_name] = toml_edit::value(request.api_key);
+    if key_name == "ollama_base_url" {
+        doc["llm"][key_name] = toml_edit::value(request.api_key.trim());
+    } else {
+        let secret_ref =
+            secret_reference::<LlmConfig>(&store, key_name, None, request.api_key.trim())?;
+        doc["llm"][key_name] = toml_edit::value(secret_ref);
+    }
     apply_model_routing(&mut doc, normalized_model);
 
-    tokio::fs::write(&config_path, doc.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    write_config_doc(&config_path, &doc).await?;
+    let _ = reload_runtime_configs(&state, &config_path).await;
 
     // Refresh in-memory defaults so newly created agents inherit the updated routing.
     refresh_defaults_config(&state).await;
@@ -929,13 +918,7 @@ pub(super) async fn delete_provider(
         }));
     }
 
-    let content = tokio::fs::read_to_string(&config_path)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let mut doc: toml_edit::DocumentMut = content
-        .parse()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     if let Some(llm) = doc.get_mut("llm")
         && let Some(table) = llm.as_table_mut()
@@ -943,9 +926,8 @@ pub(super) async fn delete_provider(
         table.remove(key_name);
     }
 
-    tokio::fs::write(&config_path, doc.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    write_config_doc(&config_path, &doc).await?;
+    let _ = reload_runtime_configs(&state, &config_path).await;
 
     Ok(Json(ProviderUpdateResponse {
         success: true,
@@ -955,7 +937,11 @@ pub(super) async fn delete_provider(
 
 #[cfg(test)]
 mod tests {
-    use super::build_test_llm_config;
+    use super::{ProviderUpdateRequest, build_test_llm_config, update_provider};
+    use crate::api::ApiState;
+    use axum::Json;
+    use axum::extract::State;
+    use std::sync::Arc;
 
     #[test]
     fn build_test_llm_config_registers_ollama_provider_from_base_url() {
@@ -967,5 +953,61 @@ mod tests {
 
         assert_eq!(provider.base_url, "http://remote-ollama.local:11434");
         assert_eq!(provider.api_key, "");
+    }
+
+    fn test_api_state() -> Arc<ApiState> {
+        let (provider_setup_tx, _provider_setup_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _agent_remove_rx) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _injection_rx) = tokio::sync::mpsc::channel(1);
+        let task_store_registry = Arc::new(arc_swap::ArcSwap::from_pointee(
+            std::collections::HashMap::new(),
+        ));
+
+        Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+            task_store_registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn update_provider_persists_secret_reference() {
+        let state = test_api_state();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let config_path = tempdir.path().join("config.toml");
+        tokio::fs::write(&config_path, "\n")
+            .await
+            .expect("write config");
+        *state.config_path.write().await = config_path.clone();
+
+        let secrets_path = tempdir.path().join("secrets.redb");
+        let store =
+            Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
+        state.set_secrets_store(store.clone());
+
+        let response = update_provider(
+            State(state),
+            Json(ProviderUpdateRequest {
+                provider: "openai".to_string(),
+                api_key: "sk-test".to_string(),
+                model: "openai/gpt-4o-mini".to_string(),
+            }),
+        )
+        .await
+        .expect("update provider");
+
+        assert!(response.0.success);
+
+        let config = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read config");
+        assert!(config.contains("secret:OPENAI_API_KEY"));
+        assert_eq!(
+            store.get("OPENAI_API_KEY").expect("secret stored").expose(),
+            "sk-test"
+        );
     }
 }

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -958,6 +958,9 @@ mod tests {
 
     #[tokio::test]
     async fn update_provider_persists_secret_reference() {
+        let _lock = crate::api::admin::config_resolution_test_lock()
+            .lock()
+            .await;
         let state = test_api_state();
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config_path = tempdir.path().join("config.toml");
@@ -970,6 +973,7 @@ mod tests {
         let store =
             Arc::new(crate::secrets::store::SecretsStore::new(&secrets_path).expect("secrets"));
         state.set_secrets_store(store.clone());
+        crate::config::set_resolve_secrets_store(store.clone());
 
         let response = update_provider(
             State(state),

--- a/src/api/secrets.rs
+++ b/src/api/secrets.rs
@@ -4,6 +4,7 @@
 //! for the instance-level secret store. Secrets are global — shared across all
 //! agents in the instance.
 
+use super::admin::require_api_auth_token;
 use super::state::ApiState;
 use crate::config::{
     DefaultsConfig, DiscordConfig, EmailConfig, LlmConfig, SlackConfig, TelegramConfig,
@@ -488,6 +489,16 @@ pub async fn migrate_secrets(State(state): State<Arc<ApiState>>) -> impl IntoRes
 
 /// `POST /api/secrets/export` — Export all secrets as a JSON backup.
 pub async fn export_secrets(State(state): State<Arc<ApiState>>) -> impl IntoResponse {
+    if let Err(status) = require_api_auth_token(&state).await {
+        return (
+            status,
+            Json(
+                serde_json::json!({"error": "api.auth_token must be configured to export secrets"}),
+            ),
+        )
+            .into_response();
+    }
+
     let store = match get_secrets_store(&state) {
         Ok(s) => s,
         Err(e) => return e.into_response(),
@@ -756,5 +767,39 @@ fn set_instance_toml_value(
     };
     if let Some(instance) = instances.get_mut(index) {
         instance[key] = toml_edit::value(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::export_secrets;
+    use crate::api::ApiState;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use std::sync::Arc;
+
+    fn test_api_state() -> Arc<ApiState> {
+        let (provider_setup_tx, _provider_setup_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _agent_remove_rx) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _injection_rx) = tokio::sync::mpsc::channel(1);
+        let task_store_registry = Arc::new(arc_swap::ArcSwap::from_pointee(
+            std::collections::HashMap::new(),
+        ));
+
+        Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+            task_store_registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn export_secrets_requires_configured_api_auth() {
+        let state = test_api_state();
+        let response = export_secrets(State(state)).await.into_response();
+        assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
     }
 }

--- a/src/api/secrets.rs
+++ b/src/api/secrets.rs
@@ -8,7 +8,7 @@ use super::admin::require_api_auth_token;
 use super::state::ApiState;
 use crate::config::{
     DefaultsConfig, DiscordConfig, EmailConfig, LlmConfig, SlackConfig, TelegramConfig,
-    TwitchConfig,
+    TwitchConfig, WebhookConfig,
 };
 use crate::secrets::store::{
     ExportData, SecretCategory, SecretsStore, StoreState, SystemSecrets, auto_categorize,
@@ -459,6 +459,7 @@ pub async fn migrate_secrets(State(state): State<Arc<ApiState>>) -> impl IntoRes
     migrate_section_secrets::<TelegramConfig>(&store, &mut doc, &mut migrated);
     migrate_section_secrets::<TwitchConfig>(&store, &mut doc, &mut migrated);
     migrate_section_secrets::<EmailConfig>(&store, &mut doc, &mut migrated);
+    migrate_section_secrets::<WebhookConfig>(&store, &mut doc, &mut migrated);
 
     // Write updated config.toml if any migrations were made.
     if !migrated.is_empty()

--- a/src/api/secrets.rs
+++ b/src/api/secrets.rs
@@ -802,5 +802,13 @@ mod tests {
         let state = test_api_state();
         let response = export_secrets(State(state)).await.into_response();
         assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
+
+        let state = test_api_state();
+        state.set_api_auth_token(Some("test".to_string())).await;
+        let response = export_secrets(State(state)).await.into_response();
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -331,7 +331,10 @@ async fn api_auth_middleware(
         return next.run(request).await;
     }
 
-    let expected_token = state.auth_token.read().await.clone();
+    let expected_token = state.auth_token.read().await.clone().and_then(|token| {
+        let trimmed = token.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
     let Some(expected_token) = expected_token.as_deref() else {
         let bind = *state.api_bind.read().await;
         if bind.is_some_and(|bind| !bind.ip().is_loopback()) {
@@ -373,11 +376,17 @@ fn allow_local_origin(
     };
 
     origin.starts_with("http://127.0.0.1:")
+        || origin.starts_with("https://127.0.0.1:")
         || origin.starts_with("http://localhost:")
+        || origin.starts_with("https://localhost:")
         || origin.starts_with("http://[::1]:")
+        || origin.starts_with("https://[::1]:")
         || origin == "http://127.0.0.1"
+        || origin == "https://127.0.0.1"
         || origin == "http://localhost"
+        || origin == "https://localhost"
         || origin == "http://[::1]"
+        || origin == "https://[::1]"
 }
 
 pub(crate) fn should_warn_unprotected_bind(bind: SocketAddr, auth_token: Option<&str>) -> bool {
@@ -518,6 +527,10 @@ mod tests {
         ));
         assert!(allow_local_origin(
             &HeaderValue::from_static("http://127.0.0.1:3000"),
+            &parts,
+        ));
+        assert!(allow_local_origin(
+            &HeaderValue::from_static("https://localhost:5173"),
             &parts,
         ));
         assert!(!allow_local_origin(

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -37,6 +37,7 @@ pub async fn start_http_server(
     state: Arc<ApiState>,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+    state.set_api_bind(bind).await;
     let auth_token = state.auth_token.read().await.clone();
     if should_warn_unprotected_bind(bind, auth_token.as_deref()) {
         anyhow::bail!(
@@ -325,15 +326,25 @@ async fn api_auth_middleware(
     request: Request,
     next: Next,
 ) -> Response {
-    let expected_token = state.auth_token.read().await.clone();
-    let Some(expected_token) = expected_token.as_deref() else {
-        return next.run(request).await;
-    };
-
     let path = request.uri().path();
     if path == "/api/health" || path == "/health" {
         return next.run(request).await;
     }
+
+    let expected_token = state.auth_token.read().await.clone();
+    let Some(expected_token) = expected_token.as_deref() else {
+        let bind = *state.api_bind.read().await;
+        if bind.is_some_and(|bind| !bind.ip().is_loopback()) {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(
+                    json!({"error": "api auth token must remain configured for public listeners"}),
+                ),
+            )
+                .into_response();
+        }
+        return next.run(request).await;
+    };
 
     let is_authorized = request
         .headers()

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -37,8 +37,15 @@ pub async fn start_http_server(
     state: Arc<ApiState>,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+    let auth_token = state.auth_token.read().await.clone();
+    if should_warn_unprotected_bind(bind, auth_token.as_deref()) {
+        anyhow::bail!(
+            "refusing to start HTTP API on {bind} without api.auth_token; use a loopback bind or configure authentication"
+        );
+    }
+
     let cors = CorsLayer::new()
-        .allow_origin(tower_http::cors::AllowOrigin::mirror_request())
+        .allow_origin(tower_http::cors::AllowOrigin::predicate(allow_local_origin))
         .allow_methods([
             axum::http::Method::GET,
             axum::http::Method::POST,
@@ -318,7 +325,8 @@ async fn api_auth_middleware(
     request: Request,
     next: Next,
 ) -> Response {
-    let Some(expected_token) = state.auth_token.as_deref() else {
+    let expected_token = state.auth_token.read().await.clone();
+    let Some(expected_token) = expected_token.as_deref() else {
         return next.run(request).await;
     };
 
@@ -343,6 +351,26 @@ async fn api_auth_middleware(
         )
             .into_response()
     }
+}
+
+fn allow_local_origin(
+    origin: &header::HeaderValue,
+    _request_parts: &axum::http::request::Parts,
+) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+
+    origin.starts_with("http://127.0.0.1:")
+        || origin.starts_with("http://localhost:")
+        || origin.starts_with("http://[::1]:")
+        || origin == "http://127.0.0.1"
+        || origin == "http://localhost"
+        || origin == "http://[::1]"
+}
+
+pub(crate) fn should_warn_unprotected_bind(bind: SocketAddr, auth_token: Option<&str>) -> bool {
+    auth_token.is_none() && !bind.ip().is_loopback()
 }
 
 #[cfg(feature = "metrics")]
@@ -453,4 +481,37 @@ async fn static_handler(uri: Uri) -> Response {
     }
 
     (StatusCode::NOT_FOUND, "not found").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{allow_local_origin, should_warn_unprotected_bind};
+    use axum::http::{HeaderValue, Request};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    #[test]
+    fn warns_for_non_loopback_bind_without_auth() {
+        let bind = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 19898);
+        assert!(should_warn_unprotected_bind(bind, None));
+        assert!(!should_warn_unprotected_bind(bind, Some("token")));
+    }
+
+    #[test]
+    fn local_origin_predicate_accepts_localhost_only() {
+        let request = Request::builder().uri("/").body(()).expect("request");
+        let parts = request.into_parts().0;
+
+        assert!(allow_local_origin(
+            &HeaderValue::from_static("http://localhost:5173"),
+            &parts,
+        ));
+        assert!(allow_local_origin(
+            &HeaderValue::from_static("http://127.0.0.1:3000"),
+            &parts,
+        ));
+        assert!(!allow_local_origin(
+            &HeaderValue::from_static("https://evil.example"),
+            &parts,
+        ));
+    }
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -370,7 +370,7 @@ fn allow_local_origin(
 }
 
 pub(crate) fn should_warn_unprotected_bind(bind: SocketAddr, auth_token: Option<&str>) -> bool {
-    auth_token.is_none() && !bind.ip().is_loopback()
+    auth_token.is_none_or(|token| token.trim().is_empty()) && !bind.ip().is_loopback()
 }
 
 #[cfg(feature = "metrics")]

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -321,7 +321,8 @@ pub(super) async fn update_global_settings(
     }
 
     write_config_doc(&config_path, &doc).await?;
-    let _ = reload_runtime_configs(&state, &config_path).await;
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    state.set_defaults_config(new_config.defaults.clone()).await;
 
     let message = if requires_restart {
         "Settings updated. API server changes require a restart to take effect.".to_string()
@@ -429,7 +430,8 @@ pub(super) async fn update_raw_config(
 
     tracing::info!("config.toml updated via raw editor");
 
-    let _ = reload_runtime_configs(&state, &config_path).await;
+    let new_config = reload_runtime_configs(&state, &config_path).await?;
+    state.set_defaults_config(new_config.defaults.clone()).await;
 
     Ok(Json(RawConfigUpdateResponse {
         success: true,

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -406,7 +406,12 @@ pub(super) async fn update_raw_config(
     Json(request): Json<RawConfigUpdateRequest>,
 ) -> Result<Json<RawConfigUpdateResponse>, StatusCode> {
     require_api_auth_token(&state).await?;
-    let (_config_guard, config_path, _doc) = load_config_doc(&state).await?;
+    let _config_guard = state.config_write_mutex.lock().await;
+    let config_path = state.config_path.read().await.clone();
+    if config_path.as_os_str().is_empty() {
+        tracing::error!("config_path not set in ApiState");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
 
     if let Err(error) = crate::config::Config::validate_toml(&request.content) {
         return Ok(Json(RawConfigUpdateResponse {

--- a/src/api/settings.rs
+++ b/src/api/settings.rs
@@ -1,3 +1,6 @@
+use super::admin::{
+    load_config_doc, reload_runtime_configs, require_api_auth_token, write_config_doc,
+};
 use super::state::ApiState;
 
 use axum::Json;
@@ -226,19 +229,7 @@ pub(super) async fn update_global_settings(
     State(state): State<Arc<ApiState>>,
     Json(request): Json<GlobalSettingsUpdate>,
 ) -> Result<Json<GlobalSettingsUpdateResponse>, StatusCode> {
-    let config_path = state.config_path.read().await.clone();
-
-    let content = if config_path.exists() {
-        tokio::fs::read_to_string(&config_path)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    } else {
-        String::new()
-    };
-
-    let mut doc: toml_edit::DocumentMut = content
-        .parse()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let (_config_guard, config_path, mut doc) = load_config_doc(&state).await?;
 
     let mut requires_restart = false;
 
@@ -329,45 +320,8 @@ pub(super) async fn update_global_settings(
         }
     }
 
-    tokio::fs::write(&config_path, doc.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let reload_path = config_path.clone();
-    match tokio::task::spawn_blocking(move || crate::config::Config::load_from_path(&reload_path))
-        .await
-    {
-        Ok(Ok(new_config)) => {
-            let runtime_configs = state.runtime_configs.load();
-            let mcp_managers = state.mcp_managers.load();
-            let reload_targets = runtime_configs
-                .iter()
-                .filter_map(|(agent_id, runtime_config)| {
-                    mcp_managers.get(agent_id).map(|mcp_manager| {
-                        (
-                            agent_id.clone(),
-                            runtime_config.clone(),
-                            mcp_manager.clone(),
-                        )
-                    })
-                })
-                .collect::<Vec<_>>();
-            drop(runtime_configs);
-            drop(mcp_managers);
-
-            for (agent_id, runtime_config, mcp_manager) in reload_targets {
-                runtime_config
-                    .reload_config(&new_config, &agent_id, &mcp_manager)
-                    .await;
-            }
-        }
-        Ok(Err(error)) => {
-            tracing::warn!(%error, "settings written but failed to reload config immediately");
-        }
-        Err(error) => {
-            tracing::warn!(%error, "settings written but config reload task failed");
-        }
-    }
+    write_config_doc(&config_path, &doc).await?;
+    let _ = reload_runtime_configs(&state, &config_path).await;
 
     let message = if requires_restart {
         "Settings updated. API server changes require a restart to take effect.".to_string()
@@ -425,6 +379,8 @@ pub(super) async fn update_apply(
 pub(super) async fn get_raw_config(
     State(state): State<Arc<ApiState>>,
 ) -> Result<Json<RawConfigResponse>, StatusCode> {
+    require_api_auth_token(&state).await?;
+
     let config_path = state.config_path.read().await.clone();
     if config_path.as_os_str().is_empty() {
         tracing::error!("config_path not set in ApiState");
@@ -449,11 +405,8 @@ pub(super) async fn update_raw_config(
     State(state): State<Arc<ApiState>>,
     Json(request): Json<RawConfigUpdateRequest>,
 ) -> Result<Json<RawConfigUpdateResponse>, StatusCode> {
-    let config_path = state.config_path.read().await.clone();
-    if config_path.as_os_str().is_empty() {
-        tracing::error!("config_path not set in ApiState");
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    }
+    require_api_auth_token(&state).await?;
+    let (_config_guard, config_path, _doc) = load_config_doc(&state).await?;
 
     if let Err(error) = crate::config::Config::validate_toml(&request.content) {
         return Ok(Json(RawConfigUpdateResponse {
@@ -471,38 +424,55 @@ pub(super) async fn update_raw_config(
 
     tracing::info!("config.toml updated via raw editor");
 
-    match crate::config::Config::load_from_path(&config_path) {
-        Ok(new_config) => {
-            let runtime_configs = state.runtime_configs.load();
-            let mcp_managers = state.mcp_managers.load();
-            let reload_targets = runtime_configs
-                .iter()
-                .filter_map(|(agent_id, runtime_config)| {
-                    mcp_managers.get(agent_id).map(|mcp_manager| {
-                        (
-                            agent_id.clone(),
-                            runtime_config.clone(),
-                            mcp_manager.clone(),
-                        )
-                    })
-                })
-                .collect::<Vec<_>>();
-            drop(runtime_configs);
-            drop(mcp_managers);
-
-            for (agent_id, runtime_config, mcp_manager) in reload_targets {
-                runtime_config
-                    .reload_config(&new_config, &agent_id, &mcp_manager)
-                    .await;
-            }
-        }
-        Err(error) => {
-            tracing::warn!(%error, "config.toml written but failed to reload immediately");
-        }
-    }
+    let _ = reload_runtime_configs(&state, &config_path).await;
 
     Ok(Json(RawConfigUpdateResponse {
         success: true,
         message: "Config saved and reloaded.".to_string(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawConfigUpdateRequest, get_raw_config, update_raw_config};
+    use crate::api::ApiState;
+    use axum::Json;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use std::sync::Arc;
+
+    fn test_api_state() -> Arc<ApiState> {
+        let (provider_setup_tx, _provider_setup_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _agent_remove_rx) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _injection_rx) = tokio::sync::mpsc::channel(1);
+        let task_store_registry = Arc::new(arc_swap::ArcSwap::from_pointee(
+            std::collections::HashMap::new(),
+        ));
+
+        Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+            task_store_registry,
+        ))
+    }
+
+    #[tokio::test]
+    async fn raw_config_endpoints_require_api_auth() {
+        let state = test_api_state();
+
+        let get_result = get_raw_config(State(state.clone())).await;
+        assert!(matches!(get_result, Err(StatusCode::FORBIDDEN)));
+
+        let update_result = update_raw_config(
+            State(state),
+            Json(RawConfigUpdateRequest {
+                content: String::new(),
+            }),
+        )
+        .await;
+        assert!(matches!(update_result, Err(StatusCode::FORBIDDEN)));
+    }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -21,6 +21,7 @@ use arc_swap::ArcSwap;
 use serde::Serialize;
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -49,6 +50,7 @@ pub struct AgentInfo {
 pub struct ApiState {
     pub started_at: Instant,
     pub auth_token: tokio::sync::RwLock<Option<String>>,
+    pub api_bind: RwLock<Option<SocketAddr>>,
     /// Aggregated event stream from all agents. SSE clients subscribe here.
     pub event_tx: broadcast::Sender<ApiEvent>,
     /// Per-agent SQLite pools for querying channel/conversation data.
@@ -291,6 +293,7 @@ impl ApiState {
         Self {
             started_at: Instant::now(),
             auth_token: tokio::sync::RwLock::new(None),
+            api_bind: RwLock::new(None),
             event_tx,
             agent_pools: arc_swap::ArcSwap::from_pointee(HashMap::new()),
             agent_configs: arc_swap::ArcSwap::from_pointee(Vec::new()),
@@ -794,7 +797,19 @@ impl ApiState {
 
     /// Set the live API auth token used by the HTTP middleware.
     pub async fn set_api_auth_token(&self, auth_token: Option<String>) {
-        *self.auth_token.write().await = auth_token;
+        *self.auth_token.write().await = auth_token.and_then(|token| {
+            let trimmed = token.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        });
+    }
+
+    /// Set the bound HTTP API listener address for runtime auth checks.
+    pub async fn set_api_bind(&self, bind: SocketAddr) {
+        *self.api_bind.write().await = Some(bind);
     }
 
     /// Set the instance directory path.

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -48,7 +48,7 @@ pub struct AgentInfo {
 /// State shared across all API handlers.
 pub struct ApiState {
     pub started_at: Instant,
-    pub auth_token: Option<String>,
+    pub auth_token: tokio::sync::RwLock<Option<String>>,
     /// Aggregated event stream from all agents. SSE clients subscribe here.
     pub event_tx: broadcast::Sender<ApiEvent>,
     /// Per-agent SQLite pools for querying channel/conversation data.
@@ -290,7 +290,7 @@ impl ApiState {
         let (event_tx, _) = broadcast::channel(512);
         Self {
             started_at: Instant::now(),
-            auth_token: None,
+            auth_token: tokio::sync::RwLock::new(None),
             event_tx,
             agent_pools: arc_swap::ArcSwap::from_pointee(HashMap::new()),
             agent_configs: arc_swap::ArcSwap::from_pointee(Vec::new()),
@@ -790,6 +790,11 @@ impl ApiState {
     /// Share the messaging manager for runtime adapter addition from API handlers.
     pub async fn set_messaging_manager(&self, manager: Arc<MessagingManager>) {
         *self.messaging_manager.write().await = Some(manager);
+    }
+
+    /// Set the live API auth token used by the HTTP middleware.
+    pub async fn set_api_auth_token(&self, auth_token: Option<String>) {
+        *self.auth_token.write().await = auth_token;
     }
 
     /// Set the instance directory path.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -175,37 +175,19 @@ pub async fn exchange_code(code_with_state: &str, verifier: &str) -> Result<OAut
 
 /// Path to the Anthropic OAuth credentials file within the instance directory.
 pub fn credentials_path(instance_dir: &Path) -> PathBuf {
-    instance_dir.join("anthropic_oauth.json")
+    crate::oauth_storage::json_credentials_path(instance_dir, "anthropic_oauth.json")
 }
 
 /// Load stored credentials from disk.
 pub fn load_credentials(instance_dir: &Path) -> Result<Option<OAuthCredentials>> {
     let path = credentials_path(instance_dir);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let data = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let creds: OAuthCredentials =
-        serde_json::from_str(&data).context("failed to parse auth.json")?;
-    Ok(Some(creds))
+    crate::oauth_storage::load_json_credentials(&path)
 }
 
 /// Save credentials to disk with restricted permissions (0600).
 pub fn save_credentials(instance_dir: &Path, creds: &OAuthCredentials) -> Result<()> {
     let path = credentials_path(instance_dir);
-    let data = serde_json::to_string_pretty(creds).context("failed to serialize credentials")?;
-
-    std::fs::write(&path, &data).with_context(|| format!("failed to write {}", path.display()))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
-    }
-
-    Ok(())
+    crate::oauth_storage::save_json_credentials(&path, creds)
 }
 
 /// Run the interactive OAuth login flow. Prints URL, prompts for code, exchanges tokens.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1554,6 +1554,21 @@ pub fn binding_runtime_adapter_key(platform: &str, adapter: Option<&str>) -> Str
     platform.to_string()
 }
 
+/// Build the persisted token filename for a named Twitch adapter instance.
+pub fn named_twitch_token_file_name(name: &str) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let safe_name: String = name
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    let name_hash = hasher.finish();
+
+    format!("twitch_token_{safe_name}_{name_hash:016x}.json")
+}
+
 /// Match a binding's adapter selector against an inbound message adapter.
 pub(super) fn binding_adapter_matches(binding: &Binding, message: &crate::InboundMessage) -> bool {
     match (&binding.adapter, message.adapter_selector()) {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -2328,6 +2328,27 @@ impl SystemSecrets for TwitchConfig {
     }
 }
 
+impl SystemSecrets for WebhookConfig {
+    fn section() -> &'static str {
+        "webhook"
+    }
+
+    fn is_messaging_adapter() -> bool {
+        true
+    }
+
+    fn secret_fields() -> &'static [SecretField] {
+        &[SecretField {
+            toml_key: "auth_token",
+            secret_name: "WEBHOOK_AUTH_TOKEN",
+            instance_pattern: Some(InstancePattern {
+                platform_prefix: "WEBHOOK",
+                field_suffix: "AUTH_TOKEN",
+            }),
+        }]
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WebhookConfig {
     pub enabled: bool,

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -16,6 +17,15 @@ type WatchedAgent = (
     Arc<crate::mcp::McpManager>,
 );
 
+type NamedDiscordPermissions =
+    Arc<std::sync::RwLock<HashMap<String, Arc<arc_swap::ArcSwap<DiscordPermissions>>>>>;
+type NamedSlackPermissions =
+    Arc<std::sync::RwLock<HashMap<String, Arc<arc_swap::ArcSwap<SlackPermissions>>>>>;
+type NamedTelegramPermissions =
+    Arc<std::sync::RwLock<HashMap<String, Arc<arc_swap::ArcSwap<TelegramPermissions>>>>>;
+type NamedTwitchPermissions =
+    Arc<std::sync::RwLock<HashMap<String, Arc<arc_swap::ArcSwap<TwitchPermissions>>>>>;
+
 /// Watches config, prompt, identity, and skill files for changes and triggers
 /// hot reload on the corresponding RuntimeConfig.
 ///
@@ -31,6 +41,10 @@ pub fn spawn_file_watcher(
     slack_permissions: Option<Arc<arc_swap::ArcSwap<SlackPermissions>>>,
     telegram_permissions: Option<Arc<arc_swap::ArcSwap<TelegramPermissions>>>,
     twitch_permissions: Option<Arc<arc_swap::ArcSwap<TwitchPermissions>>>,
+    named_discord_permissions: NamedDiscordPermissions,
+    named_slack_permissions: NamedSlackPermissions,
+    named_telegram_permissions: NamedTelegramPermissions,
+    named_twitch_permissions: NamedTwitchPermissions,
     bindings: Arc<arc_swap::ArcSwap<Vec<Binding>>>,
     messaging_manager: Option<Arc<crate::messaging::MessagingManager>>,
     llm_manager: Arc<crate::llm::LlmManager>,
@@ -213,6 +227,19 @@ pub fn spawn_file_watcher(
                         DiscordPermissions::from_config(discord_config, &config.bindings);
                     perms.store(Arc::new(new_perms));
                     tracing::info!("discord permissions reloaded");
+
+                    let registry = named_discord_permissions.read().expect("lock poisoned");
+                    for instance in &discord_config.instances {
+                        let runtime_key =
+                            binding_runtime_adapter_key("discord", Some(instance.name.as_str()));
+                        if let Some(perms) = registry.get(&runtime_key) {
+                            let new_perms = DiscordPermissions::from_instance_config(
+                                instance,
+                                &config.bindings,
+                            );
+                            perms.store(Arc::new(new_perms));
+                        }
+                    }
                 }
 
                 if let Some(ref perms) = slack_permissions
@@ -221,6 +248,17 @@ pub fn spawn_file_watcher(
                     let new_perms = SlackPermissions::from_config(slack_config, &config.bindings);
                     perms.store(Arc::new(new_perms));
                     tracing::info!("slack permissions reloaded");
+
+                    let registry = named_slack_permissions.read().expect("lock poisoned");
+                    for instance in &slack_config.instances {
+                        let runtime_key =
+                            binding_runtime_adapter_key("slack", Some(instance.name.as_str()));
+                        if let Some(perms) = registry.get(&runtime_key) {
+                            let new_perms =
+                                SlackPermissions::from_instance_config(instance, &config.bindings);
+                            perms.store(Arc::new(new_perms));
+                        }
+                    }
                 }
 
                 if let Some(ref perms) = telegram_permissions
@@ -230,6 +268,19 @@ pub fn spawn_file_watcher(
                         TelegramPermissions::from_config(telegram_config, &config.bindings);
                     perms.store(Arc::new(new_perms));
                     tracing::info!("telegram permissions reloaded");
+
+                    let registry = named_telegram_permissions.read().expect("lock poisoned");
+                    for instance in &telegram_config.instances {
+                        let runtime_key =
+                            binding_runtime_adapter_key("telegram", Some(instance.name.as_str()));
+                        if let Some(perms) = registry.get(&runtime_key) {
+                            let new_perms = TelegramPermissions::from_instance_config(
+                                instance,
+                                &config.bindings,
+                            );
+                            perms.store(Arc::new(new_perms));
+                        }
+                    }
                 }
 
                 if let Some(ref perms) = twitch_permissions
@@ -238,6 +289,17 @@ pub fn spawn_file_watcher(
                     let new_perms = TwitchPermissions::from_config(twitch_config, &config.bindings);
                     perms.store(Arc::new(new_perms));
                     tracing::info!("twitch permissions reloaded");
+
+                    let registry = named_twitch_permissions.read().expect("lock poisoned");
+                    for instance in &twitch_config.instances {
+                        let runtime_key =
+                            binding_runtime_adapter_key("twitch", Some(instance.name.as_str()));
+                        if let Some(perms) = registry.get(&runtime_key) {
+                            let new_perms =
+                                TwitchPermissions::from_instance_config(instance, &config.bindings);
+                            perms.store(Arc::new(new_perms));
+                        }
+                    }
                 }
 
                 // Hot-start adapters that are newly enabled in the config
@@ -249,6 +311,10 @@ pub fn spawn_file_watcher(
                     let slack_permissions = slack_permissions.clone();
                     let telegram_permissions = telegram_permissions.clone();
                     let twitch_permissions = twitch_permissions.clone();
+                    let named_discord_permissions = named_discord_permissions.clone();
+                    let named_slack_permissions = named_slack_permissions.clone();
+                    let named_telegram_permissions = named_telegram_permissions.clone();
+                    let named_twitch_permissions = named_twitch_permissions.clone();
                     let instance_dir = instance_dir.clone();
 
                     rt.spawn(async move {
@@ -279,18 +345,16 @@ pub fn spawn_file_watcher(
                                         Some(instance.name.as_str()),
                                     );
                                     if manager.has_adapter(runtime_key.as_str()).await {
-                                        // TODO: named instance permissions are not hot-updated on
-                                        // config reload because each instance owns its own
-                                        // Arc<ArcSwap> with no external handle. Fixing this
-                                        // requires either a permission-update method on the
-                                        // Messaging trait or a shared handle registry. Permissions
-                                        // will be correct after a full restart.
                                         continue;
                                     }
 
                                     let permissions = Arc::new(arc_swap::ArcSwap::from_pointee(
                                         DiscordPermissions::from_instance_config(instance, &config.bindings),
                                     ));
+                                    named_discord_permissions
+                                        .write()
+                                        .expect("lock poisoned")
+                                        .insert(runtime_key.clone(), permissions.clone());
                                     let adapter = crate::messaging::discord::DiscordAdapter::new(
                                         runtime_key,
                                         &instance.token,
@@ -340,13 +404,16 @@ pub fn spawn_file_watcher(
                                         Some(instance.name.as_str()),
                                     );
                                     if manager.has_adapter(runtime_key.as_str()).await {
-                                        // TODO: named instance permissions not hot-updated (see discord block comment)
                                         continue;
                                     }
 
                                     let permissions = Arc::new(arc_swap::ArcSwap::from_pointee(
                                         SlackPermissions::from_instance_config(instance, &config.bindings),
                                     ));
+                                    named_slack_permissions
+                                        .write()
+                                        .expect("lock poisoned")
+                                        .insert(runtime_key.clone(), permissions.clone());
                                     match crate::messaging::slack::SlackAdapter::new(
                                         runtime_key,
                                         &instance.bot_token,
@@ -395,13 +462,16 @@ pub fn spawn_file_watcher(
                                         Some(instance.name.as_str()),
                                     );
                                     if manager.has_adapter(runtime_key.as_str()).await {
-                                        // TODO: named instance permissions not hot-updated (see discord block comment)
                                         continue;
                                     }
 
                                     let permissions = Arc::new(arc_swap::ArcSwap::from_pointee(
                                         TelegramPermissions::from_instance_config(instance, &config.bindings),
                                     ));
+                                    named_telegram_permissions
+                                        .write()
+                                        .expect("lock poisoned")
+                                        .insert(runtime_key.clone(), permissions.clone());
                                     let adapter = crate::messaging::telegram::TelegramAdapter::new(
                                         runtime_key,
                                         &instance.token,
@@ -492,7 +562,6 @@ pub fn spawn_file_watcher(
                                         Some(instance.name.as_str()),
                                     );
                                     if manager.has_adapter(runtime_key.as_str()).await {
-                                        // TODO: named instance permissions not hot-updated (see discord block comment)
                                         continue;
                                     }
 
@@ -514,6 +583,10 @@ pub fn spawn_file_watcher(
                                     let permissions = Arc::new(arc_swap::ArcSwap::from_pointee(
                                         TwitchPermissions::from_instance_config(instance, &config.bindings),
                                     ));
+                                    named_twitch_permissions
+                                        .write()
+                                        .expect("lock poisoned")
+                                        .insert(runtime_key.clone(), permissions.clone());
                                     let adapter = crate::messaging::twitch::TwitchAdapter::new(
                                         runtime_key,
                                         &instance.username,

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -220,13 +220,13 @@ pub fn spawn_file_watcher(
                 agent_humans.store(Arc::new(config.humans.clone()));
                 tracing::info!("agent humans reloaded ({} entries)", config.humans.len());
 
-                if let Some(ref perms) = discord_permissions
-                    && let Some(discord_config) = &config.messaging.discord
-                {
-                    let new_perms =
-                        DiscordPermissions::from_config(discord_config, &config.bindings);
-                    perms.store(Arc::new(new_perms));
-                    tracing::info!("discord permissions reloaded");
+                if let Some(discord_config) = &config.messaging.discord {
+                    if let Some(ref perms) = discord_permissions {
+                        let new_perms =
+                            DiscordPermissions::from_config(discord_config, &config.bindings);
+                        perms.store(Arc::new(new_perms));
+                        tracing::info!("discord permissions reloaded");
+                    }
 
                     let registry = named_discord_permissions.read().expect("lock poisoned");
                     for instance in &discord_config.instances {
@@ -242,12 +242,13 @@ pub fn spawn_file_watcher(
                     }
                 }
 
-                if let Some(ref perms) = slack_permissions
-                    && let Some(slack_config) = &config.messaging.slack
-                {
-                    let new_perms = SlackPermissions::from_config(slack_config, &config.bindings);
-                    perms.store(Arc::new(new_perms));
-                    tracing::info!("slack permissions reloaded");
+                if let Some(slack_config) = &config.messaging.slack {
+                    if let Some(ref perms) = slack_permissions {
+                        let new_perms =
+                            SlackPermissions::from_config(slack_config, &config.bindings);
+                        perms.store(Arc::new(new_perms));
+                        tracing::info!("slack permissions reloaded");
+                    }
 
                     let registry = named_slack_permissions.read().expect("lock poisoned");
                     for instance in &slack_config.instances {
@@ -261,13 +262,13 @@ pub fn spawn_file_watcher(
                     }
                 }
 
-                if let Some(ref perms) = telegram_permissions
-                    && let Some(telegram_config) = &config.messaging.telegram
-                {
-                    let new_perms =
-                        TelegramPermissions::from_config(telegram_config, &config.bindings);
-                    perms.store(Arc::new(new_perms));
-                    tracing::info!("telegram permissions reloaded");
+                if let Some(telegram_config) = &config.messaging.telegram {
+                    if let Some(ref perms) = telegram_permissions {
+                        let new_perms =
+                            TelegramPermissions::from_config(telegram_config, &config.bindings);
+                        perms.store(Arc::new(new_perms));
+                        tracing::info!("telegram permissions reloaded");
+                    }
 
                     let registry = named_telegram_permissions.read().expect("lock poisoned");
                     for instance in &telegram_config.instances {
@@ -283,12 +284,13 @@ pub fn spawn_file_watcher(
                     }
                 }
 
-                if let Some(ref perms) = twitch_permissions
-                    && let Some(twitch_config) = &config.messaging.twitch
-                {
-                    let new_perms = TwitchPermissions::from_config(twitch_config, &config.bindings);
-                    perms.store(Arc::new(new_perms));
-                    tracing::info!("twitch permissions reloaded");
+                if let Some(twitch_config) = &config.messaging.twitch {
+                    if let Some(ref perms) = twitch_permissions {
+                        let new_perms =
+                            TwitchPermissions::from_config(twitch_config, &config.bindings);
+                        perms.store(Arc::new(new_perms));
+                        tracing::info!("twitch permissions reloaded");
+                    }
 
                     let registry = named_twitch_permissions.read().expect("lock poisoned");
                     for instance in &twitch_config.instances {
@@ -565,20 +567,8 @@ pub fn spawn_file_watcher(
                                         continue;
                                     }
 
-                                    let token_file_name = {
-                                        use std::hash::{Hash, Hasher};
-                                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                                        instance.name.hash(&mut hasher);
-                                        let name_hash = hasher.finish();
-                                        format!(
-                                            "twitch_token_{}_{name_hash:016x}.json",
-                                            instance
-                                                .name
-                                                .chars()
-                                                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                                                .collect::<String>()
-                                        )
-                                    };
+                                    let token_file_name =
+                                        crate::config::named_twitch_token_file_name(&instance.name);
                                     let token_path = instance_dir.join(token_file_name);
                                     let permissions = Arc::new(arc_swap::ArcSwap::from_pointee(
                                         TwitchPermissions::from_instance_config(instance, &config.bindings),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod llm;
 pub mod mcp;
 pub mod memory;
 pub mod messaging;
+pub mod oauth_storage;
 pub mod openai_auth;
 pub mod opencode;
 pub mod projects;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+type NamedPermissionsMap<T> = Arc<std::sync::RwLock<HashMap<String, Arc<ArcSwap<T>>>>>;
+
 #[derive(Parser)]
 #[command(name = "spacebot", version)]
 #[command(about = "A Rust agentic system with dedicated processes for every task")]
@@ -1506,14 +1508,14 @@ async fn run(
         let mut slack_permissions = None;
         let mut telegram_permissions = None;
         let mut twitch_permissions = None;
-        let named_discord_permissions =
-            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-        let named_slack_permissions =
-            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-        let named_telegram_permissions =
-            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-        let named_twitch_permissions =
-            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        let named_discord_permissions: NamedPermissionsMap<spacebot::config::DiscordPermissions> =
+            Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let named_slack_permissions: NamedPermissionsMap<spacebot::config::SlackPermissions> =
+            Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let named_telegram_permissions: NamedPermissionsMap<spacebot::config::TelegramPermissions> =
+            Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let named_twitch_permissions: NamedPermissionsMap<spacebot::config::TwitchPermissions> =
+            Arc::new(std::sync::RwLock::new(HashMap::new()));
         initialize_agents(
             &config,
             &llm_manager,
@@ -2211,10 +2213,14 @@ async fn run(
                                 let mut new_slack_permissions = None;
                                 let mut new_telegram_permissions = None;
                                 let mut new_twitch_permissions = None;
-                                let named_discord_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-                                let named_slack_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-                                let named_telegram_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
-                                let named_twitch_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+                                let named_discord_permissions: NamedPermissionsMap<spacebot::config::DiscordPermissions> =
+                                    Arc::new(std::sync::RwLock::new(HashMap::new()));
+                                let named_slack_permissions: NamedPermissionsMap<spacebot::config::SlackPermissions> =
+                                    Arc::new(std::sync::RwLock::new(HashMap::new()));
+                                let named_telegram_permissions: NamedPermissionsMap<spacebot::config::TelegramPermissions> =
+                                    Arc::new(std::sync::RwLock::new(HashMap::new()));
+                                let named_twitch_permissions: NamedPermissionsMap<spacebot::config::TwitchPermissions> =
+                                    Arc::new(std::sync::RwLock::new(HashMap::new()));
                                 match initialize_agents(
                                     &new_config,
                                     &new_llm_manager,
@@ -2379,26 +2385,10 @@ async fn initialize_agents(
     slack_permissions: &mut Option<Arc<ArcSwap<spacebot::config::SlackPermissions>>>,
     telegram_permissions: &mut Option<Arc<ArcSwap<spacebot::config::TelegramPermissions>>>,
     twitch_permissions: &mut Option<Arc<ArcSwap<spacebot::config::TwitchPermissions>>>,
-    named_discord_permissions: Arc<
-        std::sync::RwLock<
-            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::DiscordPermissions>>>,
-        >,
-    >,
-    named_slack_permissions: Arc<
-        std::sync::RwLock<
-            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::SlackPermissions>>>,
-        >,
-    >,
-    named_telegram_permissions: Arc<
-        std::sync::RwLock<
-            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::TelegramPermissions>>>,
-        >,
-    >,
-    named_twitch_permissions: Arc<
-        std::sync::RwLock<
-            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::TwitchPermissions>>>,
-        >,
-    >,
+    named_discord_permissions: NamedPermissionsMap<spacebot::config::DiscordPermissions>,
+    named_slack_permissions: NamedPermissionsMap<spacebot::config::SlackPermissions>,
+    named_telegram_permissions: NamedPermissionsMap<spacebot::config::TelegramPermissions>,
+    named_twitch_permissions: NamedPermissionsMap<spacebot::config::TwitchPermissions>,
     agent_links: Arc<ArcSwap<Vec<spacebot::links::AgentLink>>>,
     agent_humans: Arc<ArcSwap<Vec<spacebot::config::HumanDef>>>,
     injection_tx: tokio::sync::mpsc::Sender<spacebot::ChannelInjection>,
@@ -3054,20 +3044,7 @@ async fn initialize_agents(
                 "twitch",
                 Some(instance.name.as_str()),
             );
-            let token_file_name = {
-                use std::hash::{Hash, Hasher};
-                let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                instance.name.hash(&mut hasher);
-                let name_hash = hasher.finish();
-                format!(
-                    "twitch_token_{}_{name_hash:016x}.json",
-                    instance
-                        .name
-                        .chars()
-                        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
-                        .collect::<String>()
-                )
-            };
+            let token_file_name = spacebot::config::named_twitch_token_file_name(&instance.name);
             let token_path = config.instance_dir.join(token_file_name);
             let perms = Arc::new(ArcSwap::from_pointee(
                 spacebot::config::TwitchPermissions::from_instance_config(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1362,7 +1362,7 @@ async fn run(
     > = Arc::new(ArcSwap::from_pointee(std::collections::HashMap::new()));
 
     // Start HTTP API server if enabled
-    let mut api_state = spacebot::api::ApiState::new_with_provider_sender(
+    let api_state = spacebot::api::ApiState::new_with_provider_sender(
         provider_tx,
         agent_tx,
         agent_remove_tx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1369,7 +1369,9 @@ async fn run(
         injection_tx.clone(),
         task_store_registry.clone(),
     );
-    api_state.auth_token = config.api.auth_token.clone();
+    api_state
+        .set_api_auth_token(config.api.auth_token.clone())
+        .await;
     let api_state = Arc::new(api_state);
 
     // Start background update checker
@@ -1504,6 +1506,14 @@ async fn run(
         let mut slack_permissions = None;
         let mut telegram_permissions = None;
         let mut twitch_permissions = None;
+        let named_discord_permissions =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        let named_slack_permissions =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        let named_telegram_permissions =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        let named_twitch_permissions =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
         initialize_agents(
             &config,
             &llm_manager,
@@ -1521,6 +1531,10 @@ async fn run(
             &mut slack_permissions,
             &mut telegram_permissions,
             &mut twitch_permissions,
+            named_discord_permissions.clone(),
+            named_slack_permissions.clone(),
+            named_telegram_permissions.clone(),
+            named_twitch_permissions.clone(),
             agent_links.clone(),
             agent_humans.clone(),
             injection_tx.clone(),
@@ -1539,6 +1553,10 @@ async fn run(
             slack_permissions,
             telegram_permissions,
             twitch_permissions,
+            named_discord_permissions,
+            named_slack_permissions,
+            named_telegram_permissions,
+            named_twitch_permissions,
             bindings.clone(),
             Some(messaging_manager.clone()),
             llm_manager.clone(),
@@ -1555,6 +1573,10 @@ async fn run(
             None,
             None,
             None,
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
             bindings.clone(),
             None,
             llm_manager.clone(),
@@ -2189,6 +2211,10 @@ async fn run(
                                 let mut new_slack_permissions = None;
                                 let mut new_telegram_permissions = None;
                                 let mut new_twitch_permissions = None;
+                                let named_discord_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+                                let named_slack_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+                                let named_telegram_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+                                let named_twitch_permissions = Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
                                 match initialize_agents(
                                     &new_config,
                                     &new_llm_manager,
@@ -2206,6 +2232,10 @@ async fn run(
                                     &mut new_slack_permissions,
                                     &mut new_telegram_permissions,
                                     &mut new_twitch_permissions,
+                                    named_discord_permissions.clone(),
+                                    named_slack_permissions.clone(),
+                                    named_telegram_permissions.clone(),
+                                    named_twitch_permissions.clone(),
                                     agent_links.clone(),
                                     agent_humans.clone(),
                                     injection_tx.clone(),
@@ -2223,6 +2253,10 @@ async fn run(
                                             new_slack_permissions,
                                             new_telegram_permissions,
                                             new_twitch_permissions,
+                                            named_discord_permissions,
+                                            named_slack_permissions,
+                                            named_telegram_permissions,
+                                            named_twitch_permissions,
                                             bindings.clone(),
                                             Some(messaging_manager.clone()),
                                             new_llm_manager.clone(),
@@ -2345,6 +2379,26 @@ async fn initialize_agents(
     slack_permissions: &mut Option<Arc<ArcSwap<spacebot::config::SlackPermissions>>>,
     telegram_permissions: &mut Option<Arc<ArcSwap<spacebot::config::TelegramPermissions>>>,
     twitch_permissions: &mut Option<Arc<ArcSwap<spacebot::config::TwitchPermissions>>>,
+    named_discord_permissions: Arc<
+        std::sync::RwLock<
+            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::DiscordPermissions>>>,
+        >,
+    >,
+    named_slack_permissions: Arc<
+        std::sync::RwLock<
+            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::SlackPermissions>>>,
+        >,
+    >,
+    named_telegram_permissions: Arc<
+        std::sync::RwLock<
+            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::TelegramPermissions>>>,
+        >,
+    >,
+    named_twitch_permissions: Arc<
+        std::sync::RwLock<
+            std::collections::HashMap<String, Arc<ArcSwap<spacebot::config::TwitchPermissions>>>,
+        >,
+    >,
     agent_links: Arc<ArcSwap<Vec<spacebot::links::AgentLink>>>,
     agent_humans: Arc<ArcSwap<Vec<spacebot::config::HumanDef>>>,
     injection_tx: tokio::sync::mpsc::Sender<spacebot::ChannelInjection>,
@@ -2769,6 +2823,10 @@ async fn initialize_agents(
                     &config.bindings,
                 ),
             ));
+            named_discord_permissions
+                .write()
+                .expect("lock poisoned")
+                .insert(runtime_key.clone(), perms.clone());
             let adapter = spacebot::messaging::discord::DiscordAdapter::new(
                 runtime_key,
                 &instance.token,
@@ -2828,6 +2886,10 @@ async fn initialize_agents(
                     &config.bindings,
                 ),
             ));
+            named_slack_permissions
+                .write()
+                .expect("lock poisoned")
+                .insert(runtime_key.clone(), perms.clone());
             match spacebot::messaging::slack::SlackAdapter::new(
                 runtime_key,
                 &instance.bot_token,
@@ -2885,6 +2947,10 @@ async fn initialize_agents(
                     &config.bindings,
                 ),
             ));
+            named_telegram_permissions
+                .write()
+                .expect("lock poisoned")
+                .insert(runtime_key.clone(), perms.clone());
             let adapter = spacebot::messaging::telegram::TelegramAdapter::new(
                 runtime_key,
                 &instance.token,
@@ -3009,6 +3075,10 @@ async fn initialize_agents(
                     &config.bindings,
                 ),
             ));
+            named_twitch_permissions
+                .write()
+                .expect("lock poisoned")
+                .insert(runtime_key.clone(), perms.clone());
             let adapter = spacebot::messaging::twitch::TwitchAdapter::new(
                 runtime_key,
                 &instance.username,

--- a/src/memory/maintenance.rs
+++ b/src/memory/maintenance.rs
@@ -137,7 +137,10 @@ async fn merge_similar_memories(
     similarity_threshold: f32,
 ) -> Result<usize> {
     if !(0.0..=1.0).contains(&similarity_threshold) {
-        return Ok(0);
+        return Err(anyhow!(
+            "merge_similarity_threshold must be within [0.0, 1.0], got {similarity_threshold}"
+        )
+        .into());
     }
 
     let rows = sqlx::query(
@@ -183,16 +186,27 @@ async fn merge_similar_memories(
             (!remaining.is_empty()).then(|| remaining.remove(0))
         {
             let mut duplicates = vec![seed_memory];
-            let mut next_remaining = Vec::new();
+            let mut cluster_queue = std::collections::VecDeque::from([seed_normalized]);
+            let mut visited_normalized = HashSet::new();
 
-            for (memory, normalized) in remaining {
-                if normalized_similarity(&seed_normalized, &normalized) >= similarity_threshold {
-                    duplicates.push(memory);
-                } else {
-                    next_remaining.push((memory, normalized));
+            while let Some(current_normalized) = cluster_queue.pop_front() {
+                if !visited_normalized.insert(current_normalized.clone()) {
+                    continue;
                 }
+
+                let mut next_remaining = Vec::new();
+                for (memory, normalized) in remaining {
+                    if normalized_similarity(&current_normalized, &normalized)
+                        >= similarity_threshold
+                    {
+                        cluster_queue.push_back(normalized.clone());
+                        duplicates.push(memory);
+                    } else {
+                        next_remaining.push((memory, normalized));
+                    }
+                }
+                remaining = next_remaining;
             }
-            remaining = next_remaining;
 
             if duplicates.len() < 2 {
                 continue;
@@ -447,6 +461,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalid_threshold_returns_error() {
+        let store = MemoryStore::connect_in_memory().await;
+        let error = merge_similar_memories(&store, 1.1)
+            .await
+            .expect_err("invalid threshold");
+        assert!(
+            error
+                .to_string()
+                .contains("merge_similarity_threshold must be within [0.0, 1.0]"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn does_not_merge_identical_content_across_channels() {
         let store = MemoryStore::connect_in_memory().await;
         let first =
@@ -503,5 +531,23 @@ mod tests {
             })
             .expect("rewritten association");
         assert_eq!(preserved.weight, 0.9);
+    }
+
+    #[tokio::test]
+    async fn merges_transitive_duplicate_cluster() {
+        let store = MemoryStore::connect_in_memory().await;
+
+        let first = Memory::new("deploy worker now", MemoryType::Todo).with_importance(0.9);
+        let second = Memory::new("deploy worker right now", MemoryType::Todo).with_importance(0.7);
+        let third = Memory::new("deploy right now", MemoryType::Todo).with_importance(0.6);
+
+        store.save(&first).await.expect("save first");
+        store.save(&second).await.expect("save second");
+        store.save(&third).await.expect("save third");
+
+        let merged = merge_similar_memories(&store, 0.55).await.expect("merge");
+        assert_eq!(merged, 2);
+        assert!(store.load(&second.id).await.expect("load second").is_none());
+        assert!(store.load(&third.id).await.expect("load third").is_none());
     }
 }

--- a/src/memory/maintenance.rs
+++ b/src/memory/maintenance.rs
@@ -2,7 +2,11 @@
 
 use crate::error::Result;
 use crate::memory::MemoryStore;
-use crate::memory::types::MemoryType;
+use crate::memory::types::{Association, Memory, MemoryType};
+
+use sqlx::Row as _;
+
+use std::collections::{HashMap, HashSet};
 
 /// Maintenance configuration.
 #[derive(Debug, Clone)]
@@ -124,16 +128,144 @@ async fn prune_memories(memory_store: &MemoryStore, config: &MaintenanceConfig) 
 
 /// Merge near-duplicate memories.
 async fn merge_similar_memories(
-    _memory_store: &MemoryStore,
+    memory_store: &MemoryStore,
     similarity_threshold: f32,
 ) -> Result<usize> {
-    // For now, this is a placeholder
-    // Full implementation would:
-    // 1. Find pairs of memories with high embedding similarity
-    // 2. Merge them, keeping the higher importance one
-    // 3. Update associations to point to the merged memory
-    let _ = similarity_threshold;
-    Ok(0)
+    if similarity_threshold > 1.0 {
+        return Ok(0);
+    }
+
+    let rows = sqlx::query(
+        r#"
+        SELECT id, content, memory_type, importance, created_at, updated_at,
+               last_accessed_at, access_count, source, channel_id, forgotten
+        FROM memories
+        WHERE forgotten = 0
+        ORDER BY updated_at DESC, importance DESC
+        "#,
+    )
+    .fetch_all(memory_store.pool())
+    .await?;
+
+    let memories = rows.into_iter().map(row_to_memory).collect::<Vec<_>>();
+    let mut groups: HashMap<(MemoryType, String), Vec<Memory>> = HashMap::new();
+
+    for memory in memories {
+        let normalized = normalize_memory_content(&memory.content);
+        if normalized.is_empty() {
+            continue;
+        }
+
+        groups
+            .entry((memory.memory_type, normalized))
+            .or_default()
+            .push(memory);
+    }
+
+    let mut merged_count = 0;
+    for duplicates in groups.into_values() {
+        if duplicates.len() < 2 {
+            continue;
+        }
+
+        let canonical = select_canonical_memory(&duplicates);
+        let mut seen_duplicates = HashSet::new();
+
+        for duplicate in duplicates {
+            if duplicate.id == canonical.id || !seen_duplicates.insert(duplicate.id.clone()) {
+                continue;
+            }
+
+            rewrite_associations(memory_store, &canonical, &duplicate).await?;
+            memory_store.delete(&duplicate.id).await?;
+            merged_count += 1;
+        }
+    }
+
+    Ok(merged_count)
+}
+
+fn normalize_memory_content(content: &str) -> String {
+    content
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_lowercase()
+}
+
+fn select_canonical_memory(memories: &[Memory]) -> Memory {
+    memories
+        .iter()
+        .max_by(|left, right| {
+            left.importance
+                .total_cmp(&right.importance)
+                .then_with(|| left.access_count.cmp(&right.access_count))
+                .then_with(|| right.updated_at.cmp(&left.updated_at))
+                .then_with(|| right.created_at.cmp(&left.created_at))
+        })
+        .expect("duplicate group must be non-empty")
+        .clone()
+}
+
+async fn rewrite_associations(
+    memory_store: &MemoryStore,
+    canonical: &Memory,
+    duplicate: &Memory,
+) -> Result<()> {
+    let associations = memory_store.get_associations(&duplicate.id).await?;
+    for association in associations {
+        let source_id = if association.source_id == duplicate.id {
+            canonical.id.clone()
+        } else {
+            association.source_id.clone()
+        };
+        let target_id = if association.target_id == duplicate.id {
+            canonical.id.clone()
+        } else {
+            association.target_id.clone()
+        };
+
+        if source_id == target_id {
+            continue;
+        }
+
+        let rewritten = Association::new(source_id, target_id, association.relation_type)
+            .with_weight(association.weight);
+        memory_store.create_association(&rewritten).await?;
+    }
+
+    Ok(())
+}
+
+fn row_to_memory(row: sqlx::sqlite::SqliteRow) -> Memory {
+    Memory {
+        id: row.get("id"),
+        content: row.get("content"),
+        memory_type: parse_memory_type(row.get::<String, _>("memory_type").as_str()),
+        importance: row.get("importance"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        last_accessed_at: row.get("last_accessed_at"),
+        access_count: row.get("access_count"),
+        source: row.get("source"),
+        channel_id: row.get::<Option<String>, _>("channel_id").map(Into::into),
+        forgotten: row.get("forgotten"),
+    }
+}
+
+fn parse_memory_type(memory_type: &str) -> MemoryType {
+    match memory_type {
+        "fact" => MemoryType::Fact,
+        "preference" => MemoryType::Preference,
+        "decision" => MemoryType::Decision,
+        "identity" => MemoryType::Identity,
+        "event" => MemoryType::Event,
+        "observation" => MemoryType::Observation,
+        "goal" => MemoryType::Goal,
+        "todo" => MemoryType::Todo,
+        _ => MemoryType::Fact,
+    }
 }
 
 /// Maintenance report.
@@ -142,4 +274,66 @@ pub struct MaintenanceReport {
     pub decayed: usize,
     pub pruned: usize,
     pub merged: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MaintenanceConfig, merge_similar_memories};
+    use crate::memory::{Association, Memory, MemoryStore, MemoryType, RelationType};
+
+    #[tokio::test]
+    async fn merges_normalized_duplicate_memories_and_rewrites_edges() {
+        let store = MemoryStore::connect_in_memory().await;
+
+        let canonical = Memory::new("Deploy the worker", MemoryType::Todo).with_importance(0.9);
+        let duplicate =
+            Memory::new("  deploy   the worker ", MemoryType::Todo).with_importance(0.4);
+        let neighbor = Memory::new("CI checks are green", MemoryType::Observation);
+
+        store.save(&canonical).await.expect("save canonical");
+        store.save(&duplicate).await.expect("save duplicate");
+        store.save(&neighbor).await.expect("save neighbor");
+
+        store
+            .create_association(&Association::new(
+                &neighbor.id,
+                &duplicate.id,
+                RelationType::RelatedTo,
+            ))
+            .await
+            .expect("create association");
+
+        let merged = merge_similar_memories(
+            &store,
+            MaintenanceConfig::default().merge_similarity_threshold,
+        )
+        .await
+        .expect("merge");
+
+        assert_eq!(merged, 1);
+        assert!(store.load(&duplicate.id).await.expect("load").is_none());
+
+        let associations = store
+            .get_associations(&canonical.id)
+            .await
+            .expect("get associations");
+        assert!(associations.iter().any(|association| {
+            association.source_id == neighbor.id
+                && association.target_id == canonical.id
+                && association.relation_type == RelationType::RelatedTo
+        }));
+    }
+
+    #[tokio::test]
+    async fn skips_merge_when_threshold_exceeds_exact_match() {
+        let store = MemoryStore::connect_in_memory().await;
+        let first = Memory::new("same", MemoryType::Fact);
+        let second = Memory::new("same", MemoryType::Fact);
+        store.save(&first).await.expect("save first");
+        store.save(&second).await.expect("save second");
+
+        let merged = merge_similar_memories(&store, 1.1).await.expect("merge");
+        assert_eq!(merged, 0);
+        assert!(store.load(&second.id).await.expect("load").is_some());
+    }
 }

--- a/src/memory/maintenance.rs
+++ b/src/memory/maintenance.rs
@@ -201,8 +201,8 @@ fn select_canonical_memory(memories: &[Memory]) -> Memory {
             left.importance
                 .total_cmp(&right.importance)
                 .then_with(|| left.access_count.cmp(&right.access_count))
-                .then_with(|| right.updated_at.cmp(&left.updated_at))
-                .then_with(|| right.created_at.cmp(&left.created_at))
+                .then_with(|| left.updated_at.cmp(&right.updated_at))
+                .then_with(|| left.created_at.cmp(&right.created_at))
         })
         .expect("duplicate group must be non-empty")
         .clone()

--- a/src/memory/maintenance.rs
+++ b/src/memory/maintenance.rs
@@ -4,9 +4,14 @@ use crate::error::Result;
 use crate::memory::MemoryStore;
 use crate::memory::types::{Association, Memory, MemoryType};
 
+use anyhow::anyhow;
 use sqlx::Row as _;
 
 use std::collections::{HashMap, HashSet};
+
+type MergeGroupKey = (MemoryType, Option<String>);
+type MergeCandidate = (Memory, String);
+type MergeGroups = HashMap<MergeGroupKey, Vec<MergeCandidate>>;
 
 /// Maintenance configuration.
 #[derive(Debug, Clone)]
@@ -131,7 +136,7 @@ async fn merge_similar_memories(
     memory_store: &MemoryStore,
     similarity_threshold: f32,
 ) -> Result<usize> {
-    if similarity_threshold > 1.0 {
+    if !(0.0..=1.0).contains(&similarity_threshold) {
         return Ok(0);
     }
 
@@ -147,8 +152,11 @@ async fn merge_similar_memories(
     .fetch_all(memory_store.pool())
     .await?;
 
-    let memories = rows.into_iter().map(row_to_memory).collect::<Vec<_>>();
-    let mut groups: HashMap<(MemoryType, String), Vec<Memory>> = HashMap::new();
+    let memories = rows
+        .into_iter()
+        .map(row_to_memory)
+        .collect::<Result<Vec<_>>>()?;
+    let mut groups: MergeGroups = HashMap::new();
 
     for memory in memories {
         let normalized = normalize_memory_content(&memory.content);
@@ -156,29 +164,52 @@ async fn merge_similar_memories(
             continue;
         }
 
+        let channel_key = memory
+            .channel_id
+            .as_ref()
+            .map(|channel_id| channel_id.to_string());
         groups
-            .entry((memory.memory_type, normalized))
+            .entry((memory.memory_type, channel_key))
             .or_default()
-            .push(memory);
+            .push((memory, normalized));
     }
 
     let mut merged_count = 0;
-    for duplicates in groups.into_values() {
-        if duplicates.len() < 2 {
-            continue;
-        }
+    for candidates in groups.into_values() {
+        let mut remaining = candidates;
+        remaining.sort_by(|left, right| canonical_memory_cmp(&left.0, &right.0).reverse());
 
-        let canonical = select_canonical_memory(&duplicates);
-        let mut seen_duplicates = HashSet::new();
+        while let Some((seed_memory, seed_normalized)) =
+            (!remaining.is_empty()).then(|| remaining.remove(0))
+        {
+            let mut duplicates = vec![seed_memory];
+            let mut next_remaining = Vec::new();
 
-        for duplicate in duplicates {
-            if duplicate.id == canonical.id || !seen_duplicates.insert(duplicate.id.clone()) {
+            for (memory, normalized) in remaining {
+                if normalized_similarity(&seed_normalized, &normalized) >= similarity_threshold {
+                    duplicates.push(memory);
+                } else {
+                    next_remaining.push((memory, normalized));
+                }
+            }
+            remaining = next_remaining;
+
+            if duplicates.len() < 2 {
                 continue;
             }
 
-            rewrite_associations(memory_store, &canonical, &duplicate).await?;
-            memory_store.delete(&duplicate.id).await?;
-            merged_count += 1;
+            let canonical = select_canonical_memory(&duplicates);
+            let mut seen_duplicates = HashSet::new();
+
+            for duplicate in duplicates {
+                if duplicate.id == canonical.id || !seen_duplicates.insert(duplicate.id.clone()) {
+                    continue;
+                }
+
+                rewrite_associations(memory_store, &canonical, &duplicate).await?;
+                memory_store.delete(&duplicate.id).await?;
+                merged_count += 1;
+            }
         }
     }
 
@@ -197,15 +228,55 @@ fn normalize_memory_content(content: &str) -> String {
 fn select_canonical_memory(memories: &[Memory]) -> Memory {
     memories
         .iter()
-        .max_by(|left, right| {
-            left.importance
-                .total_cmp(&right.importance)
-                .then_with(|| left.access_count.cmp(&right.access_count))
-                .then_with(|| left.updated_at.cmp(&right.updated_at))
-                .then_with(|| left.created_at.cmp(&right.created_at))
-        })
+        .max_by(|left, right| canonical_memory_cmp(left, right))
         .expect("duplicate group must be non-empty")
         .clone()
+}
+
+fn canonical_memory_cmp(left: &Memory, right: &Memory) -> std::cmp::Ordering {
+    left.importance
+        .total_cmp(&right.importance)
+        .then_with(|| left.access_count.cmp(&right.access_count))
+        .then_with(|| left.updated_at.cmp(&right.updated_at))
+        .then_with(|| left.created_at.cmp(&right.created_at))
+}
+
+fn normalized_similarity(left: &str, right: &str) -> f32 {
+    if left == right {
+        return 1.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let left_bigrams = bigram_counts(left);
+    let right_bigrams = bigram_counts(right);
+    let left_total = left_bigrams.values().sum::<usize>();
+    let right_total = right_bigrams.values().sum::<usize>();
+    if left_total == 0 || right_total == 0 {
+        return 0.0;
+    }
+
+    let intersection = left_bigrams
+        .iter()
+        .map(|(bigram, count)| {
+            right_bigrams
+                .get(bigram)
+                .map_or(0_usize, |other| (*count).min(*other))
+        })
+        .sum::<usize>();
+
+    (2.0 * intersection as f32) / (left_total + right_total) as f32
+}
+
+fn bigram_counts(value: &str) -> HashMap<(char, char), usize> {
+    let chars = value.chars().collect::<Vec<_>>();
+    let mut counts = HashMap::new();
+    for bigram in chars.windows(2) {
+        let key = (bigram[0], bigram[1]);
+        *counts.entry(key).or_default() += 1;
+    }
+    counts
 }
 
 async fn rewrite_associations(
@@ -230,19 +301,56 @@ async fn rewrite_associations(
             continue;
         }
 
+        let combined_weight = existing_association_weight(
+            memory_store,
+            &source_id,
+            &target_id,
+            association.relation_type,
+        )
+        .await?
+        .map_or(association.weight, |existing_weight| {
+            existing_weight.max(association.weight)
+        });
+
         let rewritten = Association::new(source_id, target_id, association.relation_type)
-            .with_weight(association.weight);
+            .with_weight(combined_weight);
         memory_store.create_association(&rewritten).await?;
     }
 
     Ok(())
 }
 
-fn row_to_memory(row: sqlx::sqlite::SqliteRow) -> Memory {
-    Memory {
-        id: row.get("id"),
+async fn existing_association_weight(
+    memory_store: &MemoryStore,
+    source_id: &str,
+    target_id: &str,
+    relation_type: crate::memory::RelationType,
+) -> Result<Option<f32>> {
+    let row = sqlx::query(
+        r#"
+        SELECT weight
+        FROM associations
+        WHERE source_id = ? AND target_id = ? AND relation_type = ?
+        "#,
+    )
+    .bind(source_id)
+    .bind(target_id)
+    .bind(relation_type.to_string())
+    .fetch_optional(memory_store.pool())
+    .await?;
+
+    Ok(row.map(|row| row.get("weight")))
+}
+
+fn row_to_memory(row: sqlx::sqlite::SqliteRow) -> Result<Memory> {
+    let id: String = row.get("id");
+    let memory_type_raw: String = row.get("memory_type");
+
+    Ok(Memory {
+        id: id.clone(),
         content: row.get("content"),
-        memory_type: parse_memory_type(row.get::<String, _>("memory_type").as_str()),
+        memory_type: parse_memory_type(&memory_type_raw)
+            .map_err(|error| anyhow!("failed to parse memory_type for memory {id}: {error}"))?,
         importance: row.get("importance"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
@@ -251,20 +359,20 @@ fn row_to_memory(row: sqlx::sqlite::SqliteRow) -> Memory {
         source: row.get("source"),
         channel_id: row.get::<Option<String>, _>("channel_id").map(Into::into),
         forgotten: row.get("forgotten"),
-    }
+    })
 }
 
-fn parse_memory_type(memory_type: &str) -> MemoryType {
+fn parse_memory_type(memory_type: &str) -> Result<MemoryType> {
     match memory_type {
-        "fact" => MemoryType::Fact,
-        "preference" => MemoryType::Preference,
-        "decision" => MemoryType::Decision,
-        "identity" => MemoryType::Identity,
-        "event" => MemoryType::Event,
-        "observation" => MemoryType::Observation,
-        "goal" => MemoryType::Goal,
-        "todo" => MemoryType::Todo,
-        _ => MemoryType::Fact,
+        "fact" => Ok(MemoryType::Fact),
+        "preference" => Ok(MemoryType::Preference),
+        "decision" => Ok(MemoryType::Decision),
+        "identity" => Ok(MemoryType::Identity),
+        "event" => Ok(MemoryType::Event),
+        "observation" => Ok(MemoryType::Observation),
+        "goal" => Ok(MemoryType::Goal),
+        "todo" => Ok(MemoryType::Todo),
+        _ => Err(anyhow!("unknown memory type '{memory_type}'").into()),
     }
 }
 
@@ -280,6 +388,7 @@ pub struct MaintenanceReport {
 mod tests {
     use super::{MaintenanceConfig, merge_similar_memories};
     use crate::memory::{Association, Memory, MemoryStore, MemoryType, RelationType};
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn merges_normalized_duplicate_memories_and_rewrites_edges() {
@@ -327,13 +436,72 @@ mod tests {
     #[tokio::test]
     async fn skips_merge_when_threshold_exceeds_exact_match() {
         let store = MemoryStore::connect_in_memory().await;
-        let first = Memory::new("same", MemoryType::Fact);
-        let second = Memory::new("same", MemoryType::Fact);
+        let first = Memory::new("deploy worker now", MemoryType::Fact);
+        let second = Memory::new("deploy workers tomorrow", MemoryType::Fact);
         store.save(&first).await.expect("save first");
         store.save(&second).await.expect("save second");
 
-        let merged = merge_similar_memories(&store, 1.1).await.expect("merge");
+        let merged = merge_similar_memories(&store, 0.95).await.expect("merge");
         assert_eq!(merged, 0);
         assert!(store.load(&second.id).await.expect("load").is_some());
+    }
+
+    #[tokio::test]
+    async fn does_not_merge_identical_content_across_channels() {
+        let store = MemoryStore::connect_in_memory().await;
+        let first =
+            Memory::new("same content", MemoryType::Fact).with_channel_id(Arc::<str>::from("a"));
+        let second =
+            Memory::new("same content", MemoryType::Fact).with_channel_id(Arc::<str>::from("b"));
+        store.save(&first).await.expect("save first");
+        store.save(&second).await.expect("save second");
+
+        let merged = merge_similar_memories(&store, 0.95).await.expect("merge");
+        assert_eq!(merged, 0);
+    }
+
+    #[tokio::test]
+    async fn preserves_stronger_existing_association_weight() {
+        let store = MemoryStore::connect_in_memory().await;
+
+        let canonical = Memory::new("shared task", MemoryType::Todo).with_importance(0.9);
+        let duplicate = Memory::new("shared  task", MemoryType::Todo).with_importance(0.5);
+        let neighbor = Memory::new("neighbor", MemoryType::Observation);
+
+        store.save(&canonical).await.expect("save canonical");
+        store.save(&duplicate).await.expect("save duplicate");
+        store.save(&neighbor).await.expect("save neighbor");
+
+        store
+            .create_association(
+                &Association::new(&neighbor.id, &canonical.id, RelationType::RelatedTo)
+                    .with_weight(0.9),
+            )
+            .await
+            .expect("canonical association");
+        store
+            .create_association(
+                &Association::new(&neighbor.id, &duplicate.id, RelationType::RelatedTo)
+                    .with_weight(0.3),
+            )
+            .await
+            .expect("duplicate association");
+
+        let merged = merge_similar_memories(&store, 0.95).await.expect("merge");
+        assert_eq!(merged, 1);
+
+        let associations = store
+            .get_associations(&canonical.id)
+            .await
+            .expect("associations");
+        let preserved = associations
+            .iter()
+            .find(|association| {
+                association.source_id == neighbor.id
+                    && association.target_id == canonical.id
+                    && association.relation_type == RelationType::RelatedTo
+            })
+            .expect("rewritten association");
+        assert_eq!(preserved.weight, 0.9);
     }
 }

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -89,7 +89,7 @@ impl MemoryType {
 }
 
 /// Memory types.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryType {
     /// Something that is true.

--- a/src/oauth_storage.rs
+++ b/src/oauth_storage.rs
@@ -19,13 +19,29 @@ pub fn load_json_credentials<T: DeserializeOwned>(path: &Path) -> Result<Option<
 pub fn save_json_credentials<T: Serialize>(path: &Path, credentials: &T) -> Result<()> {
     let data = serde_json::to_string_pretty(credentials)
         .with_context(|| format!("failed to serialize {}", path.display()))?;
-    std::fs::write(path, &data).with_context(|| format!("failed to write {}", path.display()))?;
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::io::Write as _;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        file.write_all(data.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, &data)
+            .with_context(|| format!("failed to write {}", path.display()))?;
     }
 
     Ok(())

--- a/src/oauth_storage.rs
+++ b/src/oauth_storage.rs
@@ -1,0 +1,75 @@
+//! Shared JSON persistence helpers for OAuth credential files.
+
+use anyhow::{Context as _, Result};
+use serde::{Serialize, de::DeserializeOwned};
+use std::path::{Path, PathBuf};
+
+pub fn load_json_credentials<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let data = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let credentials = serde_json::from_str(&data)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(credentials))
+}
+
+pub fn save_json_credentials<T: Serialize>(path: &Path, credentials: &T) -> Result<()> {
+    let data = serde_json::to_string_pretty(credentials)
+        .with_context(|| format!("failed to serialize {}", path.display()))?;
+    std::fs::write(path, &data).with_context(|| format!("failed to write {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+pub fn json_credentials_path(instance_dir: &Path, file_name: &str) -> PathBuf {
+    instance_dir.join(file_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{json_credentials_path, load_json_credentials, save_json_credentials};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    struct TestCredentials {
+        access_token: String,
+        refresh_token: String,
+    }
+
+    #[test]
+    fn round_trips_json_credentials() {
+        let tempdir = tempfile::tempdir().expect("create tempdir");
+        let path = json_credentials_path(tempdir.path(), "oauth.json");
+        let credentials = TestCredentials {
+            access_token: "access".to_string(),
+            refresh_token: "refresh".to_string(),
+        };
+
+        save_json_credentials(&path, &credentials).expect("save credentials");
+        let loaded = load_json_credentials::<TestCredentials>(&path)
+            .expect("load credentials")
+            .expect("credentials should exist");
+
+        assert_eq!(loaded, credentials);
+    }
+
+    #[test]
+    fn missing_json_credentials_returns_none() {
+        let tempdir = tempfile::tempdir().expect("create tempdir");
+        let path = json_credentials_path(tempdir.path(), "missing.json");
+        let loaded =
+            load_json_credentials::<TestCredentials>(&path).expect("missing credential load");
+
+        assert!(loaded.is_none());
+    }
+}

--- a/src/oauth_storage.rs
+++ b/src/oauth_storage.rs
@@ -23,7 +23,7 @@ pub fn save_json_credentials<T: Serialize>(path: &Path, credentials: &T) -> Resu
     #[cfg(unix)]
     {
         use std::io::Write as _;
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        use std::os::unix::fs::OpenOptionsExt;
 
         let mut file = std::fs::OpenOptions::new()
             .create(true)
@@ -34,8 +34,6 @@ pub fn save_json_credentials<T: Serialize>(path: &Path, credentials: &T) -> Resu
             .with_context(|| format!("failed to open {}", path.display()))?;
         file.write_all(data.as_bytes())
             .with_context(|| format!("failed to write {}", path.display()))?;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
     }
 
     #[cfg(not(unix))]

--- a/src/openai_auth.rs
+++ b/src/openai_auth.rs
@@ -365,37 +365,17 @@ pub async fn exchange_device_code(
 
 /// Path to OpenAI OAuth credentials within the instance directory.
 pub fn credentials_path(instance_dir: &Path) -> PathBuf {
-    instance_dir.join("openai_chatgpt_oauth.json")
+    crate::oauth_storage::json_credentials_path(instance_dir, "openai_chatgpt_oauth.json")
 }
 
 /// Load OpenAI OAuth credentials from disk.
 pub fn load_credentials(instance_dir: &Path) -> Result<Option<OAuthCredentials>> {
     let path = credentials_path(instance_dir);
-    if !path.exists() {
-        return Ok(None);
-    }
-
-    let data = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let creds: OAuthCredentials =
-        serde_json::from_str(&data).context("failed to parse OpenAI OAuth credentials")?;
-    Ok(Some(creds))
+    crate::oauth_storage::load_json_credentials(&path)
 }
 
 /// Save OpenAI OAuth credentials to disk with restricted permissions (0600).
 pub fn save_credentials(instance_dir: &Path, creds: &OAuthCredentials) -> Result<()> {
     let path = credentials_path(instance_dir);
-    let data = serde_json::to_string_pretty(creds)
-        .context("failed to serialize OpenAI OAuth credentials")?;
-
-    std::fs::write(&path, &data).with_context(|| format!("failed to write {}", path.display()))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to set permissions on {}", path.display()))?;
-    }
-
-    Ok(())
+    crate::oauth_storage::save_json_credentials(&path, creds)
 }

--- a/src/secrets/store.rs
+++ b/src/secrets/store.rs
@@ -1371,6 +1371,10 @@ mod tests {
             auto_categorize("BRAVE_SEARCH_API_KEY"),
             SecretCategory::System
         );
+        assert_eq!(
+            auto_categorize("WEBHOOK_AUTH_TOKEN"),
+            SecretCategory::System
+        );
 
         // Case-insensitive matching:
         assert_eq!(auto_categorize("anthropic_api_key"), SecretCategory::System);

--- a/src/secrets/store.rs
+++ b/src/secrets/store.rs
@@ -1102,7 +1102,7 @@ pub trait SystemSecrets {
 pub fn system_secret_registry() -> Vec<&'static SecretField> {
     use crate::config::{
         DefaultsConfig, DiscordConfig, EmailConfig, LlmConfig, SlackConfig, TelegramConfig,
-        TwitchConfig,
+        TwitchConfig, WebhookConfig,
     };
 
     let mut fields = Vec::new();
@@ -1116,6 +1116,7 @@ pub fn system_secret_registry() -> Vec<&'static SecretField> {
     fields.extend(TelegramConfig::secret_fields());
     fields.extend(TwitchConfig::secret_fields());
     fields.extend(EmailConfig::secret_fields());
+    fields.extend(WebhookConfig::secret_fields());
     fields
 }
 


### PR DESCRIPTION
## What?
This PR hardens the admin plane so API-initiated configuration changes no longer write plaintext credentials into `config.toml`, narrows access to the highest-risk admin endpoints, and replaces a few documented-but-unimplemented maintenance paths with real behavior.

At a high level, this change does five things:

1. Moves provider, messaging, and binding-supplied credentials into `SecretsStore` and writes `secret:` references into config instead of plaintext values.
2. Tightens the HTTP API security posture by removing mirrored CORS, requiring configured auth for raw-config and secret-export surfaces, and refusing to start on a non-loopback bind without `api.auth_token`.
3. Makes the API auth token live-reloadable so config reloads update middleware behavior instead of leaving the server in its startup auth state forever.
4. Deduplicates Anthropic/OpenAI OAuth credential file persistence behind one shared helper.
5. Replaces the memory maintenance merge stub with a real duplicate merge path that rewrites graph edges before deleting duplicates.

## Why?
Before this change, the admin API had a few concrete weaknesses:

- `update_provider`, `create_messaging_instance`, and `create_binding` could persist sensitive credentials directly into `config.toml`.
- `config/raw` and `secrets/export` were only protected by the optional global API token. If `api.auth_token` was unset, these very sensitive admin surfaces were effectively open.
- The HTTP server mirrored arbitrary `Origin` headers and would happily start on non-loopback binds without auth, which is too easy to misconfigure for a control-plane API.
- The auth token in `ApiState` was fixed at startup. Updating config later did not change the middleware behavior.
- Named messaging adapter permissions could be hot-started, but existing named adapters did not have a reload path for their permission `ArcSwap`s.
- Memory maintenance reported a merge step but the core merge function was still a stub.

This PR fixes those issues without changing the intended local-dev workflow:

- local loopback + no auth still works for general development,
- externally reachable no-auth API startup no longer works,
- the most sensitive admin endpoints now require configured auth even in otherwise local/dev-friendly setups.

## How?

### 1. Shared admin config / secret plumbing
New helper module: `src/api/admin.rs`

This module centralizes the repeated admin-plane logic for:

- loading and locking `config.toml` edits,
- writing config changes safely,
- reloading runtime configs after writes,
- resolving the shared `SecretsStore`,
- deriving `secret:` references from `SystemSecrets` metadata.

This removes the prior pattern where each admin handler open-coded its own read/parse/write/reload sequence and independently decided how to persist credentials.

### 2. Stop writing plaintext credentials into config
Changed handlers:

- `src/api/providers.rs`
- `src/api/messaging.rs`
- `src/api/bindings.rs`

Behavior changes:

- Provider updates now store provider secrets in `SecretsStore` and write `secret:...` references into `[llm]`.
- Messaging instance creation now stores secret-bearing fields (tokens, passwords, client secrets, webhook auth token, etc.) in `SecretsStore` and persists only references into `config.toml`.
- Binding-driven platform bootstrap does the same, so the alternate admin path cannot bypass the secret store.

Important detail:

- `ollama_base_url` stays plaintext because it is configuration, not a secret.
- `WebhookConfig` now participates in `SystemSecrets`, so webhook auth tokens follow the same secret-store path and auto-categorization as the other admin-managed credentials.

### 3. Harden the HTTP API surface
Changed handlers / server wiring:

- `src/api/server.rs`
- `src/api/settings.rs`
- `src/api/secrets.rs`
- `src/api/state.rs`

Behavior changes:

- CORS no longer mirrors arbitrary origins. It now only allows localhost / loopback origins for cross-origin browser access.
- `GET /api/config/raw`, `PUT /api/config/raw`, and `POST /api/secrets/export` now require a configured `api.auth_token`. If the server is running without one, those endpoints return `403` instead of exposing sensitive content.
- The server now refuses to start on a non-loopback bind without `api.auth_token`.
- `ApiState.auth_token` is now live and reloadable. Config reloads update the middleware token instead of leaving the server on whatever auth state existed at startup.

### 4. Shared OAuth credential persistence
New helper module: `src/oauth_storage.rs`

Changed modules:

- `src/auth.rs`
- `src/openai_auth.rs`

This extracts the duplicated JSON credential save/load logic used by Anthropic and OpenAI OAuth persistence into one shared helper with tests. That gives us one place to maintain the on-disk policy and removes duplicate serialization / permission code.

### 5. Hot-reload permissions for named messaging adapters
Changed modules:

- `src/config/watcher.rs`
- `src/main.rs`

This introduces registries of the named adapter permission `ArcSwap`s for Discord, Slack, Telegram, and Twitch.

Before:

- named adapters could be hot-started,
- but existing named adapters had no external handle for permission reload,
- so config edits changed permissions only after a restart.

After:

- the watcher updates the existing `ArcSwap` for each named runtime key on config reload,
- and newly hot-started named adapters register their permission handles into the same registry.

### 6. Replace the memory merge stub
Changed module:

- `src/memory/maintenance.rs`

`merge_similar_memories()` is now a real implementation instead of returning `Ok(0)` unconditionally.

Implementation details:

- it groups non-forgotten memories by type + normalized content,
- picks a canonical memory using importance / access / recency ordering,
- rewrites associations from the duplicate to the canonical memory,
- skips self-loops,
- deletes the duplicate memory after edges are preserved.

This is intentionally conservative. It does not attempt semantic embedding-based merge yet; it implements a real exact/normalized duplicate merge that is safe and testable with the current maintenance inputs.

## Testing
Added targeted regression tests for:

- provider secret persistence (`update_provider` writes `secret:` refs + stores value),
- messaging instance secret persistence,
- binding bootstrap secret persistence,
- raw-config auth gating,
- secret export auth gating,
- OAuth JSON persistence round-trip,
- local-only CORS predicate / bind protection helper,
- duplicate memory merge edge-rewrite behavior.

Validation run:

- `cargo fmt`
- `cargo fmt --check`

## Validation caveat
Full Rust build validation is currently blocked in this environment because `lance-encoding`'s build script requires `protoc`, and `protoc` is not installed here.

The current `cargo check` failure is:

```text
Error: Could not find `protoc`
```

So the PR includes formatting validation and targeted test additions, but I could not complete a full compile/test run from this machine.

## Reviewer guide
Suggested review order:

1. `src/api/admin.rs`
2. `src/api/providers.rs`
3. `src/api/messaging.rs`
4. `src/api/bindings.rs`
5. `src/api/server.rs` + `src/api/settings.rs` + `src/api/secrets.rs`
6. `src/config/watcher.rs` + `src/main.rs`
7. `src/oauth_storage.rs`, `src/auth.rs`, `src/openai_auth.rs`
8. `src/memory/maintenance.rs`

## Screenshots
N/A. This PR is backend / config-plane / maintenance work only and does not change the UI.

> [!NOTE]
> This PR consolidates security hardening across the admin API surface. The core change moves sensitive credentials from plaintext `config.toml` writes into an encrypted `SecretsStore`, with `secret:` references persisted to config instead. Additionally, the HTTP API now gates raw config and secret export endpoints with mandatory authentication, refuses to bind on non-loopback addresses without configured auth tokens, and restricts CORS to localhost. The API auth token is now live-reloadable on config changes, named adapter permissions hot-reload via registries, and the memory maintenance merge function transitions from a stub to a real duplicate-merging implementation.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [ac586cdd](https://github.com/spacedriveapp/spacebot/commit/ac586cdd911fdfc6c9ea2bd92224d543b2289aa8). This will update automatically on new commits.</sub>