### PR TITLE
fix: preserve whitespace-only content segments in streaming responses

### DIFF
--- a/src/llm/model.rs
+++ b/src/llm/model.rs
@@ -2568,7 +2568,10 @@ fn parse_openai_reasoning_fallback(message: &serde_json::Value) -> Option<String
 fn collect_openai_text_content(value: &serde_json::Value, text_parts: &mut Vec<String>) {
     match value {
         serde_json::Value::String(text) => {
-            if !text.trim().is_empty() {
+            // Use is_empty() instead of trim().is_empty() to preserve whitespace-only
+            // segments. Streaming providers (e.g. Kimi) sometimes send content chunks
+            // that are just spaces; dropping those causes missing spaces in output.
+            if !text.is_empty() {
                 text_parts.push(text.to_string());
             }
         }
@@ -2579,17 +2582,17 @@ fn collect_openai_text_content(value: &serde_json::Value, text_parts: &mut Vec<S
         }
         serde_json::Value::Object(map) => {
             if let Some(text) = map.get("text").and_then(serde_json::Value::as_str)
-                && !text.trim().is_empty()
+                && !text.is_empty()
             {
                 text_parts.push(text.to_string());
             }
             if let Some(summary) = map.get("summary").and_then(serde_json::Value::as_str)
-                && !summary.trim().is_empty()
+                && !summary.is_empty()
             {
                 text_parts.push(summary.to_string());
             }
             if let Some(refusal) = map.get("refusal").and_then(serde_json::Value::as_str)
-                && !refusal.trim().is_empty()
+                && !refusal.is_empty()
             {
                 text_parts.push(refusal.to_string());
             }
@@ -2663,7 +2666,7 @@ fn extract_text_content_from_responses_output_item(
             }
 
             if let Some(text) = map.get("text").and_then(serde_json::Value::as_str)
-                && !text.trim().is_empty()
+                && !text.is_empty()
             {
                 text_parts.push(text.to_string());
             }


### PR DESCRIPTION
## Summary

- Streaming providers (e.g. Kimi) sometimes send content chunks that are just whitespace (spaces, newlines). `collect_openai_text_content` and `extract_text_content_from_responses_output_item` used `trim().is_empty()` to filter content segments, which dropped these whitespace-only chunks — causing missing spaces in reconstructed output, especially at sentence boundaries and around numbers in lists.
- Changed `trim().is_empty()` to `is_empty()` so only truly empty strings `""` are filtered, preserving legitimate whitespace tokens from streaming deltas.
- The `trim().is_empty()` guards in outbound message conversion (`convert_messages_to_anthropic`) and non-streaming Anthropic parsing (`parse_anthropic_response`) are intentionally left unchanged — those filter complete message blocks where whitespace-only content is genuinely meaningless.

## Verification

- `cargo fmt` — clean
- `cargo check --all-targets` — clean
- `cargo clippy --all-targets -D warnings` — clean
- `cargo test --lib` — 625 tests passed

> [!NOTE]
> Changes made in `src/llm/model.rs` to preserve whitespace tokens from streaming providers across content collection functions (`collect_openai_text_content` and `extract_text_content_from_responses_output_item`).
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [b85ae3a](https://github.com/spacedriveapp/spacebot/commit/b85ae3ad8ad00b34965f39b3b36d64803f6e524d).</sub>