### PR TITLE
fix: apply [agents.channel] config when spawning platform channels

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -952,6 +952,24 @@ pub struct ChannelConfig {
     pub save_attachments: bool,
 }
 
+impl ChannelConfig {
+    /// Convert to a `ConversationSettings` for use as the agent-level default in
+    /// `ResolvedConversationSettings::resolve`. Returns `None` when both fields
+    /// match their system defaults (avoids injecting a no-op layer).
+    pub fn to_conversation_settings(
+        &self,
+    ) -> Option<crate::conversation::ConversationSettings> {
+        if self.response_mode.is_none() && !self.save_attachments {
+            return None;
+        }
+        Some(crate::conversation::ConversationSettings {
+            response_mode: self.response_mode.unwrap_or_default(),
+            save_attachments: Some(self.save_attachments),
+            ..Default::default()
+        })
+    }
+}
+
 /// OpenCode subprocess worker configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenCodeConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1960,6 +1960,7 @@ async fn run(
 
                     // Load per-conversation settings (idle worker resume).
                     // Try portal store first, then channel_settings for platform channels.
+                    let agent_channel_default = agent.config.channel.to_conversation_settings();
                     let resolved_settings = {
                         let agent_id_str = agent_id.to_string();
                         let portal_store = spacebot::conversation::PortalConversationStore::new(
@@ -1973,7 +1974,7 @@ async fn run(
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     conv.settings.as_ref(),
                                     None,
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                             Ok(None) => {
@@ -1982,11 +1983,15 @@ async fn run(
                                         spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                             Some(&settings),
                                             None,
-                                            None,
+                                            agent_channel_default.as_ref(),
                                         )
                                     }
                                     Ok(None) => {
-                                        spacebot::conversation::settings::ResolvedConversationSettings::default()
+                                        spacebot::conversation::settings::ResolvedConversationSettings::resolve(
+                                            None,
+                                            None,
+                                            agent_channel_default.as_ref(),
+                                        )
                                     }
                                     Err(error) => {
                                         tracing::warn!(
@@ -1994,7 +1999,11 @@ async fn run(
                                             %conversation_id,
                                             "idle worker resume: failed to load channel settings, using defaults"
                                         );
-                                        spacebot::conversation::settings::ResolvedConversationSettings::default()
+                                        spacebot::conversation::settings::ResolvedConversationSettings::resolve(
+                                            None,
+                                            None,
+                                            agent_channel_default.as_ref(),
+                                        )
                                     }
                                 }
                             }
@@ -2004,7 +2013,11 @@ async fn run(
                                     %conversation_id,
                                     "idle worker resume: failed to load portal settings, using defaults"
                                 );
-                                spacebot::conversation::settings::ResolvedConversationSettings::default()
+                                spacebot::conversation::settings::ResolvedConversationSettings::resolve(
+                                    None,
+                                    None,
+                                    agent_channel_default.as_ref(),
+                                )
                             }
                         }
                     };
@@ -2224,6 +2237,7 @@ async fn run(
 
                     // Load per-conversation settings.
                     // Resolution: per-channel DB override > binding defaults > agent defaults > system defaults
+                    let agent_channel_default = agent.config.channel.to_conversation_settings();
                     let resolved_settings = if message.adapter.as_deref() == Some("portal") {
                         // Portal: load from portal_conversations table.
                         let store = spacebot::conversation::PortalConversationStore::new(
@@ -2234,14 +2248,14 @@ async fn run(
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     conv.settings.as_ref(),
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                             Ok(None) => {
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     None,
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                             Err(error) => {
@@ -2253,7 +2267,7 @@ async fn run(
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     None,
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                         }
@@ -2267,14 +2281,14 @@ async fn run(
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     Some(&settings),
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                             Ok(None) => {
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     None,
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                             Err(error) => {
@@ -2286,7 +2300,7 @@ async fn run(
                                 spacebot::conversation::settings::ResolvedConversationSettings::resolve(
                                     None,
                                     binding_settings.as_ref(),
-                                    None,
+                                    agent_channel_default.as_ref(),
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary

- `[agents.channel]` settings (`response_mode`, `save_attachments`) were loaded from TOML but silently discarded at runtime — `agent_default` was always `None` in every `ResolvedConversationSettings::resolve()` call for platform channels and the idle-worker resume path
- Adds `ChannelConfig::to_conversation_settings()` in `config/types.rs` to centralise the conversion logic
- Passes the result as `agent_default` across all six `resolve()` call sites (new-message spawn path + idle-worker resume path)
- Also fixes a secondary bug: the old inline construction was gated on `response_mode.is_some()`, which would silently drop a configured `save_attachments = true` when no `response_mode` was set

## Test plan

- [ ] Config with `response_mode = "quiet"` under `[agents.channel]` now suppresses responses without needing a `/quiet` slash command
- [ ] Config with `save_attachments = true` under `[agents.channel]` now applies even when `response_mode` is unset
- [ ] Idle-worker resumed channels inherit `[agents.channel]` defaults correctly
- [ ] Existing DB-persisted overrides (via `/quiet`, `/active`) still take precedence over config

🤖 Generated with [Claude Code](https://claude.com/claude-code)