### PR TITLE
feat: add directory browse button to Create Project dialog

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "dialog:default",
     "shell:allow-open",
     "shell:allow-spawn",
     "shell:allow-stdin-write",

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![get_server_url, set_server_url])
         .setup(|app| {
             // Apply macOS titlebar style (invisible toolbar for traffic light padding)

--- a/interface/package.json
+++ b/interface/package.json
@@ -77,6 +77,7 @@
 	},
 	"optionalDependencies": {
 		"@tauri-apps/api": "^2",
+		"@tauri-apps/plugin-dialog": "^2",
 		"@tauri-apps/plugin-shell": "^2"
 	}
 }

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -1584,6 +1584,18 @@ export interface DiskUsageResponse {
 	entries: DiskUsageEntry[];
 }
 
+export interface DirEntry {
+	name: string;
+	path: string;
+	is_dir: boolean;
+}
+
+export interface ListDirResponse {
+	path: string;
+	parent: string | null;
+	entries: DirEntry[];
+}
+
 export interface CreateProjectRequest {
 	name: string;
 	description?: string;
@@ -2618,4 +2630,12 @@ export const api = {
 	},
 
 	getEventsUrl: () => `${getApiBase()}/events`,
+
+	listDir: async (path?: string): Promise<ListDirResponse> => {
+		const params = new URLSearchParams();
+		if (path) params.set("path", path);
+		const response = await fetch(`${getApiBase()}/fs/list-dir?${params.toString()}`);
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<ListDirResponse>;
+	},
 };

--- a/interface/src/routes/AgentProjects.tsx
+++ b/interface/src/routes/AgentProjects.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
 	api,
