### PR TITLE
fix: prevent chat page layout shift hiding top navbar on Windows

### DIFF
--- a/interface/src/components/WebChatPanel.tsx
+++ b/interface/src/components/WebChatPanel.tsx
@@ -104,7 +104,7 @@ function FloatingChatInput({
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
 	useEffect(() => {
-		textareaRef.current?.focus();
+		textareaRef.current?.focus({preventScroll: true});
 	}, []);
 
 	useEffect(() => {
@@ -179,7 +179,7 @@ export function WebChatPanel({agentId}: WebChatPanelProps) {
 	const {sessionId, isSending, error, sendMessage} = useWebChat(agentId);
 	const {liveStates} = useLiveContext();
 	const [input, setInput] = useState("");
-	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const liveState = liveStates[sessionId];
 	const timeline = liveState?.timeline ?? [];
@@ -187,9 +187,15 @@ export function WebChatPanel({agentId}: WebChatPanelProps) {
 	const activeWorkers = Object.values(liveState?.workers ?? {});
 	const hasActiveWorkers = activeWorkers.length > 0;
 
-	// Auto-scroll on new messages or typing state changes
+	// Auto-scroll on new messages or typing state changes.
+	// Use direct scrollTo on the container instead of scrollIntoView,
+	// which can propagate scroll to ancestor overflow-hidden containers
+	// and shift the entire layout (hiding the top navbar).
 	useEffect(() => {
-		messagesEndRef.current?.scrollIntoView({behavior: "smooth"});
+		const el = scrollRef.current;
+		if (el) {
+			el.scrollTo({top: el.scrollHeight, behavior: "smooth"});
+		}
 	}, [timeline.length, isTyping, activeWorkers.length]);
 
 	const handleSubmit = () => {
@@ -202,7 +208,7 @@ export function WebChatPanel({agentId}: WebChatPanelProps) {
 	return (
 		<div className="relative flex h-full w-full flex-col">
 			{/* Messages */}
-			<div className="flex-1 overflow-x-hidden overflow-y-auto">
+			<div ref={scrollRef} className="flex-1 overflow-x-hidden overflow-y-auto">
 				<div className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-6 pb-32">
 					{hasActiveWorkers && (
 						<div className="sticky top-0 z-10 bg-app/90 pb-2 pt-2 backdrop-blur-sm">
@@ -247,7 +253,6 @@ export function WebChatPanel({agentId}: WebChatPanelProps) {
 							{error}
 						</div>
 					)}
-					<div ref={messagesEndRef} />
 				</div>
 			</div>
 

--- a/interface/src/main.tsx
+++ b/interface/src/main.tsx
@@ -7,9 +7,13 @@ import "@fontsource/ibm-plex-sans/500.css";
 import "@fontsource/ibm-plex-sans/600.css";
 import "@fontsource/ibm-plex-sans/700.css";
 
-// WKWebView renders at a slightly smaller effective scale than browsers
+// WKWebView (macOS) renders at a slightly smaller effective scale than browsers.
+// Only apply zoom compensation there — WebView2 (Windows) doesn't need it.
 if ((window as any).__TAURI_INTERNALS__) {
-	document.body.style.zoom = "1.1";
+	const isMac = /mac/i.test((navigator as any).userAgentData?.platform ?? navigator.platform ?? "");
+	if (isMac) {
+		document.body.style.zoom = "1.1";
+	}
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/interface/src/router.tsx
+++ b/interface/src/router.tsx
@@ -35,7 +35,7 @@ function RootLayout() {
 
 	return (
 		<TopBarProvider>
-			<div className="flex h-screen flex-col bg-app">
+			<div className="flex h-screen flex-col overflow-hidden bg-app">
 				<TopBar />
 				<ConnectionBanner state={connectionState} hasData={hasData} />
 				<div className="flex min-h-0 flex-1">


### PR DESCRIPTION
## Summary

- **Scope zoom to macOS only**: The `zoom: 1.1` on `<body>` was meant to compensate for WKWebView's smaller rendering scale, but was applied on all Tauri platforms. On Windows (WebView2/Chromium), this made content 10% taller than the viewport, causing overflow that hid the top navbar or clipped the chat input. Now only applied when running on macOS.
- **Replace `scrollIntoView` with targeted `scrollTo`**: `scrollIntoView()` propagates scroll to *all* scrollable ancestors — including elements with `overflow: hidden` — which shifted the entire root layout upward, hiding the top navbar. Using `scrollTo()` directly on the messages container keeps scrolling contained.
- **Prevent scroll on textarea focus**: `textarea.focus()` in the floating chat input triggered the browser's scroll-to-focus behavior on ancestor containers. Added `preventScroll: true`.
- **Add `overflow-hidden` to root layout**: Safety net to prevent any future scroll propagation from shifting the layout.

## Test plan
- [ ] Open the desktop app on Windows — verify the top navbar (agent name) stays visible on the Chat tab
- [ ] Verify the chat input bar is visible at the bottom of the Chat page
- [ ] Send messages and confirm auto-scroll works correctly within the messages container
- [ ] Verify no layout shift occurs when navigating between agent tabs (Overview → Chat → Channels, etc.)
- [ ] Open the desktop app on macOS — verify the `zoom: 1.1` still applies and the UI looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)