### PR TITLE
Fix quickstart section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,14 +422,18 @@ Read the full vision in the [roadmap](docs/content/docs/(deployment)/roadmap.mdx
 ### Build and Run
 
 ```bash
-git clone https://github.com/spacedriveapp/spacebot
+git clone https://github.com/spacedriveapp/spacebot.git
 cd spacebot
 
-# Optional: build the OpenCode embedded UI (requires Node 22+ and bun)
-# Without this, OpenCode workers still work — the Workers tab shows a transcript view instead.
-# ./scripts/build-opencode-embed.sh
+# Build the web UI (React + Vite, embedded into the binary)
+cd interface && bun install && npm i && bun build && cd ..
 
-cargo build --release
+# Optional: build the OpenCode embed (live coding UI in the Workers tab)
+# Requires Node 22+ (use fnm: fnm install v24.14.0 && fnm use v24.14.0)
+./scripts/build-opencode-embed.sh
+
+# Install the binary
+cargo install --path .
 ```
 
 ### Minimal Config


### PR DESCRIPTION
Updated README with corrected build instructions in the quickstart section.

`cargo install --path .` was throwing
```
   Compiling spacebot v0.3.3 (/home/user/spacebot)
error: #[derive(RustEmbed)] folder '/home/user/spacebot/interface/dist/' does not exist. cwd: '/home/user/spacebot'
  --> src/api/server.rs:26:1
   |
26 | / /// Embedded frontend assets from the Vite build output.
27 | | #[derive(Embed)]
28 | | #[folder = "interface/dist/"]
29 | | #[allow(unused)]
30 | | struct InterfaceAssets;
   | |_______________________^
```
without `cd interface && bun install && bun run build`

and `bun run build` was throwing
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
```

without `npm i`