### PR TITLE
fix: collapse nested if statements in signal adapter routing

### DIFF
--- a/src/tools/send_message_to_another_channel.rs
+++ b/src/tools/send_message_to_another_channel.rs
@@ -150,14 +150,13 @@ impl Tool for SendMessageTool {
             // If explicit prefix returned default "signal" adapter but we're in a named
             // Signal adapter conversation (e.g., signal:gvoice1), use the current adapter
             // to ensure the message goes through the correct account.
-            if target.adapter == "signal" {
-                if let Some(current_adapter) = self
+            if target.adapter == "signal"
+                && let Some(current_adapter) = self
                     .current_adapter
                     .as_ref()
                     .filter(|adapter| adapter.starts_with("signal:"))
-                {
-                    target.adapter = current_adapter.clone();
-                }
+            {
+                target.adapter = current_adapter.clone();
             }
 
             self.messaging_manager
@@ -189,31 +188,28 @@ impl Tool for SendMessageTool {
             .current_adapter
             .as_ref()
             .filter(|adapter| adapter.starts_with("signal"))
+            && let Some(target) = parse_implicit_signal_shorthand(&args.target, current_adapter)
         {
-            if let Some(target) = parse_implicit_signal_shorthand(&args.target, current_adapter) {
-                self.messaging_manager
-                    .broadcast(
-                        &target.adapter,
-                        &target.target,
-                        crate::OutboundResponse::Text(args.message),
-                    )
-                    .await
-                    .map_err(|error| {
-                        SendMessageError(format!("failed to send message: {error}"))
-                    })?;
+            self.messaging_manager
+                .broadcast(
+                    &target.adapter,
+                    &target.target,
+                    crate::OutboundResponse::Text(args.message),
+                )
+                .await
+                .map_err(|error| SendMessageError(format!("failed to send message: {error}")))?;
 
-                tracing::info!(
-                    adapter = %target.adapter,
-                    broadcast_target = %"[REDACTED]",
-                    "message sent via implicit Signal shorthand"
-                );
+            tracing::info!(
+                adapter = %target.adapter,
+                broadcast_target = %"[REDACTED]",
+                "message sent via implicit Signal shorthand"
+            );
 
-                return Ok(SendMessageOutput {
-                    success: true,
-                    target: target.target,
-                    platform: target.adapter,
-                });
-            }
+            return Ok(SendMessageOutput {
+                success: true,
+                target: target.target,
+                platform: target.adapter,
+            });
         }
 
         // Check for explicit email target


### PR DESCRIPTION
## Summary

Fixes clippy `collapsible_if` lint introduced by the Signal adapter merge (#347). Two nested if blocks in `send_message_to_another_channel.rs` are collapsed into single conditional expressions using let chains.

This is currently breaking CI on all PRs branched from main.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] All lib tests pass

---

> [!NOTE]
> **AI Summary:** Collapses two nested if blocks into single conditions using let chains. First block (lines 153-160) combines the adapter check with optional current adapter assignment. Second block (lines 191-207) combines the implicit signal shorthand check with target parsing, reducing nesting and improving readability. Changes are purely structural with no logic modification.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [0faf9c8](https://github.com/spacedriveapp/spacebot/commit/0faf9c8213e120d4ab6f4c084fe93e679d41298a). This will update automatically on new commits.</sub>