### PR TITLE
fix: prevent unwanted scrollbars in Windows/Tauri desktop app

### DIFF
--- a/interface/src/components/ConnectionScreen.tsx
+++ b/interface/src/components/ConnectionScreen.tsx
@@ -89,7 +89,7 @@ export function ConnectionScreen() {
 	const isChecking = state === "checking";
 
 	return (
-		<div className="flex h-screen w-screen flex-col items-center justify-center bg-app">
+		<div className="flex h-screen w-full flex-col items-center justify-center bg-app overflow-hidden">
 			{/* Draggable titlebar region for Tauri */}
 			{IS_TAURI && (
 				<div

--- a/interface/src/ui/style/style.scss
+++ b/interface/src/ui/style/style.scss
@@ -16,6 +16,11 @@
 
 }
 
+html, body {
+	overflow: hidden;
+	height: 100%;
+}
+
 html {
 	font-size: 106.25%;
 	background: hsla(var(--color-app), 1);


### PR DESCRIPTION
## Summary
- The Tauri `zoom: 1.1` factor causes `w-screen`/`h-screen` elements to overflow the actual viewport, producing unwanted horizontal and vertical scrollbars on Windows
- Added `overflow: hidden; height: 100%` to `html`/`body` in global styles to suppress the outer window scrollbar
- Replaced `w-screen` with `w-full` on the connection screen to prevent horizontal overflow

## Test plan
- [ ] Open the app in Tauri on Windows and verify no scrollbars appear on the connection screen
- [ ] Connect to a server and navigate to Settings > Providers — verify only the provider list content area scrolls, not the outer window
- [ ] Verify the fix doesn't affect browser-based usage (no Tauri zoom applied there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)