### PR TITLE
fix: add libxfixes3 to Docker runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxkbcommon0 \
     libxss1 \
     libxtst6 \
+    libxfixes3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/bin/spacebot /usr/local/bin/spacebot


### PR DESCRIPTION
Without this library, Chromium-based browser tools fail to initialize in the container, typically resulting in an error related to a missing shared library: libXfixes.so.3. This change ensures all necessary X11 extensions are present for headless
  browser operations.

> [!NOTE]
> Adds the `libxfixes3` package to the Dockerfile runtime dependencies. This single-line change resolves initialization failures for Chromium-based browser tools in containerized environments by providing the required X11 Fixes extension library.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [8f21ed4](https://github.com/spacedriveapp/spacebot/commit/8f21ed4a43e5b3d5fb5b21c8379b38eb6348b164). This will update automatically on new commits.</sub>