### PR TITLE
fix: correct ingest file upload endpoint URL

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -1691,7 +1691,7 @@ export const api = {
 			formData.append("files", file);
 		}
 		const response = await fetch(
-			`${getApiBase()}/agents/ingest/upload?agent_id=${encodeURIComponent(agentId)}`,
+			`${getApiBase()}/agents/ingest/files?agent_id=${encodeURIComponent(agentId)}`,
 			{ method: "POST", body: formData },
 		);
 		if (!response.ok) {


### PR DESCRIPTION
## Summary
- The frontend `uploadIngestFiles` function was POSTing to `/agents/ingest/upload`, but the backend handler (`upload_ingest_file`) is registered at `/agents/ingest/files` — causing a silent 404 and "Upload failed" in the UI.
- Fixed the frontend URL to match the backend route.

## Verification
- Backend route: `#[utoipa::path(post, path = "/agents/ingest/files", ...)]` in `src/api/ingest.rs:113`
- Route registration: `routes!(ingest::upload_ingest_file)` in `src/api/server.rs:155`
- Generated OpenAPI schema (`schema.d.ts`) has no `/agents/ingest/upload` path — confirms only `/agents/ingest/files` exists