### PR TITLE
fix: race condition losing opencode worker port in database

### DIFF
--- a/src/conversation/history.rs
+++ b/src/conversation/history.rs
@@ -499,22 +499,60 @@ impl ProcessRunLogger {
     ///
     /// Stores the session ID and server port so the frontend can construct
     /// an iframe URL to the embedded OpenCode web UI.
+    ///
+    /// The worker row is inserted by `log_worker_started` (also fire-and-forget),
+    /// which may not have committed yet when this runs. To handle the race we
+    /// retry with a short back-off when the UPDATE affects zero rows.
     pub fn log_opencode_metadata(&self, worker_id: WorkerId, session_id: &str, port: u16) {
         let pool = self.pool.clone();
         let id = worker_id.to_string();
         let session_id = session_id.to_string();
 
         tokio::spawn(async move {
-            if let Err(error) = sqlx::query(
-                "UPDATE worker_runs SET opencode_session_id = ?, opencode_port = ? WHERE id = ?",
-            )
-            .bind(&session_id)
-            .bind(port as i32)
-            .bind(&id)
-            .execute(&pool)
-            .await
-            {
-                tracing::warn!(%error, worker_id = %id, "failed to persist OpenCode metadata");
+            const MAX_RETRIES: u32 = 5;
+            const BASE_DELAY_MS: u64 = 50;
+
+            for attempt in 0..=MAX_RETRIES {
+                match sqlx::query(
+                    "UPDATE worker_runs SET opencode_session_id = ?, opencode_port = ? WHERE id = ?",
+                )
+                .bind(&session_id)
+                .bind(port as i32)
+                .bind(&id)
+                .execute(&pool)
+                .await
+                {
+                    Ok(result) if result.rows_affected() > 0 => {
+                        return; // Successfully updated.
+                    }
+                    Ok(_) => {
+                        // Row doesn't exist yet — INSERT hasn't committed.
+                        if attempt < MAX_RETRIES {
+                            let delay = BASE_DELAY_MS * 2u64.pow(attempt);
+                            tracing::debug!(
+                                worker_id = %id,
+                                attempt,
+                                delay_ms = delay,
+                                "worker_runs row not yet inserted, retrying opencode metadata update"
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                        } else {
+                            tracing::warn!(
+                                worker_id = %id,
+                                "worker_runs row never appeared after {MAX_RETRIES} retries, \
+                                 opencode metadata (port={port}) lost"
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            worker_id = %id,
+                            "failed to persist OpenCode metadata"
+                        );
+                        return;
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary

- Fixes the recurring bug where `opencode_port` is never written to `worker_runs`, causing the OpenCode embed to not render in the UI.

## Root Cause

`log_worker_started` (INSERT) and `log_opencode_metadata` (UPDATE) are both fire-and-forget `tokio::spawn` calls. In `channel_dispatch.rs`, `spawn_worker_task()` starts `worker.run()` *before* the `WorkerStarted` event is sent. The worker creates its OpenCode session quickly and emits `OpenCodeSessionCreated`, triggering the UPDATE — but the INSERT from `WorkerStarted` hasn't committed yet. The UPDATE matches 0 rows, silently \"succeeds\" (only `Err` was checked, not `rows_affected`), and the port is permanently lost.

## Fix

`log_opencode_metadata` now checks `rows_affected()` and retries with exponential back-off (50ms, 100ms, 200ms, 400ms, 800ms) when the row doesn't exist yet. The first retry at 50ms will almost always succeed. Logs a warning if the row never appears after 5 retries.

---

> [!NOTE]
> Modified `src/conversation/history.rs` to add exponential backoff retry logic in `log_opencode_metadata()`. The function now checks `rows_affected()` on UPDATE and retries with increasing delays (50ms base) up to 5 times when the target row hasn't been inserted yet. Prevents silent data loss of OpenCode port metadata. Includes enhanced debug logging for visibility during retries.
> 
> <sub>Written by [Tembo](https://app.tembo.io) for commit [0a3e8c8](https://github.com/spacedriveapp/spacebot/commit/0a3e8c88ca1653120f8ccf6d189528a741d9c30e). This will update automatically on new commits.</sub>