@@ -7,6 +7,7 @@ import {
 	type ProjectRepo,
 	type CreateProjectRequest,
 	type CreateWorktreeRequest,
+	type DirEntry,
 } from "@/api/client";
 import { Badge, Button } from "@/ui";
 import {
@@ -21,6 +22,7 @@ import { Input, Label, TextArea } from "@/ui/Input";
 import { formatTimeAgo } from "@/lib/format";
 import { clsx } from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
+import { useServer } from "@/hooks/useServer";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,6 +113,123 @@ function ProjectCard({
 // Create Project Dialog
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Directory Browser (web mode fallback)
+// ---------------------------------------------------------------------------
+
+function DirectoryBrowser({
+	onSelect,
+	onClose,
+}: {
+	onSelect: (path: string) => void;
+	onClose: () => void;
+}) {
+	const [currentPath, setCurrentPath] = useState<string>("");
+	const [entries, setEntries] = useState<DirEntry[]>([]);
+	const [parentPath, setParentPath] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const loadDir = useCallback(async (path?: string) => {
+		setLoading(true);
+		setError(null);
+		try {
+			const result = await api.listDir(path);
+			setCurrentPath(result.path);
+			setParentPath(result.parent);
+			setEntries(result.entries.filter((e) => e.is_dir));
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Failed to load directory");
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadDir();
+	}, [loadDir]);
+
+	return (
+		<div className="rounded-lg border border-app-line bg-app-darkBox">
+			<div className="flex items-center gap-2 border-b border-app-line px-3 py-2">
+				<button
+					type="button"
+					onClick={() => parentPath && loadDir(parentPath)}
+					disabled={!parentPath}
+					className="rounded px-1.5 py-0.5 text-xs text-ink-dull hover:bg-app-hover/40 disabled:opacity-30"
+				>
+					..
+				</button>
+				<span className="min-w-0 flex-1 truncate font-mono text-xs text-ink-dull">
+					{currentPath}
+				</span>
+				<Button
+					type="button"
+					size="sm"
+					onClick={() => onSelect(currentPath)}
+				>
+					Select
+				</Button>
+				<button
+					type="button"
+					onClick={onClose}
+					className="rounded px-1.5 py-0.5 text-xs text-ink-faint hover:text-ink"
+				>
+					&times;
+				</button>
+			</div>
+			<div className="max-h-48 overflow-y-auto">
+				{loading && (
+					<div className="px-3 py-4 text-center text-xs text-ink-faint">
+						Loading...
+					</div>
+				)}
+				{error && (
+					<div className="px-3 py-4 text-center text-xs text-red-400">
+						{error}
+					</div>
+				)}
+				{!loading && !error && entries.length === 0 && (
+					<div className="px-3 py-4 text-center text-xs text-ink-faint">
+						No subdirectories
+					</div>
+				)}
+				{!loading &&
+					!error &&
+					entries.map((entry) => (
+						<button
+							key={entry.path}
+							type="button"
+							onClick={() => loadDir(entry.path)}
+							className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-ink hover:bg-app-hover/40"
+						>
+							<span className="text-xs text-accent">&#128193;</span>
+							<span className="truncate">{entry.name}</span>
+						</button>
+					))}
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Browse Button (Tauri native dialog or web directory browser)
+// ---------------------------------------------------------------------------
+
+async function openNativeFolderDialog(): Promise<string | null> {
+	try {
+		const { open } = await import("@tauri-apps/plugin-dialog");
+		const selected = await open({
+			directory: true,
+			multiple: false,
+			title: "Select Project Directory",
+		});
+		return typeof selected === "string" ? selected : null;
+	} catch {
+		return null;
+	}
+}
+
 function CreateProjectDialog({
 	open,
 	onOpenChange,
@@ -121,11 +240,13 @@ function CreateProjectDialog({
 	agentId: string;
 }) {
 	const queryClient = useQueryClient();
+	const { isTauri } = useServer();
 	const [name, setName] = useState("");
 	const [rootPath, setRootPath] = useState("");
 	const [description, setDescription] = useState("");
 	const [icon, setIcon] = useState("");
 	const [tagsRaw, setTagsRaw] = useState("");
+	const [showBrowser, setShowBrowser] = useState(false);
 
 	const createMutation = useMutation({
 		mutationFn: (request: CreateProjectRequest) =>
@@ -138,8 +259,18 @@ function CreateProjectDialog({
 			setDescription("");
 			setIcon("");
 			setTagsRaw("");
+			setShowBrowser(false);
 		},
 	});
+
+	const handleBrowse = async () => {
+		if (isTauri) {
+			const selected = await openNativeFolderDialog();
+			if (selected) setRootPath(selected);
+		} else {
+			setShowBrowser((prev) => !prev);
+		}
+	};
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
@@ -180,12 +311,34 @@ function CreateProjectDialog({
 					</div>
 					<div>
 						<Label>Root Path</Label>
-						<Input
-							value={rootPath}
-							onChange={(e) => setRootPath(e.target.value)}
-							placeholder="/home/user/projects/my-project"
-							className="font-mono"
-						/>
+						<div className="flex gap-2">
+							<Input
+								value={rootPath}
+								onChange={(e) => setRootPath(e.target.value)}
+								placeholder="/home/user/projects/my-project"
+								className="flex-1 font-mono"
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								size="default"
+								onClick={handleBrowse}
+								title="Browse for directory"
+							>
+								Browse
+							</Button>
+						</div>
+						{showBrowser && !isTauri && (
+							<div className="mt-2">
+								<DirectoryBrowser
+									onSelect={(path) => {
+										setRootPath(path);
+										setShowBrowser(false);
+									}}
+									onClose={() => setShowBrowser(false)}
+								/>
+							</div>
+						)}
 					</div>
 					<div>
 						<Label>Description (optional)</Label>

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,6 +11,7 @@ mod config;
 mod cortex;
 mod cron;
 mod factory;
+mod fs;
 mod ingest;
 mod links;
 mod mcp;

--- a/src/api/fs.rs
+++ b/src/api/fs.rs
@@ -1,0 +1,92 @@
+//! Filesystem browsing endpoints for directory selection.
+
+use axum::Json;
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Deserialize)]
+pub(super) struct ListDirQuery {
+    /// The directory path to list. If omitted, lists user home directory.
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) struct DirEntry {
+    name: String,
+    path: String,
+    is_dir: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct ListDirResponse {
+    /// The absolute path of the listed directory.
+    path: String,
+    /// Parent directory path, if any.
+    parent: Option<String>,
+    /// Entries in the directory (directories first, then files).
+    entries: Vec<DirEntry>,
+}
+
+/// List the contents of a directory. Defaults to the user's home directory.
+pub(super) async fn list_dir(
+    Query(query): Query<ListDirQuery>,
+) -> Result<Json<ListDirResponse>, impl IntoResponse> {
+    let dir = match &query.path {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")),
+    };
+
+    let dir = match dir.canonicalize() {
+        Ok(d) => d,
+        Err(e) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("Invalid path: {e}") })),
+            ));
+        }
+    };
+
+    if !dir.is_dir() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Path is not a directory" })),
+        ));
+    }
+
+    let mut entries = Vec::new();
+
+    let mut read_dir = match tokio::fs::read_dir(&dir).await {
+        Ok(rd) => rd,
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Cannot read directory: {e}") })),
+            ));
+        }
+    };
+
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Skip hidden files/directories (starting with .)
+        if name.starts_with('.') {
+            continue;
+        }
+        let is_dir = entry.file_type().await.map(|ft| ft.is_dir()).unwrap_or(false);
+        let path = entry.path().to_string_lossy().to_string();
+        entries.push(DirEntry { name, path, is_dir });
+    }
+
+    // Sort: directories first, then alphabetically
+    entries.sort_by(|a, b| b.is_dir.cmp(&a.is_dir).then(a.name.to_lowercase().cmp(&b.name.to_lowercase())));
+
+    let parent = dir.parent().map(|p| p.to_string_lossy().to_string());
+
+    Ok(Json(ListDirResponse {
+        path: dir.to_string_lossy().to_string(),
+        parent,
+        entries,
+    }))
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -2,7 +2,7 @@
 
 use super::state::ApiState;
 use super::{
-    agents, bindings, channels, config, cortex, cron, factory, ingest, links, mcp, memories,
+    agents, bindings, channels, config, cortex, cron, factory, fs, ingest, links, mcp, memories,
     messaging, models, opencode_proxy, projects, providers, secrets, settings, skills, ssh, system,
     tasks, tools, webchat, workers,
 };
