### PR TITLE
fix(discord): ignore invalid poll payloads

### DIFF
--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -1152,12 +1152,9 @@ fn build_action_row(elements: &crate::InteractiveElements) -> CreateActionRow {
 fn build_poll(
     poll: &crate::Poll,
 ) -> serenity::builder::CreatePoll<serenity::builder::create_poll::Ready> {
-    // Discord limits: max 10 answers
-    let answers: Vec<_> = poll
-        .answers
-        .iter()
-        .take(10)
-        .map(|a| CreatePollAnswer::new().text(a))
+    let answers: Vec<_> = normalized_poll_answers(poll)
+        .into_iter()
+        .map(|answer| CreatePollAnswer::new().text(answer))
         .collect();
 
     // Duration must be at least 1 hour, usually up to 720 hours (30 days).
@@ -1176,18 +1173,25 @@ fn build_poll(
     p
 }
 
+fn normalized_poll_answers(poll: &crate::Poll) -> Vec<String> {
+    // Discord limits polls to 10 answers and rejects blank options.
+    poll.answers
+        .iter()
+        .map(|answer| answer.trim())
+        .filter(|answer| !answer.is_empty())
+        .take(10)
+        .map(str::to_owned)
+        .collect()
+}
+
 fn is_valid_poll(poll: &crate::Poll) -> bool {
     let question = poll.question.trim();
-    let answer_count = poll
-        .answers
-        .iter()
-        .filter(|answer| !answer.trim().is_empty())
-        .count();
+    let answers = normalized_poll_answers(poll);
 
-    if question.is_empty() || answer_count < 2 {
+    if question.is_empty() || answers.len() < 2 {
         tracing::debug!(
             question_len = question.len(),
-            answer_count,
+            answer_count = answers.len(),
             "skipping invalid discord poll payload"
         );
         return false;
@@ -1270,11 +1274,83 @@ mod tests {
 
         let one_answer = Poll {
             question: "Question?".into(),
-            answers: vec!["Only one".into()],
+            answers: vec![" Only one ".into(), "   ".into()],
             allow_multiselect: false,
             duration_hours: 24,
         };
         assert!(!is_valid_poll(&one_answer));
+
+        let sparse_answers = Poll {
+            question: "Question?".into(),
+            answers: vec!["Yes".into(), "   ".into(), "No".into()],
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert_eq!(
+            normalized_poll_answers(&sparse_answers),
+            vec!["Yes".to_string(), "No".to_string()]
+        );
+        assert!(is_valid_poll(&sparse_answers));
+
+        let answers_beyond_limit = Poll {
+            question: "Question?".into(),
+            answers: vec![
+                "Yes".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                " ".into(),
+                "No".into(),
+            ],
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert_eq!(
+            normalized_poll_answers(&answers_beyond_limit),
+            vec!["Yes".to_string(), "No".to_string()]
+        );
+        assert!(is_valid_poll(&answers_beyond_limit));
+
+        let normalized_limit = Poll {
+            question: "Question?".into(),
+            answers: vec![
+                "Answer 1".into(),
+                " ".into(),
+                "Answer 2".into(),
+                "Answer 3".into(),
+                "Answer 4".into(),
+                "Answer 5".into(),
+                "Answer 6".into(),
+                "Answer 7".into(),
+                "Answer 8".into(),
+                "Answer 9".into(),
+                "Answer 10".into(),
+                "Answer 11".into(),
+            ],
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert_eq!(
+            normalized_poll_answers(&normalized_limit),
+            vec![
+                "Answer 1".to_string(),
+                "Answer 2".to_string(),
+                "Answer 3".to_string(),
+                "Answer 4".to_string(),
+                "Answer 5".to_string(),
+                "Answer 6".to_string(),
+                "Answer 7".to_string(),
+                "Answer 8".to_string(),
+                "Answer 9".to_string(),
+                "Answer 10".to_string(),
+            ]
+        );
+        assert!(is_valid_poll(&normalized_limit));
 
         let valid = Poll {
             question: "Question?".into(),

--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -223,7 +223,7 @@ impl Messaging for DiscordAdapter {
                             msg = msg.components(components);
                         }
 
-                        if let Some(poll_data) = &poll {
+                        if let Some(poll_data) = poll.as_ref().filter(|p| is_valid_poll(p)) {
                             msg = msg.poll(build_poll(poll_data));
                         }
                     }
@@ -504,7 +504,7 @@ impl Messaging for DiscordAdapter {
                         msg = msg.components(components);
                     }
 
-                    if let Some(poll_data) = &poll {
+                    if let Some(poll_data) = poll.as_ref().filter(|p| is_valid_poll(p)) {
                         msg = msg.poll(build_poll(poll_data));
                     }
                 }
@@ -1176,6 +1176,26 @@ fn build_poll(
     p
 }
 
+fn is_valid_poll(poll: &crate::Poll) -> bool {
+    let question = poll.question.trim();
+    let answer_count = poll
+        .answers
+        .iter()
+        .filter(|answer| !answer.trim().is_empty())
+        .count();
+
+    if question.is_empty() || answer_count < 2 {
+        tracing::debug!(
+            question_len = question.len(),
+            answer_count,
+            "skipping invalid discord poll payload"
+        );
+        return false;
+    }
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1236,5 +1256,32 @@ mod tests {
         // build_poll should limit answers to 10 and duration to 720
         let _ = build_poll(&poll);
         // Again, can't easily inspect CreatePoll fields, but we verify it runs.
+    }
+
+    #[test]
+    fn test_invalid_poll_is_rejected() {
+        let empty = Poll {
+            question: String::new(),
+            answers: Vec::new(),
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert!(!is_valid_poll(&empty));
+
+        let one_answer = Poll {
+            question: "Question?".into(),
+            answers: vec!["Only one".into()],
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert!(!is_valid_poll(&one_answer));
+
+        let valid = Poll {
+            question: "Question?".into(),
+            answers: vec!["Yes".into(), "No".into()],
+            allow_multiselect: false,
+            duration_hours: 24,
+        };
+        assert!(is_valid_poll(&valid));
     }
 }


### PR DESCRIPTION
## Summary
- ignore invalid Discord poll payloads in rich replies
- keep plain text replies working even when a malformed optional poll object is present
- add a unit test covering empty and incomplete poll payloads

## Why
Some reply payloads can include an empty poll stub even when the intent is just a normal text reply. Discord rejects those malformed polls, which causes the whole rich message send to fail.

This change validates poll payloads before attaching them to Discord messages. Invalid polls are skipped instead of breaking delivery.

## Testing
- added unit test coverage for invalid and valid poll payloads

> [!NOTE]
> This PR adds poll validation to the Discord adapter. A new `is_valid_poll()` function checks that polls have a non-empty question and at least 2 answers, filtering them at the point of attachment in two locations. Invalid polls are silently skipped with a debug log. The unit test covers empty, single-answer, and valid poll payloads.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [badfb61](https://github.com/spacedriveapp/spacebot/commit/badfb611f6f5b86b5424cbab0184f94effce3144). This will update automatically on new commits.</sub>