### PR TITLE
fix: skill install 500 error and chart dimension warnings

### DIFF
--- a/interface/src/routes/AgentDetail.tsx
+++ b/interface/src/routes/AgentDetail.tsx
@@ -365,8 +365,8 @@ function MemoryGrowthChart({ data }: { data: { date: string; count: number }[] }
 	});
 
 	return (
-		<div className="h-48">
-			<ResponsiveContainer width="100%" height="100%">
+		<div className="h-48 min-h-[192px]">
+			<ResponsiveContainer width="100%" height="100%" minWidth={100} minHeight={100}>
 				<AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
 					<defs>
 						<linearGradient id="memoryGradient" x1="0" y1="0" x2="0" y2="1">
@@ -426,8 +426,8 @@ function ProcessActivityChart({ data }: { data: { date: string; branches: number
 	}));
 
 	return (
-		<div className="h-48">
-			<ResponsiveContainer width="100%" height="100%">
+		<div className="h-48 min-h-[192px]">
+			<ResponsiveContainer width="100%" height="100%" minWidth={100} minHeight={100}>
 				<AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
 					<defs>
 						<linearGradient id="branchGradient" x1="0" y1="0" x2="0" y2="1">
@@ -552,8 +552,8 @@ function MemoryDonut({ counts }: { counts: Record<string, number> }) {
 
 	return (
 			<div>
-			<div className="relative h-40">
-				<ResponsiveContainer width="100%" height="100%">
+			<div className="relative h-40 min-h-[160px]">
+				<ResponsiveContainer width="100%" height="100%" minWidth={100} minHeight={100}>
 					<PieChart>
 						<Pie
 							data={data}

--- a/interface/src/routes/AgentSkills.tsx
+++ b/interface/src/routes/AgentSkills.tsx
@@ -30,16 +30,10 @@ function formatInstalls(n: number): string {
 /**
  * Derive the install spec from a registry skill.
  *
- * For multi-skill repos (e.g. anthropics/skills with skill "frontend-design"),
- * the spec is "owner/repo/skill-name". For single-skill repos where the repo
- * name matches the skillId (e.g. vercel-labs/agent-browser), use "owner/repo"
- * so the installer scans the whole repo for SKILL.md files.
+ * The spec is always "owner/repo/skill-name" (3-part format required by backend).
+ * Even for single-skill repos, the skillId is included.
  */
 function installSpec(skill: RegistrySkill): string {
-	const repoName = skill.source.split("/").pop();
-	if (repoName === skill.skillId) {
-		return skill.source;
-	}
 	return `${skill.source}/${skill.skillId}`;
 }
 


### PR DESCRIPTION
## Summary

Fixes two issues causing browser console errors:

### 1. Skill Install 500 Error
The frontend sent bare `owner/repo` format for single-skill repos (where repo name equals skill ID), but the backend explicitly rejects 2-part specs with:
```
bare owner/repo format is not supported — specify the skill name: owner/repo/SKILL_NAME
```

**Fix**: Always use 3-part spec format `owner/repo/skill-name` regardless of repo structure.

### 2. Chart Dimension Warnings
Recharts was logging warnings about negative dimensions:
```
The width(-1) and height(-1) of chart should be greater than 0
```

**Fix**: Added `minWidth={100} minHeight={100}` to all `ResponsiveContainer` components and `min-h-[192px]` / `min-h-[160px]` to parent containers.

## Test Plan

- [ ] Install a single-skill repo (e.g., `vercel-labs/agent-browser`) - should succeed with 200
- [ ] Install a multi-skill repo (e.g., `anthropics/skills/pdf`) - should continue to work
- [ ] Navigate to Agent Detail page - chart warnings should not appear in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)