### PR TITLE
fix: add missing libxkbcommon0 to Docker runtime deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libcairo2 \
     libcups2 \
+    libxkbcommon0 \
     libxss1 \
     libxtst6 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Adds `libxkbcommon0` to the runtime stage Chrome dependencies in the Dockerfile
- Browser tools fail to launch Chromium with `libxkbcommon.so.0: cannot open shared object file` error

## Test plan
- [ ] Build Docker image and verify browser tools can launch Chromium
- [ ] Confirm `ldd` on the Chromium binary shows `libxkbcommon.so.0` resolved

Closes #425

> [!NOTE]
> This PR adds a single missing system dependency (`libxkbcommon0`) to the Dockerfile's runtime stage. This library is required by Chromium for keyboard handling and was causing browser tool launches to fail with a missing shared object error. The fix is a minimal one-line addition to the existing Chrome dependency list in the runtime image.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [ab845c5](https://github.com/spacedriveapp/spacebot/commit/ab845c537e4327bc8e6f5fe6c3cf87ba6c2fdaf7). This will update automatically on new commits.</sub>