@@ -57,6 +57,7 @@ pub async fn start_http_server(
         .route("/idle", get(system::idle))
         .route("/status", get(system::status))
         .route("/system/storage", get(system::storage_status))
+        .route("/fs/list-dir", get(fs::list_dir))
         .route("/system/backup/export", get(system::backup_export))
         .route("/system/backup/restore", post(system::backup_restore))
         .route("/overview", get(agents::instance_overview))


### PR DESCRIPTION
## Summary
- Adds a **Browse** button next to the Root Path input in the Create Project dialog so users can select a directory without manually copying/pasting the path
- **Tauri desktop (Windows/macOS/Linux):** opens the native OS folder picker via `tauri-plugin-dialog`
- **Web/Docker:** shows an inline directory browser backed by a new `GET /api/fs/list-dir` backend endpoint

## Changes
- `desktop/src-tauri/Cargo.toml` — added `tauri-plugin-dialog` dependency
- `desktop/src-tauri/src/main.rs` — registered dialog plugin
- `desktop/src-tauri/capabilities/default.json` — added `dialog:default` permission
- `interface/package.json` — added `@tauri-apps/plugin-dialog` optional dependency
- `interface/src/api/client.ts` — added `DirEntry`, `ListDirResponse` types and `api.listDir()` 
- `interface/src/routes/AgentProjects.tsx` — added Browse button, `DirectoryBrowser` component, and native dialog integration
- `src/api/fs.rs` — new filesystem listing endpoint (directories first, skips hidden files, defaults to home dir)
- `src/api.rs` + `src/api/server.rs` — wired the new `fs` module and `/fs/list-dir` route

## Test plan
- [ ] Tauri desktop: click Browse → native OS folder dialog opens → selecting a folder populates the Root Path field
- [ ] Web mode: click Browse → inline directory browser appears → navigate folders → click Select to populate Root Path
- [ ] Verify the text input still works for manual path entry
- [ ] Test on Windows, macOS, and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)