### PR TITLE
fix: add provider prefix to zai-coding-plan default model

### DIFF
--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -145,7 +145,7 @@ const PROVIDERS = [
 		description: "GLM coding models (glm-4.7, glm-5, glm-4.5-air)",
 		placeholder: "...",
 		envVar: "ZAI_CODING_PLAN_API_KEY",
-		defaultModel: "glm-5",
+		defaultModel: "zai-coding-plan/glm-5",
 	},
 	{
 		id: "zhipu",


### PR DESCRIPTION
## Summary
- The Z.AI Coding Plan `defaultModel` in the frontend provider list was `"glm-5"` instead of `"zai-coding-plan/glm-5"`
- This caused `model_matches_provider` to fail because `provider_from_model("glm-5")` returns `"anthropic"` (the default when there's no `/` separator), not `"zai-coding-plan"`
- The provider test endpoint rejected the request before ever hitting the Z.AI API, causing a 500 when trying to save the key in the UI
- Every other provider already uses the correct prefixed format

## Test plan
- [x] Open Settings, add a Z.AI Coding Plan API key, and verify the model test passes
- [x] Verify the key saves successfully after passing the test