### PR TITLE
fix(ingestion): wire memory persistence contract to ingestion hook

### DIFF
--- a/src/agent/ingestion.rs
+++ b/src/agent/ingestion.rs
@@ -520,7 +520,8 @@ async fn process_chunk(
         ProcessType::Branch,
         None,
         deps.event_tx.clone(),
-    );
+    )
+    .with_memory_persistence_contract(contract_state.clone());
 
     let user_prompt =
         prompt_engine.render_system_ingestion_chunk(filename, chunk_number, total_chunks, chunk)?;

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -2368,4 +2368,64 @@ mod tests {
 
         assert!(matches!(action, HookAction::Continue));
     }
+
+    /// Regression test for #538: ingestion hook must wire the memory persistence
+    /// contract so that `has_terminal_outcome()` returns true after a successful
+    /// `memory_persistence_complete` tool call.
+    #[tokio::test]
+    async fn ingestion_hook_without_contract_does_not_record_terminal_outcome() {
+        // Simulate the OLD ingestion code path: hook created without
+        // with_memory_persistence_contract — terminal outcome is never recorded.
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(8);
+        let contract_state = Arc::new(MemoryPersistenceContractState::default());
+        let hook_without_contract = SpacebotHook::new(
+            std::sync::Arc::<str>::from("agent"),
+            ProcessId::Branch(uuid::Uuid::new_v4()),
+            ProcessType::Branch,
+            None,
+            event_tx,
+        );
+        // Do NOT call .with_memory_persistence_contract()
+
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook_without_contract,
+            "memory_persistence_complete",
+            None,
+            "internal_1",
+            "{}",
+            "{\"success\":true,\"outcome\":\"no_memories\",\"saved_memory_ids\":[],\"reason\":\"No durable facts\"}",
+        )
+        .await;
+
+        // Without contract wiring, has_terminal_outcome stays false — this was the #538 bug.
+        assert!(
+            !contract_state.has_terminal_outcome(),
+            "contract state should NOT be set when hook lacks with_memory_persistence_contract"
+        );
+    }
+
+    /// Regression test for #538: ingestion hook WITH the contract wired correctly
+    /// records the terminal outcome after memory_persistence_complete succeeds.
+    #[tokio::test]
+    async fn ingestion_hook_with_contract_records_terminal_outcome() {
+        // Simulate the FIXED ingestion code path: hook created with
+        // with_memory_persistence_contract — terminal outcome is recorded.
+        let (hook, contract_state) = make_memory_persistence_hook();
+
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "memory_persistence_complete",
+            None,
+            "internal_1",
+            "{}",
+            "{\"success\":true,\"outcome\":\"no_memories\",\"saved_memory_ids\":[],\"reason\":\"No durable facts\"}",
+        )
+        .await;
+
+        // With contract wiring, has_terminal_outcome returns true — the fix for #538.
+        assert!(
+            contract_state.has_terminal_outcome(),
+            "contract state MUST be set when hook has with_memory_persistence_contract"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Connects the `MemoryPersistenceContractState` to the `SpacebotHook` in the ingestion `process_chunk` function
- Adds `.with_memory_persistence_contract(contract_state.clone())` to match how `branch.rs` wires the same state (line 71)

## Problem
The ingestion pipeline creates a `MemoryPersistenceContractState` and passes it to the tool server, but never connects it to the `SpacebotHook`. Because `memory_persistence_contract` is `None` on the hook, the `on_tool_call_result` handler never calls `set_terminal_outcome()` — even when the model correctly calls `memory_persistence_complete` and receives a success response.

This causes `has_terminal_outcome()` to always return `false`, making every ingestion chunk fail with:
```
completed without memory_persistence_complete signal
```

## Root Cause
In `ingestion.rs` line 517-523, the hook is constructed via `SpacebotHook::new(...)` without calling `.with_memory_persistence_contract()`. Compare with `branch.rs` line 70-71 which correctly wires the contract state.

## Fix
One line: add `.with_memory_persistence_contract(contract_state.clone())` to the hook construction in `process_chunk`.

## Testing
Tested with 4 different models via OpenRouter (MiniMax M2.7, Step 3.5 Flash, GPT-4.1 nano, Mistral Small 3.2). All correctly call `memory_persistence_complete` but all fail the `has_terminal_outcome()` check. This fix resolves the check by ensuring the hook records the terminal outcome when the tool succeeds.

Fixes #538