### PR TITLE
Fix API route mismatches from OpenAPI migration

### DIFF
--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -1632,7 +1632,7 @@ export const api = {
 		}>;
 	},
 	startOpenAiOAuthBrowser: async (params: {model: string}) => {
-		const response = await fetch(`${getApiBase()}/providers/openai/oauth/browser/start`, {
+		const response = await fetch(`${getApiBase()}/providers/openai/browser-oauth/start`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -1646,7 +1646,7 @@ export const api = {
 	},
 	openAiOAuthBrowserStatus: async (state: string) => {
 		const response = await fetch(
-			`${getApiBase()}/providers/openai/oauth/browser/status?state=${encodeURIComponent(state)}`,
+			`${getApiBase()}/providers/openai/browser-oauth/status?state=${encodeURIComponent(state)}`,
 		);
 		if (!response.ok) {
 			throw new Error(`API error: ${response.status}`);
@@ -1825,9 +1825,9 @@ export const api = {
 	},
 
 	// Raw config API
-	rawConfig: () => fetchJson<Types.RawConfigResponse>("/config/raw"),
+	rawConfig: () => fetchJson<Types.RawConfigResponse>("/settings/raw"),
 	updateRawConfig: async (content: string) => {
-		const response = await fetch(`${getApiBase()}/config/raw`, {
+		const response = await fetch(`${getApiBase()}/settings/raw`, {
 			method: "PUT",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ content }),


### PR DESCRIPTION
## Summary
- Fix ChatGPT OAuth device flow routes: client was calling `/providers/openai/oauth/browser/*` but backend serves `/providers/openai/browser-oauth/*`
- Fix raw config editor routes: client was calling `/config/raw` but backend serves `/settings/raw`

## Test plan
- [ ] Open ChatGPT Plus OAuth modal in Settings — should start device code flow without error
- [ ] Open raw config editor in Settings — should load and display config.toml

> [!NOTE]
> This PR fixes two client-side API route mismatches that occurred after an OpenAPI migration. The changes align the frontend API calls with the actual backend endpoints, restoring functionality for ChatGPT OAuth initialization and the raw configuration file editor.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [1b1e14f](https://github.com/spacedriveapp/spacebot/commit/1b1e14f2521d7c8438226e3b9bdce7e3b260191b). This will update automatically on new commits.</sub>