### PR TITLE
feat(providers): add Anthropic OAuth subscription support with CLI detection

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -911,6 +911,7 @@ export interface CronExecutionsParams {
 
 export interface ProviderStatus {
 	anthropic: boolean;
+	anthropic_oauth: boolean;
 	openai: boolean;
 	openai_chatgpt: boolean;
 	openrouter: boolean;
@@ -964,6 +965,28 @@ export interface OpenAiOAuthBrowserStatusResponse {
 	done: boolean;
 	success: boolean;
 	message: string | null;
+}
+
+export interface ClaudeCliStatusResponse {
+	claude_folder_exists: boolean;
+	credentials_file_exists: boolean;
+	cli_installed: boolean;
+	cli_version: string | null;
+	authenticated: boolean;
+	email: string | null;
+	oauth_configured: boolean;
+}
+
+export interface AnthropicOAuthStartResponse {
+	success: boolean;
+	message: string;
+	authorize_url: string | null;
+	state: string | null;
+}
+
+export interface AnthropicOAuthExchangeResponse {
+	success: boolean;
+	message: string;
 }
 
 // -- Model Types --
@@ -1950,6 +1973,29 @@ export const api = {
 			throw new Error(`API error: ${response.status}`);
 		}
 		return response.json() as Promise<ProviderModelTestResponse>;
+	},
+	claudeCliStatus: () => fetchJson<ClaudeCliStatusResponse>("/providers/anthropic/oauth/cli-status"),
+	startAnthropicOAuth: async (params: { model: string; mode?: string }) => {
+		const response = await fetch(`${API_BASE}/providers/anthropic/oauth/start`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(params),
+		});
+		if (!response.ok) {
+			throw new Error(`API error: ${response.status}`);
+		}
+		return response.json() as Promise<AnthropicOAuthStartResponse>;
+	},
+	exchangeAnthropicOAuth: async (params: { code: string; state: string }) => {
+		const response = await fetch(`${API_BASE}/providers/anthropic/oauth/exchange`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(params),
+		});
+		if (!response.ok) {
+			throw new Error(`API error: ${response.status}`);
+		}
+		return response.json() as Promise<AnthropicOAuthExchangeResponse>;
 	},
 	startOpenAiOAuthBrowser: async (params: {model: string}) => {
 		const response = await fetch(`${API_BASE}/providers/openai/oauth/browser/start`, {

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, type GlobalSettingsResponse, type UpdateStatus, type SecretCategory, type SecretListItem, type StoreState } from "@/api/client";
+import { api, type GlobalSettingsResponse, type UpdateStatus, type SecretCategory, type SecretListItem, type StoreState, type ClaudeCliStatusResponse } from "@/api/client";
 import { Badge, Button, Input, SettingSidebarButton, Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, Select, SelectTrigger, SelectValue, SelectContent, SelectItem, Toggle } from "@/ui";
 import { useSearch, useNavigate } from "@tanstack/react-router";
 import { PlatformCatalog, InstanceCard, AddInstanceCard } from "@/components/ChannelSettingCard";
@@ -280,6 +280,14 @@ export function Settings() {
 		message: string;
 		sample?: string | null;
 	} | null>(null);
+	const [anthropicOAuthDialogOpen, setAnthropicOAuthDialogOpen] = useState(false);
+	const [anthropicOAuthModel, setAnthropicOAuthModel] = useState("");
+	const [anthropicOAuthMessage, setAnthropicOAuthMessage] = useState<{
+		text: string;
+		type: "success" | "error";
+	} | null>(null);
+	const [anthropicOAuthState, setAnthropicOAuthState] = useState<string | null>(null);
+	const [anthropicOAuthCodeInput, setAnthropicOAuthCodeInput] = useState("");
 	const [isPollingOpenAiBrowserOAuth, setIsPollingOpenAiBrowserOAuth] = useState(false);
 	const [openAiBrowserOAuthMessage, setOpenAiBrowserOAuthMessage] = useState<{
 		text: string;
@@ -342,6 +350,21 @@ export function Settings() {
 		mutationFn: ({ provider, apiKey, model }: { provider: string; apiKey: string; model: string }) =>
 			api.testProviderModel(provider, apiKey, model),
 	});
+	const { data: cliStatus } = useQuery({
+		queryKey: ["claude-cli-status"],
+		queryFn: api.claudeCliStatus,
+		staleTime: 60_000,
+		enabled: activeSection === "providers",
+	});
+
+	const startAnthropicOAuthMutation = useMutation({
+		mutationFn: (params: { model: string; mode?: string }) => api.startAnthropicOAuth(params),
+	});
+
+	const exchangeAnthropicOAuthMutation = useMutation({
+		mutationFn: (params: { code: string; state: string }) => api.exchangeAnthropicOAuth(params),
+	});
+
 	const startOpenAiBrowserOAuthMutation = useMutation({
 		mutationFn: (params: { model: string }) => api.startOpenAiOAuthBrowser(params),
 	});
@@ -550,6 +573,71 @@ export function Settings() {
 		);
 	};
 
+	const handleStartAnthropicOAuth = async () => {
+		if (!anthropicOAuthModel.trim()) {
+			setAnthropicOAuthMessage({ text: "Please select a model first", type: "error" });
+			return;
+		}
+		setAnthropicOAuthMessage(null);
+		setAnthropicOAuthState(null);
+		setAnthropicOAuthCodeInput("");
+		try {
+			const result = await startAnthropicOAuthMutation.mutateAsync({
+				model: anthropicOAuthModel.trim(),
+			});
+			if (!result.success || !result.authorize_url || !result.state) {
+				setAnthropicOAuthMessage({
+					text: result.message || "Failed to start OAuth flow",
+					type: "error",
+				});
+				return;
+			}
+			setAnthropicOAuthState(result.state);
+			window.open(
+				result.authorize_url,
+				"spacebot-anthropic-oauth",
+				"popup=true,width=780,height=960,noopener,noreferrer",
+			);
+		} catch (error: any) {
+			setAnthropicOAuthMessage({ text: `Failed: ${error.message}`, type: "error" });
+		}
+	};
+
+	const handleExchangeAnthropicOAuth = async () => {
+		if (!anthropicOAuthState || !anthropicOAuthCodeInput.trim()) return;
+		setAnthropicOAuthMessage(null);
+		try {
+			const result = await exchangeAnthropicOAuthMutation.mutateAsync({
+				code: anthropicOAuthCodeInput.trim(),
+				state: anthropicOAuthState,
+			});
+			if (result.success) {
+				setAnthropicOAuthMessage({ text: result.message, type: "success" });
+				setAnthropicOAuthState(null);
+				setAnthropicOAuthCodeInput("");
+				queryClient.invalidateQueries({ queryKey: ["providers"] });
+				queryClient.invalidateQueries({ queryKey: ["claude-cli-status"] });
+				setTimeout(() => {
+					queryClient.invalidateQueries({ queryKey: ["agents"] });
+					queryClient.invalidateQueries({ queryKey: ["overview"] });
+				}, 3000);
+			} else {
+				setAnthropicOAuthMessage({ text: result.message, type: "error" });
+			}
+		} catch (error: any) {
+			setAnthropicOAuthMessage({ text: `Failed: ${error.message}`, type: "error" });
+		}
+	};
+
+	useEffect(() => {
+		if (!anthropicOAuthDialogOpen) {
+			setAnthropicOAuthMessage(null);
+			setAnthropicOAuthState(null);
+			setAnthropicOAuthCodeInput("");
+			setAnthropicOAuthModel("");
+		}
+	}, [anthropicOAuthDialogOpen]);
+
 	const handleClose = () => {
 		setEditingProvider(null);
 		setKeyInput("");
@@ -643,6 +731,16 @@ export function Settings() {
 												onRemove={() => removeMutation.mutate(provider.id)}
 												removing={removeMutation.isPending}
 											/>,
+											provider.id === "anthropic" ? (
+												<AnthropicOAuthProviderCard
+													key="anthropic-oauth"
+													configured={isConfigured("anthropic-oauth")}
+													cliStatus={cliStatus}
+													onSignIn={() => setAnthropicOAuthDialogOpen(true)}
+													onRemove={() => removeMutation.mutate("anthropic-oauth")}
+													removing={removeMutation.isPending}
+												/>
+											) : null,
 											provider.id === "openai" ? (
 												<ProviderCard
 													key="openai-chatgpt"
@@ -678,6 +776,22 @@ export function Settings() {
 									, etc.).
 								</p>
 							</div>
+
+							<AnthropicOAuthDialog
+								open={anthropicOAuthDialogOpen}
+								onOpenChange={setAnthropicOAuthDialogOpen}
+								isRequesting={startAnthropicOAuthMutation.isPending}
+								isExchanging={exchangeAnthropicOAuthMutation.isPending}
+								message={anthropicOAuthMessage}
+								hasState={!!anthropicOAuthState}
+								codeInput={anthropicOAuthCodeInput}
+								onCodeInputChange={setAnthropicOAuthCodeInput}
+								onStartOAuth={handleStartAnthropicOAuth}
+								onExchangeCode={handleExchangeAnthropicOAuth}
+								cliStatus={cliStatus}
+								modelValue={anthropicOAuthModel}
+								onModelChange={setAnthropicOAuthModel}
+							/>
 
 							<ChatGptOAuthDialog
 								open={openAiOAuthDialogOpen}
@@ -2809,6 +2923,224 @@ function ConfigFileSection() {
 		</div>
 	);
 }
+
+// ── Anthropic OAuth Provider Card ────────────────────────────────────────
+
+function AnthropicOAuthProviderCard({
+	configured,
+	cliStatus,
+	onSignIn,
+	onRemove,
+	removing,
+}: {
+	configured: boolean;
+	cliStatus: ClaudeCliStatusResponse | undefined;
+	onSignIn: () => void;
+	onRemove: () => void;
+	removing: boolean;
+}) {
+	const cliDetected = cliStatus?.cli_installed && cliStatus?.authenticated;
+
+	return (
+		<div className="rounded-lg border border-app-line bg-app-box p-4">
+			<div className="flex items-center gap-3">
+				<ProviderIcon provider="anthropic" size={32} />
+				<div className="flex-1">
+					<div className="flex items-center gap-2">
+						<span className="text-sm font-medium text-ink">Claude Code CLI (OAuth)</span>
+						{configured && (
+							<span className="inline-flex items-center">
+								<span className="h-2 w-2 rounded-full bg-green-400" aria-hidden="true" />
+								<span className="sr-only">Configured</span>
+							</span>
+						)}
+					</div>
+					<p className="mt-0.5 text-sm text-ink-dull">
+						Use your Claude Pro/Max subscription via OAuth instead of an API key.
+					</p>
+					{cliDetected && !configured && (
+						<p className="mt-1 text-tiny text-green-400">
+							Claude Code CLI detected{cliStatus?.email ? ` (${cliStatus.email})` : ""} — you can sign in with your existing account.
+						</p>
+					)}
+					{cliStatus && !cliDetected && !configured && (
+						<p className="mt-1 text-tiny text-ink-faint">
+							Claude Code CLI not detected. You can still sign in via browser.
+						</p>
+					)}
+					<p className="mt-1 text-tiny text-ink-faint">
+						Model selected during sign-in is applied to routing.
+					</p>
+				</div>
+				<div className="flex gap-2">
+					<Button onClick={onSignIn} variant="outline" size="sm">
+						{configured ? "Update" : "Sign in"}
+					</Button>
+					{configured && (
+						<Button onClick={onRemove} variant="outline" size="sm" loading={removing}>
+							Remove
+						</Button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ── Anthropic OAuth Dialog ──────────────────────────────────────────────
+
+function AnthropicOAuthDialog({
+	open,
+	onOpenChange,
+	isRequesting,
+	isExchanging,
+	message,
+	hasState,
+	codeInput,
+	onCodeInputChange,
+	onStartOAuth,
+	onExchangeCode,
+	cliStatus,
+	modelValue,
+	onModelChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	isRequesting: boolean;
+	isExchanging: boolean;
+	message: { text: string; type: "success" | "error" } | null;
+	hasState: boolean;
+	codeInput: string;
+	onCodeInputChange: (value: string) => void;
+	onStartOAuth: () => void;
+	onExchangeCode: () => void;
+	cliStatus: ClaudeCliStatusResponse | undefined;
+	modelValue: string;
+	onModelChange: (value: string) => void;
+}) {
+	const cliDetected = cliStatus?.cli_installed && cliStatus?.authenticated;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<ProviderIcon provider="anthropic" size={20} />
+						Sign in with Anthropic OAuth
+					</DialogTitle>
+					{!message && (
+						<DialogDescription>
+							{cliDetected
+								? `Claude Code CLI detected${cliStatus?.email ? ` (${cliStatus.email})` : ""}. Click below to authorize this app — since you're already signed in, it should be quick.`
+								: "Sign in with your Anthropic account (Claude Pro, Max, or API console) to use OAuth instead of an API key."
+							}
+						</DialogDescription>
+					)}
+				</DialogHeader>
+
+				<div className="space-y-4">
+					{message && !hasState && (
+						<div
+							className={`rounded-md border px-3 py-2 text-sm ${message.type === "success"
+								? "border-green-500/20 bg-green-500/10 text-green-400"
+								: "border-red-500/20 bg-red-500/10 text-red-400"
+							}`}
+						>
+							{message.text}
+						</div>
+					)}
+
+					{!hasState && !message && (
+						<div className="space-y-3">
+							<p className="text-sm text-ink-dull">
+								Choose the model to use, then authorize access in a browser window.
+							</p>
+							<ModelSelect
+								label="Model"
+								description="Pick the model to apply to routing"
+								value={modelValue}
+								onChange={onModelChange}
+								provider="anthropic"
+							/>
+							<Button
+								onClick={onStartOAuth}
+								disabled={!modelValue.trim()}
+								loading={isRequesting}
+								variant="outline"
+								size="sm"
+							>
+								Open authorization page
+							</Button>
+						</div>
+					)}
+
+					{hasState && (
+						<div className="space-y-4">
+							<div className="rounded-md border border-app-line p-3">
+								<div className="flex items-center gap-2">
+									<span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/15 text-[11px] font-semibold text-accent">1</span>
+									<p className="text-sm text-ink-dull">Approve access in the browser window that opened</p>
+								</div>
+							</div>
+
+							<div className="rounded-md border border-app-line p-3">
+								<div className="flex items-center gap-2">
+									<span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/15 text-[11px] font-semibold text-accent">2</span>
+									<p className="text-sm text-ink-dull">Paste the authorization code below</p>
+								</div>
+								<div className="mt-2.5 flex items-center gap-2 pl-7">
+									<Input
+										type="text"
+										value={codeInput}
+										onChange={(e) => onCodeInputChange(e.target.value)}
+										placeholder="Paste code here..."
+										onKeyDown={(e) => {
+											if (e.key === "Enter") onExchangeCode();
+										}}
+										autoFocus
+									/>
+									<Button
+										onClick={onExchangeCode}
+										disabled={!codeInput.trim()}
+										loading={isExchanging}
+										size="sm"
+									>
+										Submit
+									</Button>
+								</div>
+							</div>
+
+							{message && (
+								<div
+									className={`rounded-md border px-3 py-2 text-sm ${message.type === "success"
+										? "border-green-500/20 bg-green-500/10 text-green-400"
+										: "border-red-500/20 bg-red-500/10 text-red-400"
+									}`}
+								>
+									{message.text}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
+
+				<DialogFooter>
+					{message?.type === "success" ? (
+						<Button onClick={() => onOpenChange(false)} size="sm">
+							Done
+						</Button>
+					) : hasState ? (
+						<Button onClick={onStartOAuth} variant="ghost" size="sm" loading={isRequesting}>
+							Restart
+						</Button>
+					) : null}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+// ── Provider Card ───────────────────────────────────────────────────────
 
 interface ProviderCardProps {
 	provider: string;

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -8,8 +8,19 @@ import { ModelSelect } from "@/components/ModelSelect";
 import { ProviderIcon } from "@/lib/providerIcons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
+import { IS_TAURI } from "@/api/client";
 
 import { parse as parseToml } from "smol-toml";
+
+/** Open a URL in the system browser. In Tauri, uses the shell plugin; otherwise falls back to window.open. */
+async function openExternal(url: string) {
+	if (IS_TAURI) {
+		const { open } = await import("@tauri-apps/plugin-shell");
+		await open(url);
+	} else {
+		window.open(url, "_blank", "noopener,noreferrer");
+	}
+}
 import { useTheme, THEMES, type ThemeId } from "@/hooks/useTheme";
 import { Markdown } from "@/components/Markdown";
 
@@ -566,11 +577,7 @@ export function Settings() {
 
 	const handleOpenDeviceLogin = () => {
 		if (!deviceCodeInfo || !deviceCodeCopied) return;
-		window.open(
-			deviceCodeInfo.verificationUrl,
-			"spacebot-openai-device",
-			"popup=true,width=780,height=960,noopener,noreferrer",
-		);
+		openExternal(deviceCodeInfo.verificationUrl);
 	};
 
 	const handleStartAnthropicOAuth = async () => {
@@ -593,11 +600,7 @@ export function Settings() {
 				return;
 			}
 			setAnthropicOAuthState(result.state);
-			window.open(
-				result.authorize_url,
-				"spacebot-anthropic-oauth",
-				"popup=true,width=780,height=960,noopener,noreferrer",
-			);
+			openExternal(result.authorize_url);
 		} catch (error: any) {
 			setAnthropicOAuthMessage({ text: `Failed: ${error.message}`, type: "error" });
 		}

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -24,6 +24,17 @@ const OPENAI_DEVICE_OAUTH_MAX_POLL_INTERVAL_SECS: u64 = 30;
 static OPENAI_DEVICE_OAUTH_SESSIONS: LazyLock<RwLock<HashMap<String, DeviceOAuthSession>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Active Anthropic OAuth PKCE sessions: state_key → (pkce_verifier, model, expires_at).
+static ANTHROPIC_OAUTH_SESSIONS: LazyLock<RwLock<HashMap<String, AnthropicOAuthSession>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Clone, Debug)]
+struct AnthropicOAuthSession {
+    verifier: String,
+    model: String,
+    expires_at: i64,
+}
+
 #[derive(Clone, Debug)]
 struct DeviceOAuthSession {
     expires_at: i64,
@@ -40,6 +51,7 @@ enum DeviceOAuthSessionStatus {
 #[derive(Serialize)]
 pub(super) struct ProviderStatus {
     anthropic: bool,
+    anthropic_oauth: bool,
     openai: bool,
     openai_chatgpt: bool,
     openrouter: bool,
@@ -96,6 +108,55 @@ pub(super) struct ProviderModelTestResponse {
     model: String,
     sample: Option<String>,
 }
+
+// ── Anthropic OAuth types ────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub(super) struct ClaudeCliStatusResponse {
+    /// Whether the `~/.claude/` folder exists (CLI has been used).
+    pub claude_folder_exists: bool,
+    /// Whether `~/.claude/credentials.json` exists (CLI has stored credentials).
+    pub credentials_file_exists: bool,
+    /// Whether the `claude` binary was found on the system.
+    pub cli_installed: bool,
+    /// CLI version string if the binary was found and `--version` succeeded.
+    pub cli_version: Option<String>,
+    /// Whether the CLI reports being authenticated.
+    pub authenticated: bool,
+    /// Email from `claude auth status`, if available.
+    pub email: Option<String>,
+    /// Whether Anthropic OAuth is already configured in this spacebot instance.
+    pub oauth_configured: bool,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AnthropicOAuthStartRequest {
+    model: String,
+    #[serde(default)]
+    mode: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) struct AnthropicOAuthStartResponse {
+    pub success: bool,
+    pub message: String,
+    pub authorize_url: Option<String>,
+    pub state: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct AnthropicOAuthExchangeRequest {
+    code: String,
+    state: String,
+}
+
+#[derive(Serialize)]
+pub(super) struct AnthropicOAuthExchangeResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+// ── OpenAI OAuth types ──────────────────────────────────────────────────
 
 #[derive(Deserialize)]
 pub(super) struct OpenAiOAuthBrowserStartRequest {
@@ -345,6 +406,7 @@ pub(super) async fn get_providers(
 ) -> Result<Json<ProvidersResponse>, StatusCode> {
     let config_path = state.config_path.read().await.clone();
     let instance_dir = (**state.instance_dir.load()).clone();
+    let anthropic_oauth_configured = crate::auth::credentials_path(&instance_dir).exists();
     let openai_oauth_configured = crate::openai_auth::credentials_path(&instance_dir).exists();
 
     let (
@@ -442,6 +504,7 @@ pub(super) async fn get_providers(
 
     let providers = ProviderStatus {
         anthropic,
+        anthropic_oauth: anthropic_oauth_configured,
         openai,
         openai_chatgpt,
         openrouter,
@@ -464,6 +527,7 @@ pub(super) async fn get_providers(
         zai_coding_plan,
     };
     let has_any = providers.anthropic
+        || providers.anthropic_oauth
         || providers.openai
         || providers.openai_chatgpt
         || providers.openrouter
@@ -895,6 +959,24 @@ pub(super) async fn delete_provider(
     axum::extract::Path(provider): axum::extract::Path<String>,
 ) -> Result<Json<ProviderUpdateResponse>, StatusCode> {
     let provider = provider.trim().to_lowercase();
+    // Anthropic OAuth credentials are stored as a separate JSON file.
+    if provider == "anthropic-oauth" {
+        let instance_dir = (**state.instance_dir.load()).clone();
+        let cred_path = crate::auth::credentials_path(&instance_dir);
+        if cred_path.exists() {
+            tokio::fs::remove_file(&cred_path)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        }
+        if let Some(mgr) = state.llm_manager.read().await.as_ref() {
+            mgr.clear_anthropic_oauth_credentials().await;
+        }
+        return Ok(Json(ProviderUpdateResponse {
+            success: true,
+            message: "Anthropic OAuth credentials removed".into(),
+        }));
+    }
+
     // OpenAI ChatGPT OAuth credentials are stored as a separate JSON file,
     // not in the TOML config, so handle removal separately.
     if provider == "openai-chatgpt" {
@@ -950,6 +1032,302 @@ pub(super) async fn delete_provider(
     Ok(Json(ProviderUpdateResponse {
         success: true,
         message: format!("Provider '{}' removed", provider),
+    }))
+}
+
+// ── Anthropic OAuth / CLI detection handlers ────────────────────────────
+
+/// Detect whether the Claude Code CLI is installed and authenticated on
+/// the local machine by inspecting `~/.claude/` and running the binary.
+pub(super) async fn claude_cli_status(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ClaudeCliStatusResponse>, StatusCode> {
+    let instance_dir = (**state.instance_dir.load()).clone();
+    let oauth_configured = crate::auth::credentials_path(&instance_dir).exists();
+
+    let home = dirs::home_dir().unwrap_or_default();
+    let claude_dir = home.join(".claude");
+    let claude_folder_exists = claude_dir.is_dir();
+    let credentials_file_exists = claude_dir.join("credentials.json").is_file();
+
+    // Try to find the `claude` binary.
+    let (cli_installed, cli_version, authenticated, email) =
+        tokio::task::spawn_blocking(move || detect_claude_cli())
+            .await
+            .unwrap_or((false, None, false, None));
+
+    Ok(Json(ClaudeCliStatusResponse {
+        claude_folder_exists,
+        credentials_file_exists,
+        cli_installed,
+        cli_version,
+        authenticated,
+        email,
+        oauth_configured,
+    }))
+}
+
+/// Blocking helper: find the `claude` binary, run `--version` and `auth status`.
+fn detect_claude_cli() -> (bool, Option<String>, bool, Option<String>) {
+    let claude_path = find_claude_binary();
+    let Some(claude_path) = claude_path else {
+        return (false, None, false, None);
+    };
+
+    // Strip env vars that make the CLI think it's inside a nested session.
+    let clean_env: Vec<(String, String)> = std::env::vars()
+        .filter(|(k, _)| k != "CLAUDECODE" && k != "CLAUDE_CODE_ENTRYPOINT")
+        .collect();
+
+    // Version check
+    let version = std::process::Command::new(&claude_path)
+        .arg("--version")
+        .env_clear()
+        .envs(clean_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        });
+
+    if version.is_none() {
+        return (false, None, false, None);
+    }
+
+    // Auth status check
+    let auth_result = std::process::Command::new(&claude_path)
+        .args(["auth", "status"])
+        .env_clear()
+        .envs(clean_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output();
+
+    let (authenticated, email) = match auth_result {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            match serde_json::from_str::<serde_json::Value>(stdout.trim()) {
+                Ok(json) => {
+                    let logged_in = json
+                        .get("loggedIn")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let email = json
+                        .get("email")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    (logged_in, email)
+                }
+                Err(_) => {
+                    // Older CLI versions may not return JSON — assume authed if
+                    // --version worked and the binary didn't error.
+                    (true, None)
+                }
+            }
+        }
+        Ok(_) => (false, None),
+        Err(_) => {
+            // Command failed to run but binary exists — assume authed (older CLI).
+            (true, None)
+        }
+    };
+
+    (true, version, authenticated, email)
+}
+
+/// Locate the `claude` binary on the system.
+fn find_claude_binary() -> Option<String> {
+    let which_cmd = if cfg!(windows) { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(which_cmd)
+        .arg("claude")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+
+    // Fallback paths
+    let home = dirs::home_dir()?;
+    let candidates: Vec<std::path::PathBuf> = if cfg!(windows) {
+        vec![
+            home.join(".local").join("bin").join("claude.exe"),
+            home.join("AppData")
+                .join("Local")
+                .join("Programs")
+                .join("claude")
+                .join("claude.exe"),
+        ]
+    } else {
+        vec![
+            home.join(".local").join("bin").join("claude"),
+            std::path::PathBuf::from("/usr/local/bin/claude"),
+        ]
+    };
+
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().to_string());
+        }
+    }
+
+    None
+}
+
+/// Start the Anthropic OAuth PKCE flow. Returns an authorization URL the
+/// frontend should open in a popup/tab so the user can authorize.
+pub(super) async fn start_anthropic_oauth(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<AnthropicOAuthStartRequest>,
+) -> Result<Json<AnthropicOAuthStartResponse>, StatusCode> {
+    let model = request.model.trim().to_string();
+    if model.is_empty() {
+        return Ok(Json(AnthropicOAuthStartResponse {
+            success: false,
+            message: "Model cannot be empty".to_string(),
+            authorize_url: None,
+            state: None,
+        }));
+    }
+
+    let mode = match request.mode.as_deref() {
+        Some("console") => crate::auth::AuthMode::Console,
+        _ => crate::auth::AuthMode::Max,
+    };
+
+    let (url, verifier) = crate::auth::authorize_url(mode);
+    let state_key = Uuid::new_v4().to_string();
+    let expires_at = chrono::Utc::now().timestamp() + 10 * 60; // 10 minute TTL
+
+    // Insert the new session and prune expired ones in a single lock acquisition.
+    let now = chrono::Utc::now().timestamp();
+    let mut sessions = ANTHROPIC_OAUTH_SESSIONS.write().await;
+    sessions.insert(
+        state_key.clone(),
+        AnthropicOAuthSession {
+            verifier,
+            model,
+            expires_at,
+        },
+    );
+    sessions.retain(|_, s| s.expires_at > now);
+    drop(sessions);
+
+    Ok(Json(AnthropicOAuthStartResponse {
+        success: true,
+        message: "Authorization URL generated".to_string(),
+        authorize_url: Some(url),
+        state: Some(state_key),
+    }))
+}
+
+/// Exchange the authorization code from the Anthropic OAuth callback for
+/// access and refresh tokens, save them, and update routing.
+pub(super) async fn exchange_anthropic_oauth(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<AnthropicOAuthExchangeRequest>,
+) -> Result<Json<AnthropicOAuthExchangeResponse>, StatusCode> {
+    let state_key = request.state.trim().to_string();
+    let code = request.code.trim().to_string();
+
+    if state_key.is_empty() || code.is_empty() {
+        return Ok(Json(AnthropicOAuthExchangeResponse {
+            success: false,
+            message: "State and code are required".to_string(),
+        }));
+    }
+
+    // Look up the session
+    let session = ANTHROPIC_OAUTH_SESSIONS.write().await.remove(&state_key);
+    let Some(session) = session else {
+        return Ok(Json(AnthropicOAuthExchangeResponse {
+            success: false,
+            message: "OAuth session not found or expired. Please try again.".to_string(),
+        }));
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    if now >= session.expires_at {
+        return Ok(Json(AnthropicOAuthExchangeResponse {
+            success: false,
+            message: "OAuth session expired. Please try again.".to_string(),
+        }));
+    }
+
+    // Exchange code for tokens
+    let credentials = match crate::auth::exchange_code(&code, &session.verifier).await {
+        Ok(creds) => creds,
+        Err(error) => {
+            return Ok(Json(AnthropicOAuthExchangeResponse {
+                success: false,
+                message: format!("Token exchange failed: {error}"),
+            }));
+        }
+    };
+
+    // Save credentials to disk
+    let instance_dir = (**state.instance_dir.load()).clone();
+    if let Err(error) = crate::auth::save_credentials(&instance_dir, &credentials) {
+        tracing::warn!(%error, "failed to save Anthropic OAuth credentials");
+        return Ok(Json(AnthropicOAuthExchangeResponse {
+            success: false,
+            message: format!("Failed to save credentials: {error}"),
+        }));
+    }
+
+    // Update the LLM manager
+    if let Some(llm_manager) = state.llm_manager.read().await.as_ref() {
+        llm_manager
+            .set_anthropic_oauth_credentials(credentials)
+            .await;
+    }
+
+    // Update model routing in config.toml
+    let config_path = state.config_path.read().await.clone();
+    let content = if config_path.exists() {
+        tokio::fs::read_to_string(&config_path)
+            .await
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    if let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>() {
+        apply_model_routing(&mut doc, &session.model);
+        if let Err(error) = tokio::fs::write(&config_path, doc.to_string()).await {
+            tracing::warn!(%error, "failed to write config.toml after Anthropic OAuth");
+        }
+    }
+
+    refresh_defaults_config(&state).await;
+
+    state
+        .provider_setup_tx
+        .try_send(crate::ProviderSetupEvent::ProvidersConfigured)
+        .ok();
+
+    Ok(Json(AnthropicOAuthExchangeResponse {
+        success: true,
+        message: format!(
+            "Anthropic OAuth configured. Model '{}' applied to routing.",
+            session.model
+        ),
     }))
 }
 

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -1193,7 +1193,7 @@ fn find_claude_binary() -> Option<String> {
 /// Start the Anthropic OAuth PKCE flow. Returns an authorization URL the
 /// frontend should open in a popup/tab so the user can authorize.
 pub(super) async fn start_anthropic_oauth(
-    State(state): State<Arc<ApiState>>,
+    State(_state): State<Arc<ApiState>>,
     Json(request): Json<AnthropicOAuthStartRequest>,
 ) -> Result<Json<AnthropicOAuthStartResponse>, StatusCode> {
     let model = request.model.trim().to_string();

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -228,6 +228,18 @@ pub async fn start_http_server(
             get(providers::get_providers).put(providers::update_provider),
         )
         .route(
+            "/providers/anthropic/oauth/cli-status",
+            get(providers::claude_cli_status),
+        )
+        .route(
+            "/providers/anthropic/oauth/start",
+            post(providers::start_anthropic_oauth),
+        )
+        .route(
+            "/providers/anthropic/oauth/exchange",
+            post(providers::exchange_anthropic_oauth),
+        )
+        .route(
             "/providers/openai/oauth/browser/start",
             post(providers::start_openai_browser_oauth),
         )

--- a/src/llm/manager.rs
+++ b/src/llm/manager.rs
@@ -192,6 +192,16 @@ impl LlmManager {
         }
     }
 
+    /// Set Anthropic OAuth credentials in memory after successful auth.
+    pub async fn set_anthropic_oauth_credentials(&self, creds: AnthropicOAuthCredentials) {
+        *self.anthropic_oauth_credentials.write().await = Some(creds);
+    }
+
+    /// Clear Anthropic OAuth credentials from memory.
+    pub async fn clear_anthropic_oauth_credentials(&self) {
+        *self.anthropic_oauth_credentials.write().await = None;
+    }
+
     /// Set OpenAI OAuth credentials in memory after successful auth.
     pub async fn set_openai_oauth_credentials(&self, creds: OpenAiOAuthCredentials) {
         *self.openai_oauth_credentials.write().await = Some(creds);


### PR DESCRIPTION
## Summary

Adds the ability for users to authenticate with their Anthropic Claude Pro/Max subscription via OAuth (PKCE flow) instead of requiring a separate API key. This brings Anthropic OAuth support on par with the existing ChatGPT Plus OAuth integration.

### Key capabilities:

- **Claude Code CLI detection** — automatically detects if the user has Claude Code CLI installed and authenticated on their local machine by inspecting `~/.claude/` and running `claude auth status`. When detected, the UI surfaces the user's email and indicates they can sign in quickly since they're already authenticated with Anthropic.
- **OAuth PKCE flow** — users can sign in with their Anthropic account (Claude Pro, Max, or API console) through a browser-based authorization flow. The backend generates a PKCE challenge, opens the Anthropic authorization page, and exchanges the returned code for access/refresh tokens.
- **Model selector** — during sign-in, users choose which Anthropic model to apply to all routing roles (channel, branch, worker, compactor, cortex) rather than being locked to a hardcoded default. This is important because OAuth tokens require fully versioned model IDs (e.g., `claude-sonnet-4-20250514`) rather than short aliases.
- **Provider switching** — under Settings > Providers, a new "Claude Code CLI (OAuth)" card appears directly below the Anthropic API key card, allowing users to switch between API key and OAuth authentication methods. OAuth credentials can be independently added or removed.

## Changes

### Backend (`src/`)

| File | Changes |
|------|---------:|
| `src/api/providers.rs` | Added `anthropic_oauth` to `ProviderStatus`. Added `ClaudeCliStatusResponse`, `AnthropicOAuthStartRequest/Response`, `AnthropicOAuthExchangeRequest/Response` types. Added `ANTHROPIC_OAUTH_SESSIONS` static for PKCE session tracking. Implemented `claude_cli_status()` handler (CLI binary discovery via PATH + fallback paths, version verification, auth status parsing). Implemented `start_anthropic_oauth()` handler (PKCE flow initiation with session management). Implemented `exchange_anthropic_oauth()` handler (code exchange, credential persistence, model routing update). Added `anthropic-oauth` case to `delete_provider()`. |
| `src/api/server.rs` | Added 3 new routes: `GET /providers/anthropic/oauth/cli-status`, `POST /providers/anthropic/oauth/start`, `POST /providers/anthropic/oauth/exchange`. |
| `src/llm/manager.rs` | Added `set_anthropic_oauth_credentials()` and `clear_anthropic_oauth_credentials()` methods to `LlmManager` for runtime credential management. |

### Frontend (`interface/src/`)

| File | Changes |
|------|---------:|
| `interface/src/api/client.ts` | Added `anthropic_oauth` to `ProviderStatus`. Added `ClaudeCliStatusResponse`, `AnthropicOAuthStartResponse`, `AnthropicOAuthExchangeResponse` types. Added `claudeCliStatus()`, `startAnthropicOAuth()`, `exchangeAnthropicOAuth()` API functions. |
| `interface/src/routes/Settings.tsx` | Added `AnthropicOAuthProviderCard` component with CLI detection status indicator. Added `AnthropicOAuthDialog` component with model selector (`ModelSelect`), PKCE flow step indicators, and authorization code input. Integrated both into the providers section alongside the existing Anthropic API key card. Added supporting state and mutation hooks. |

## How it works

1. User navigates to Settings > Providers
2. Below the Anthropic API key card, they see "Claude Code CLI (OAuth)" with:
   - If CLI is detected: green indicator showing their email and a note that sign-in will be quick
   - If CLI is not detected: note that they can still sign in via browser
3. User clicks "Sign in", selects a model from the dropdown
4. Clicks "Open authorization page" which opens an Anthropic consent page in a popup
5. After approving, user copies the authorization code and pastes it into the dialog
6. Backend exchanges the code for OAuth tokens, saves them to `anthropic_oauth.json`, updates the LLM manager, and applies the selected model to all routing roles
7. The OAuth token is automatically refreshed when it expires (5-minute buffer)

## Test plan

- [ ] Verify CLI detection endpoint returns correct status when Claude Code CLI is/isn't installed
- [ ] Verify OAuth sign-in flow completes successfully with a Claude Pro/Max account
- [ ] Verify the selected model is applied to all routing roles in config.toml
- [ ] Verify the bot responds correctly when using OAuth credentials
- [ ] Verify removing the OAuth provider clears credentials and updates provider status
- [ ] Verify OAuth and API key can coexist (OAuth takes precedence per existing `get_anthropic_provider()` logic)
- [ ] Verify token refresh works when the access token expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> [!NOTE]
> **Implementation Summary:** This PR adds Anthropic OAuth authentication with smart CLI detection. The backend implements PKCE-based OAuth flow (10-minute session TTL) with CLI binary detection via `which` command and fallback paths, parses `claude auth status` JSON output for email extraction, and persists OAuth credentials separately from API keys. The frontend provides two new components: a provider card with CLI status indication and a multi-step dialog for PKCE authorization with model selection. The implementation integrates seamlessly with existing provider management—OAuth is stored independently and takes precedence over API keys when both exist. Key additions: 3 API routes, 290 lines of backend logic for OAuth flow + CLI detection, 220 lines of frontend UI components with proper state management and polling.
> <sub>Written by [Tembo](https://app.tembo.io) for commit [eedc001](https://github.com/spacedriveapp/spacebot/commit/eedc001b914cef0548dfbd5c7ddf26f18e2d0902).</sub>