### PR TITLE
fix: skip unresolvable channel bindings instead of crashing on startup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1602,7 +1602,7 @@ maintenance_merge_similarity_threshold = 1.1
                 dm_allowed_users: vec![],
             },
         ];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert_eq!(result.len(), 2);
     }
@@ -1634,7 +1634,7 @@ maintenance_merge_similarity_threshold = 1.1
             require_mention: false,
             dm_allowed_users: vec![],
         }];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert!(result.is_empty(), "unresolvable binding should be skipped");
     }
@@ -1699,7 +1699,7 @@ maintenance_merge_similarity_threshold = 1.1
             require_mention: false,
             dm_allowed_users: vec![],
         }];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert!(
             result.is_empty(),
@@ -1740,7 +1740,7 @@ maintenance_merge_similarity_threshold = 1.1
             require_mention: false,
             dm_allowed_users: vec![],
         }];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert!(
             result.is_empty(),
@@ -1819,7 +1819,7 @@ maintenance_merge_similarity_threshold = 1.1
                 dm_allowed_users: vec![],
             },
         ];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert_eq!(
             result.len(),
@@ -1852,11 +1852,115 @@ maintenance_merge_similarity_threshold = 1.1
             require_mention: false,
             dm_allowed_users: vec![],
         }];
