### PR TITLE
fix: MentionOnly mode retains channel context and memory capture

### DIFF
--- a/interface/src/components/ChannelEditModal.tsx
+++ b/interface/src/components/ChannelEditModal.tsx
@@ -570,15 +570,15 @@ export function ChannelEditModal({platform, name, status, open, onOpenChange}: C
 
 								{platform === "discord" && (
 									<div>
-										<div className="flex items-center gap-2">
+										<label className="flex items-center gap-2 text-sm text-ink-dull">
 											<input
 												type="checkbox"
 												checked={bindingForm.require_mention}
 												onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
 												className="h-4 w-4 rounded border-app-line bg-app-box"
 											/>
-											<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
-										</div>
+											Require @mention or reply to bot
+										</label>
 										<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
 									</div>
 								)}

--- a/interface/src/components/ChannelEditModal.tsx
+++ b/interface/src/components/ChannelEditModal.tsx
@@ -569,14 +569,17 @@ export function ChannelEditModal({platform, name, status, open, onOpenChange}: C
 								)}
 
 								{platform === "discord" && (
-									<div className="flex items-center gap-2">
-										<input
-											type="checkbox"
-											checked={bindingForm.require_mention}
-											onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
-											className="h-4 w-4 rounded border-app-line bg-app-box"
-										/>
-										<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
+									<div>
+										<div className="flex items-center gap-2">
+											<input
+												type="checkbox"
+												checked={bindingForm.require_mention}
+												onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
+												className="h-4 w-4 rounded border-app-line bg-app-box"
+											/>
+											<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
+										</div>
+										<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
 									</div>
 								)}
 

--- a/interface/src/components/ChannelEditModal.tsx
+++ b/interface/src/components/ChannelEditModal.tsx
@@ -579,7 +579,7 @@ export function ChannelEditModal({platform, name, status, open, onOpenChange}: C
 											/>
 											Require @mention or reply to bot
 										</label>
-										<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
+										<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to commands, mentions, or replies, use Mention Only mode in Channels settings (cog icon).</p>
 									</div>
 								)}
 

