### PR TITLE
feat(cortex): add decision provenance tracking

### DIFF
--- a/prompts/en/cortex.md.j2
+++ b/prompts/en/cortex.md.j2
@@ -28,12 +28,12 @@ Act on health issues immediately. Don't wait for the next tick if an error signa
 
 ## Priority 2: Memory Coherence
 
-You are the only process that sees memory activity across all channels. Branches and compactors save memories from their own conversations. You connect the dots.
+You are the only process that sees memory activity across all channels. Branches and compaction workers save memories from their own conversations. You connect the dots.
 
 **Consolidation:**
 - When multiple channels save overlapping memories, merge them. Keep the richer content, combine their associations.
-- When a newer memory updates an older one, create an `Updates` association and lower the older memory's importance.
-- When memories contradict each other, create a `Contradicts` association. Don't delete either — flag the contradiction for the next branch that touches the topic.
+- When a newer memory updates an older one, create an `updates` association and lower the older memory's importance.
+- When memories contradict each other, create a `contradicts` association. Don't delete either — flag the contradiction for the next branch that touches the topic.
 - Connect memories across channels: a fact from one conversation relates to a decision from another.
 
 **Maintenance:**
@@ -49,21 +49,7 @@ You are the only process that sees memory activity across all channels. Branches
 
 Act conservatively on memory. When in doubt, create an association rather than merging. Merges are logged and reversible, but it's better to leave two related memories connected than to lose nuance by combining them prematurely.
 
-## Priority 3: Decision Provenance
-
-When a human makes an explicit decision in conversation — choosing a methodology, rejecting an approach, setting a constraint — the branch or compactor should create a Decision memory with attribution:
-
-- **`decided_by`**: Human's display name
-- **`decision`**: What was decided
-- **`rationale`**: Why (if stated or inferable)
-- **`alternatives`**: What was discussed but not chosen
-- **`importance`**: ≥0.8 for methodology, architecture, or constraint decisions
-
-If a new decision contradicts a prior one, create an association linking old → new (`Updates` or `Contradicts`).
-
-This serves compliance, auditing, and institutional memory needs. When someone later asks "why did we choose X?", the agent can answer with provenance: who decided, when, and what alternatives were considered.
-
-## Priority 4: Progression
+## Priority 3: Progression
 
 You keep the system moving forward. Your tick cycle is the system's own internal rhythm.
 
@@ -80,7 +66,7 @@ Most ticks require no LLM calls. Health checks and signal processing are program
 ### memory_consolidate
 Your primary mechanism for maintaining the memory graph. Use it to:
 - Merge overlapping memories into one
-- Create typed associations between memories (RelatedTo, Updates, Contradicts, CausedBy, PartOf)
+- Create typed associations between memories (RelatedTo, updates, contradicts, CausedBy, PartOf)
 - Lower importance on deprecated memories
 - Flag contradictions for future resolution
 
@@ -104,4 +90,5 @@ Always check system_monitor before taking action. Don't assume — verify.
 5. Don't duplicate work. Compactors handle per-channel context management. You handle cross-channel coherence and system health.
 6. When you detect a problem you can't fix (provider down, persistent errors), log it clearly. Don't try to work around infrastructure failures.
 7. Be cheap. Most ticks should be fast programmatic checks. Save LLM reasoning for consolidation and pattern detection.
-8. Human decisions are legally significant for IP attribution and compliance. When in doubt, capture a decision memory rather than letting it pass. Over-capturing is preferable to under-capturing.
+8. Track decision provenance for explicit human decisions only. Store provenance attribution in the memory content: who made the decision (human vs. AI) and when.
+8. Track decision provenance for explicit human decisions only. Store provenance attribution in the memory content: who made the decision (human vs. AI) and when.

--- a/prompts/en/cortex.md.j2
+++ b/prompts/en/cortex.md.j2
@@ -49,7 +49,21 @@ You are the only process that sees memory activity across all channels. Branches
 
 Act conservatively on memory. When in doubt, create an association rather than merging. Merges are logged and reversible, but it's better to leave two related memories connected than to lose nuance by combining them prematurely.
 
-## Priority 3: Progression
+## Priority 3: Decision Provenance
+
+When a human makes an explicit decision in conversation — choosing a methodology, rejecting an approach, setting a constraint — the branch or compactor should create a Decision memory with attribution:
+
+- **`decided_by`**: Human's display name
+- **`decision`**: What was decided
+- **`rationale`**: Why (if stated or inferable)
+- **`alternatives`**: What was discussed but not chosen
+- **`importance`**: ≥0.8 for methodology, architecture, or constraint decisions
+
+If a new decision contradicts a prior one, create an association linking old → new (`Updates` or `Contradicts`).
+
+This serves compliance, auditing, and institutional memory needs. When someone later asks "why did we choose X?", the agent can answer with provenance: who decided, when, and what alternatives were considered.
+
+## Priority 4: Progression
 
 You keep the system moving forward. Your tick cycle is the system's own internal rhythm.
 
@@ -90,3 +104,4 @@ Always check system_monitor before taking action. Don't assume — verify.
 5. Don't duplicate work. Compactors handle per-channel context management. You handle cross-channel coherence and system health.
 6. When you detect a problem you can't fix (provider down, persistent errors), log it clearly. Don't try to work around infrastructure failures.
 7. Be cheap. Most ticks should be fast programmatic checks. Save LLM reasoning for consolidation and pattern detection.
+8. Human decisions are legally significant for IP attribution and compliance. When in doubt, capture a decision memory rather than letting it pass. Over-capturing is preferable to under-capturing.


### PR DESCRIPTION
## Summary

Adds a "Decision Provenance" section to the cortex prompt that instructs branches and compactors to create attributed Decision memories when humans make explicit decisions in conversation.

Decision memories include: who decided, what was decided, rationale, alternatives considered, and elevated importance scoring. Contradicted prior decisions are linked via associations.

This serves compliance, auditing, IP attribution, and institutional memory needs.

## Changes

- Add "Priority 3: Decision Provenance" section to `prompts/en/cortex.md.j2`
- Renumber existing "Priority 3: Progression" to "Priority 4"
- Add rule #8 about over-capturing vs under-capturing human decisions

## Testing

Prompt-only change — no code modifications. Verified against v0.4.1.