-        let result = validate_named_messaging_adapters(&messaging, bindings)
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
             .expect("bindings should be resolvable");
         assert!(
             result.is_empty(),
             "binding with no messaging config should be skipped"
+        );
+    }
+
+    #[test]
+    fn validate_strict_mode_rejects_missing_messaging_config() {
+        let messaging = MessagingConfig {
+            discord: None,
+            slack: None,
+            telegram: None,
+            email: None,
+            webhook: None,
+            twitch: None,
+            signal: None,
+        };
+        let bindings = vec![Binding {
+            agent_id: "main".into(),
+            channel: "telegram".into(),
+            adapter: None,
+            guild_id: None,
+            workspace_id: None,
+            chat_id: None,
+            channel_ids: vec![],
+            require_mention: false,
+            dm_allowed_users: vec![],
+        }];
+        let result = validate_named_messaging_adapters(&messaging, bindings, true);
+        assert!(
+            result.is_err(),
+            "strict mode should reject unresolvable bindings"
+        );
+    }
+
+    #[test]
+    fn validate_disabled_instance_is_filtered_out() {
+        let messaging = MessagingConfig {
+            discord: None,
+            slack: None,
+            telegram: Some(TelegramConfig {
+                enabled: true,
+                token: "tok".into(),
+                instances: vec![TelegramInstanceConfig {
+                    name: "support".into(),
+                    enabled: false,
+                    token: "tok2".into(),
+                    dm_allowed_users: vec![],
+                }],
+                dm_allowed_users: vec![],
+            }),
+            email: None,
+            webhook: None,
+            twitch: None,
+            signal: None,
+        };
+        let bindings = vec![Binding {
+            agent_id: "main".into(),
+            channel: "telegram".into(),
+            adapter: Some("support".into()),
+            guild_id: None,
+            workspace_id: None,
+            chat_id: None,
+            channel_ids: vec![],
+            require_mention: false,
+            dm_allowed_users: vec![],
+        }];
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
+            .expect("bindings should be resolvable");
+        assert!(
+            result.is_empty(),
+            "binding to disabled instance should be skipped"
+        );
+    }
+
+    #[test]
+    fn validate_disabled_platform_default_is_filtered_out() {
+        let messaging = MessagingConfig {
+            discord: None,
+            slack: None,
+            telegram: Some(TelegramConfig {
+                enabled: false,
+                token: "tok".into(),
+                instances: vec![],
+                dm_allowed_users: vec![],
+            }),
+            email: None,
+            webhook: None,
+            twitch: None,
+            signal: None,
+        };
+        let bindings = vec![Binding {
+            agent_id: "main".into(),
+            channel: "telegram".into(),
+            adapter: None,
+            guild_id: None,
+            workspace_id: None,
+            chat_id: None,
+            channel_ids: vec![],
+            require_mention: false,
+            dm_allowed_users: vec![],
+        }];
+        let result = validate_named_messaging_adapters(&messaging, bindings, false)
+            .expect("bindings should be resolvable");
+        assert!(
+            result.is_empty(),
+            "binding to disabled platform default should be skipped"
         );
     }
 

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -905,13 +905,22 @@ impl Config {
 
         let toml_config: TomlConfig =
             toml::from_str(content).context("failed to parse config TOML")?;
-        // Run full conversion to catch semantic errors (env resolution, defaults, etc.)
+        // Run full conversion with strict binding validation so config
+        // authoring catches unresolvable bindings as errors.
         let instance_dir = Self::default_instance_dir();
-        Self::from_toml(toml_config, instance_dir)?;
+        Self::from_toml_inner(toml_config, instance_dir, true)?;
         Ok(())
     }
 
     pub(super) fn from_toml(toml: TomlConfig, instance_dir: PathBuf) -> Result<Self> {
+        Self::from_toml_inner(toml, instance_dir, false)
+    }
+
+    fn from_toml_inner(
+        toml: TomlConfig,
+        instance_dir: PathBuf,
+        strict_bindings: bool,
+    ) -> Result<Self> {
         // Validate providers before processing
         for (provider_id, config) in &toml.llm.providers {
             // Validate provider_id
@@ -2245,7 +2254,7 @@ impl Config {
             })
             .collect();
 
-        let bindings = validate_named_messaging_adapters(&messaging, bindings)?;
+        let bindings = validate_named_messaging_adapters(&messaging, bindings, strict_bindings)?;
 
         let api = ApiConfig {
             enabled: toml.api.enabled,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1678,9 +1678,14 @@ pub(super) fn is_named_adapter_platform(platform: &str) -> bool {
 /// resolvable bindings. Unresolvable bindings (missing messaging config,
 /// missing adapter, etc.) are logged as warnings and skipped instead of
 /// causing a hard startup failure.
+/// Validate channel bindings against messaging config, returning only the
+/// resolvable bindings. When `strict` is true (config authoring/validation),
+/// unresolvable bindings cause an error. When `strict` is false (startup),
+/// they are logged as warnings and skipped so the agent can still boot.
 pub(super) fn validate_named_messaging_adapters(
     messaging: &MessagingConfig,
     bindings: Vec<Binding>,
+    strict: bool,
 ) -> Result<Vec<Binding>> {
     let adapter_states = build_adapter_validation_states(messaging)?;
 
@@ -1689,6 +1694,13 @@ pub(super) fn validate_named_messaging_adapters(
     for binding in bindings {
         if !is_named_adapter_platform(binding.channel.as_str()) {
             if binding.adapter.is_some() {
+                let msg = format!(
+                    "binding for agent '{}' on channel '{}' can't set adapter: this platform does not support named adapters",
+                    binding.agent_id, binding.channel
+                );
+                if strict {
+                    return Err(ConfigError::Invalid(msg).into());
+                }
                 tracing::warn!(
                     agent_id = %binding.agent_id,
                     channel = %binding.channel,
@@ -1704,6 +1716,13 @@ pub(super) fn validate_named_messaging_adapters(
         let state = match adapter_states.get(binding.channel.as_str()) {
             Some(s) => s,
             None => {
+                let msg = format!(
+                    "binding for agent '{}' on channel '{}' can't be resolved: no messaging config exists for that platform",
+                    binding.agent_id, binding.channel
+                );
+                if strict {
+                    return Err(ConfigError::Invalid(msg).into());
+                }
                 tracing::warn!(
                     agent_id = %binding.agent_id,
                     channel = %binding.channel,
@@ -1717,21 +1736,35 @@ pub(super) fn validate_named_messaging_adapters(
         match binding.adapter.as_deref() {
             Some(adapter_name) => {
                 if !state.named_instances.contains(adapter_name) {
+                    let msg = format!(
+                        "binding for agent '{}' on channel '{}' references missing or disabled adapter '{}'",
+                        binding.agent_id, binding.channel, adapter_name
+                    );
+                    if strict {
+                        return Err(ConfigError::Invalid(msg).into());
+                    }
                     tracing::warn!(
                         agent_id = %binding.agent_id,
                         channel = %binding.channel,
                         adapter = %adapter_name,
-                        "skipping binding: references missing adapter"
+                        "skipping binding: references missing or disabled adapter"
                     );
                     continue;
                 }
             }
             None => {
                 if !state.default_present {
+                    let msg = format!(
+                        "binding for agent '{}' on channel '{}' requires the default adapter, but it is disabled or has no credentials configured",
+                        binding.agent_id, binding.channel
+                    );
+                    if strict {
+                        return Err(ConfigError::Invalid(msg).into());
+                    }
                     tracing::warn!(
                         agent_id = %binding.agent_id,
                         channel = %binding.channel,
-                        "skipping binding: requires the default adapter, but no default credentials are configured"
+                        "skipping binding: requires the default adapter, but it is disabled or has no credentials configured"
                     );
                     continue;
                 }
@@ -1750,37 +1783,49 @@ pub(super) fn build_adapter_validation_states(
     let mut states = std::collections::HashMap::new();
 
     if let Some(discord) = &messaging.discord {
-        let named_instances = validate_instance_names(
+        // Validate ALL instance names for structural issues (duplicates, empty, etc.)
+        validate_instance_names(
             "discord",
             discord
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        validate_runtime_keys(
-            "discord",
-            !discord.token.trim().is_empty(),
-            &named_instances,
-        )?;
+        // Only include enabled instances in the resolvable set
+        let named_instances: std::collections::HashSet<String> = discord
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = discord.enabled && !discord.token.trim().is_empty();
+        validate_runtime_keys("discord", default_present, &named_instances)?;
         states.insert(
             "discord",
             AdapterValidationState {
-                default_present: !discord.token.trim().is_empty(),
+                default_present,
                 named_instances,
             },
         );
     }
 
     if let Some(slack) = &messaging.slack {
-        let named_instances = validate_instance_names(
+        validate_instance_names(
             "slack",
             slack
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        let default_present =
-            !slack.bot_token.trim().is_empty() && !slack.app_token.trim().is_empty();
+        let named_instances: std::collections::HashSet<String> = slack
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = slack.enabled
+            && !slack.bot_token.trim().is_empty()
+            && !slack.app_token.trim().is_empty();
         validate_runtime_keys("slack", default_present, &named_instances)?;
         states.insert(
             "slack",
@@ -1792,14 +1837,20 @@ pub(super) fn build_adapter_validation_states(
     }
 
     if let Some(telegram) = &messaging.telegram {
-        let named_instances = validate_instance_names(
+        validate_instance_names(
             "telegram",
             telegram
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        let default_present = !telegram.token.trim().is_empty();
+        let named_instances: std::collections::HashSet<String> = telegram
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = telegram.enabled && !telegram.token.trim().is_empty();
         validate_runtime_keys("telegram", default_present, &named_instances)?;
         states.insert(
             "telegram",
@@ -1811,15 +1862,22 @@ pub(super) fn build_adapter_validation_states(
     }
 
     if let Some(twitch) = &messaging.twitch {
-        let named_instances = validate_instance_names(
+        validate_instance_names(
             "twitch",
             twitch
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        let default_present =
-            !twitch.username.trim().is_empty() && !twitch.oauth_token.trim().is_empty();
+        let named_instances: std::collections::HashSet<String> = twitch
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = twitch.enabled
+            && !twitch.username.trim().is_empty()
+            && !twitch.oauth_token.trim().is_empty();
         validate_runtime_keys("twitch", default_present, &named_instances)?;
         states.insert(
             "twitch",
@@ -1831,14 +1889,21 @@ pub(super) fn build_adapter_validation_states(
     }
 
     if let Some(email) = &messaging.email {
-        let named_instances = validate_instance_names(
+        validate_instance_names(
             "email",
             email
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        let default_present = !email.imap_host.trim().is_empty()
+        let named_instances: std::collections::HashSet<String> = email
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = email.enabled
+            && !email.imap_host.trim().is_empty()
             && !email.imap_username.trim().is_empty()
             && !email.imap_password.trim().is_empty()
             && !email.smtp_host.trim().is_empty();
@@ -1853,15 +1918,22 @@ pub(super) fn build_adapter_validation_states(
     }
 
     if let Some(signal) = &messaging.signal {
-        let named_instances = validate_instance_names(
+        validate_instance_names(
             "signal",
             signal
                 .instances
                 .iter()
                 .map(|instance| instance.name.as_str()),
         )?;
-        let default_present =
-            !signal.http_url.trim().is_empty() && !signal.account.trim().is_empty();
+        let named_instances: std::collections::HashSet<String> = signal
+            .instances
+            .iter()
+            .filter(|i| i.enabled)
+            .map(|i| i.name.clone())
+            .collect();
+        let default_present = signal.enabled
+            && !signal.http_url.trim().is_empty()
+            && !signal.account.trim().is_empty();
         validate_runtime_keys("signal", default_present, &named_instances)?;
         states.insert(
             "signal",


### PR DESCRIPTION
## Summary

When a channel binding references a messaging platform (e.g. `telegram`) with no corresponding `[messaging.telegram]` config section, the agent hard-crashes during config validation, causing Fly machines to crash-loop until max restart count.

Changed `validate_named_messaging_adapters()` from a hard-fail validator to a filter that returns only resolvable bindings. Unresolvable bindings are logged as warnings and skipped. The agent starts successfully with the remaining valid bindings.

All four error cases now warn-and-skip instead of crash:
- Missing messaging config for platform
- Missing named adapter instance
- Named adapter on unsupported platform
- No default credentials configured

Closes #411

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] All 622 lib tests pass (including 5 updated + 1 new validation test)
- [ ] Configure a binding for a platform with no messaging config, verify agent starts with warning log

> [!NOTE]
> **Key changes:** Refactored `validate_named_messaging_adapters()` to return filtered `Vec<Binding>` instead of validating in-place. The function now logs warnings for unresolvable bindings and skips them gracefully rather than hard-failing. Updated 4 test cases to reflect this new behavior and added 1 new test for the missing messaging config scenario.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [ee4f1cb](https://github.com/spacedriveapp/spacebot/commit/ee4f1cb911fc989aee288d8223ed935018023099). This will update automatically on new commits.</sub>