--- a/interface/src/components/ChannelSettingCard.tsx
+++ b/interface/src/components/ChannelSettingCard.tsx
@@ -1172,15 +1172,15 @@ function BindingForm({
 
 			{platform === "discord" && (
 				<div>
-					<div className="flex items-center gap-2">
+					<label className="flex items-center gap-2 text-sm text-ink-dull">
 						<input
 							type="checkbox"
 							checked={bindingForm.require_mention}
 							onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
 							className="h-4 w-4 rounded border-app-line bg-app-box"
 						/>
-						<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
-					</div>
+						Require @mention or reply to bot
+					</label>
 					<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
 				</div>
 			)}

--- a/interface/src/components/ChannelSettingCard.tsx
+++ b/interface/src/components/ChannelSettingCard.tsx
@@ -1181,7 +1181,7 @@ function BindingForm({
 						/>
 						Require @mention or reply to bot
 					</label>
-					<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
+					<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to commands, mentions, or replies, use Mention Only mode in Channels settings (cog icon).</p>
 				</div>
 			)}
 

--- a/interface/src/components/ChannelSettingCard.tsx
+++ b/interface/src/components/ChannelSettingCard.tsx
@@ -1171,14 +1171,17 @@ function BindingForm({
 			)}
 
 			{platform === "discord" && (
-				<div className="flex items-center gap-2">
-					<input
-						type="checkbox"
-						checked={bindingForm.require_mention}
-						onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
-						className="h-4 w-4 rounded border-app-line bg-app-box"
-					/>
-					<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
+				<div>
+					<div className="flex items-center gap-2">
+						<input
+							type="checkbox"
+							checked={bindingForm.require_mention}
+							onChange={(e) => setBindingForm({...bindingForm, require_mention: e.target.checked})}
+							className="h-4 w-4 rounded border-app-line bg-app-box"
+						/>
+						<label className="text-sm text-ink-dull">Require @mention or reply to bot</label>
+					</div>
+					<p className="mt-1.5 text-xs text-ink-faint">Blocks messages entirely — the agent won't see them at all. To let the agent read all messages but only respond to mentions, use Mention Only mode in Channels settings (cog icon).</p>
 				</div>
 			)}
 

--- a/interface/src/components/ConversationSettingsPanel.tsx
+++ b/interface/src/components/ConversationSettingsPanel.tsx
@@ -104,7 +104,7 @@ const RESPONSE_MODE_DESCRIPTIONS: Record<string, string> = {
 	quiet:
 		"Observes and learns from the conversation, but only responds when @mentioned, replied to, or given a command.",
 	mention_only:
-		"Messages are still visible to the agent for context, but it only responds when explicitly @mentioned or replied to. To block messages entirely, use the binding-level require mention setting instead.",
+		"Messages are still visible to the agent for context, but it only responds when explicitly @mentioned, replied to, or given a command. To block messages entirely, use the binding-level require mention setting instead.",
 };
 
 const WORKER_HISTORY_OPTIONS = [

--- a/interface/src/components/ConversationSettingsPanel.tsx
+++ b/interface/src/components/ConversationSettingsPanel.tsx
@@ -104,7 +104,7 @@ const RESPONSE_MODE_DESCRIPTIONS: Record<string, string> = {
 	quiet:
 		"Observes and learns from the conversation, but only responds when @mentioned, replied to, or given a command.",
 	mention_only:
-		"Only responds when explicitly @mentioned or replied to. No passive memory capture.",
+		"Messages are still visible to the agent for context, but it only responds when explicitly @mentioned or replied to. To block messages entirely, use the binding-level require mention setting instead.",
 };
 
 const WORKER_HISTORY_OPTIONS = [

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -1434,11 +1434,18 @@ impl Channel {
                 self.resolved_settings.response_mode,
                 ResponseMode::MentionOnly
             ) {
-                let mut history = self.state.history.write().await;
-                for (formatted_text, _, _) in &pending_batch_entries {
-                    history.push(rig::message::Message::User {
-                        content: OneOrMany::one(UserContent::text(formatted_text)),
-                    });
+                {
+                    let mut history = self.state.history.write().await;
+                    for (formatted_text, _, _) in &pending_batch_entries {
+                        history.push(rig::message::Message::User {
+                            content: OneOrMany::one(UserContent::text(formatted_text)),
+                        });
+                    }
+                }
+                // Compaction guard: suppressed messages accumulate in history
+                // without agent turns, so check compaction to prevent unbounded growth.
+                if let Err(error) = self.compactor.check_and_compact().await {
+                    tracing::warn!(channel_id = %self.id, %error, "compaction check failed");
                 }
             }
             // Both Quiet and MentionOnly keep passive memory capture.
@@ -1862,10 +1869,17 @@ impl Channel {
                     self.resolved_settings.response_mode,
                     ResponseMode::MentionOnly
                 ) {
-                    let mut history = self.state.history.write().await;
-                    history.push(rig::message::Message::User {
-                        content: OneOrMany::one(UserContent::text(&user_text)),
-                    });
+                    {
+                        let mut history = self.state.history.write().await;
+                        history.push(rig::message::Message::User {
+                            content: OneOrMany::one(UserContent::text(&user_text)),
+                        });
+                    }
+                    // Compaction guard: suppressed messages accumulate in history
+                    // without agent turns, so check compaction to prevent unbounded growth.
+                    if let Err(error) = self.compactor.check_and_compact().await {
+                        tracing::warn!(channel_id = %self.id, %error, "compaction check failed");
+                    }
                 }
                 // Both Quiet and MentionOnly keep passive memory capture.
                 self.message_count += 1;

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -1428,12 +1428,22 @@ impl Channel {
                 response_mode = ?self.resolved_settings.response_mode,
                 "suppressing unsolicited coalesced batch"
             );
-            // In Quiet mode, keep passive memory capture.
-            // In MentionOnly mode, skip memory persistence.
-            if matches!(self.resolved_settings.response_mode, ResponseMode::Quiet) {
-                self.message_count += message_count;
-                self.check_memory_persistence().await;
+            // In MentionOnly mode, inject batch messages into in-memory history
+            // so the LLM retains channel context when eventually triggered.
+            if matches!(
+                self.resolved_settings.response_mode,
+                ResponseMode::MentionOnly
+            ) {
+                let mut history = self.state.history.write().await;
+                for (formatted_text, _, _) in &pending_batch_entries {
+                    history.push(rig::message::Message::User {
+                        content: OneOrMany::one(UserContent::text(formatted_text)),
+                    });
+                }
             }
+            // Both Quiet and MentionOnly keep passive memory capture.
+            self.message_count += message_count;
+            self.check_memory_persistence().await;
             return Ok(());
         }
 
@@ -1846,12 +1856,20 @@ impl Channel {
                     response_mode = ?self.resolved_settings.response_mode,
                     "suppressing unsolicited reply"
                 );
-                // In Quiet mode, keep passive memory capture.
-                // In MentionOnly mode, skip memory persistence entirely.
-                if matches!(self.resolved_settings.response_mode, ResponseMode::Quiet) {
-                    self.message_count += 1;
-                    self.check_memory_persistence().await;
+                // In MentionOnly mode, inject the message into in-memory history
+                // so the LLM retains channel context when eventually triggered.
+                if matches!(
+                    self.resolved_settings.response_mode,
+                    ResponseMode::MentionOnly
+                ) {
+                    let mut history = self.state.history.write().await;
+                    history.push(rig::message::Message::User {
+                        content: OneOrMany::one(UserContent::text(&user_text)),
+                    });
                 }
+                // Both Quiet and MentionOnly keep passive memory capture.
+                self.message_count += 1;
+                self.check_memory_persistence().await;
                 return Ok(());
             }
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1638,6 +1638,11 @@ pub struct Binding {
     /// Channel IDs this binding applies to. If empty, all channels in the guild/workspace are allowed.
     pub channel_ids: Vec<String>,
     /// Require explicit @mention (or reply-to-bot) for inbound messages.
+    /// Messages that don't match are blocked at the routing level and never
+    /// reach the channel — the agent cannot see them at all.
+    /// For context-aware mention filtering (agent sees messages but only
+    /// responds to mentions), use the channel-level `MentionOnly` response
+    /// mode instead.
     pub require_mention: bool,
     /// User IDs allowed to DM the bot through this binding.
     pub dm_allowed_users: Vec<String>,

--- a/src/conversation/settings.rs
+++ b/src/conversation/settings.rs
@@ -119,7 +119,7 @@ pub enum ResponseMode {
     /// Observe and learn (history + memory persistence) but only respond
     /// to @mentions, replies-to-bot, and slash commands.
     Quiet,
-    /// Only respond when explicitly @mentioned or replied to.
+    /// Only respond when explicitly @mentioned, replied to, or given a command.
     /// Messages that don't pass the mention check are still ingested into
     /// the in-memory context window (so the agent stays context-aware),
     /// recorded in conversation history, and contribute to passive memory

--- a/src/conversation/settings.rs
+++ b/src/conversation/settings.rs
@@ -120,8 +120,14 @@ pub enum ResponseMode {
     /// to @mentions, replies-to-bot, and slash commands.
     Quiet,
     /// Only respond when explicitly @mentioned or replied to.
-    /// Messages that don't pass the mention check are recorded in history
-    /// but receive no processing (no memory persistence, no LLM).
+    /// Messages that don't pass the mention check are still ingested into
+    /// the in-memory context window (so the agent stays context-aware),
+    /// recorded in conversation history, and contribute to passive memory
+    /// capture — but do not trigger an LLM turn.
+    ///
+    /// This differs from the binding-level `require_mention` flag, which
+    /// blocks message routing entirely — unmentioned messages never reach
+    /// the channel and are invisible to the agent.
     MentionOnly,
 }
 


### PR DESCRIPTION
## Summary
- **Channel-settings MentionOnly** was behaving identically to binding-level `require_mention` — suppressed messages were invisible to the agent on its next turn
- Now MentionOnly injects suppressed messages into the in-memory LLM context window, so the agent stays context-aware when eventually @mentioned
- MentionOnly now also runs passive memory capture (previously skipped), matching Quiet mode behavior
- Added UI helper text on both binding forms explaining the difference: binding-level blocks entirely, channel-level MentionOnly lets the agent see everything but only respond to mentions

## Test plan
- [ ] Set channel to MentionOnly via channel settings, send several messages without mentioning the bot, then @mention — verify the agent can reference the prior unmentioned messages
- [ ] Set binding-level require_mention, send messages without mentioning — verify the agent cannot see them at all
- [ ] Verify memory persistence works in MentionOnly (check working memory after suppressed messages)
- [ ] Check binding UI shows helper text below the require_mention checkbox on Discord bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!NOTE]
> **AI-generated summary:** This fix changes how MentionOnly mode works at the channel level. Instead of completely suppressing unmentioned messages from the agent (like binding-level `require_mention` does), MentionOnly now keeps them in the agent's context window while preventing automatic responses. The agent sees the conversation flow and memory accumulates passively, creating a more aware but selectively-responsive bot. UI improvements clarify the distinction between these two levels of mention enforcement.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [99467d2](https://github.com/spacedriveapp/spacebot/commit/99467d23856c61e1c2556a6e44e9254ac3c34586). This will update automatically on new commits.</sub>