### PR TITLE
fix: skip listen-only mode filtering for DMs in Slack

### DIFF
--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -1092,7 +1092,7 @@ impl Channel {
     fn is_dm(&self) -> bool {
         self.conversation_id
             .as_deref()
-            .map_or(false, is_dm_conversation_id)
+            .is_some_and(is_dm_conversation_id)
     }
 
     /// Update the coalesce deadline based on buffer size and config.
@@ -1367,7 +1367,7 @@ impl Channel {
             }
         }
 
-        if self.listen_only_mode && !batch_has_invoke {
+        if self.listen_only_mode && !batch_has_invoke && !self.is_dm() {
             tracing::debug!(
                 channel_id = %self.id,
                 message_count,


### PR DESCRIPTION
DMs are inherently directed at the bot, so requiring an @mention or reply in listen-only mode is unnecessary friction. Bypass the listen-only filter when the channel is a DM, consistent with how require_mention already behaves for DMs.

Also fix is_dm_conversation_id() to detect Slack DMs, which use slack:TEAM:DCHANNEL format (D-prefixed channel ID) rather than the :dm: segment used by Discord and Mattermost.