### PR TITLE
fix: prevent interactive workers from getting stuck in idle after outcome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libcairo2 \
     libcups2 \
+    libxkbcommon0 \
     libxss1 \
     libxtst6 \
     && rm -rf /var/lib/apt/lists/*

--- a/interface/package-lock.json
+++ b/interface/package-lock.json
@@ -1,0 +1,12368 @@
+{
+	"name": "spacebot-interface",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "spacebot-interface",
+			"version": "0.1.0",
+			"dependencies": {
+				"@codemirror/language": "^6.12.1",
+				"@codemirror/legacy-modes": "^6.5.2",
+				"@codemirror/state": "^6.5.4",
+				"@codemirror/theme-one-dark": "^6.1.3",
+				"@codemirror/view": "^6.39.14",
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
+				"@fontsource/ibm-plex-sans": "^5.1.0",
+				"@fortawesome/fontawesome-svg-core": "^7.2.0",
+				"@fortawesome/free-brands-svg-icons": "^7.2.0",
+				"@fortawesome/free-solid-svg-icons": "^7.2.0",
+				"@fortawesome/react-fontawesome": "^3.0.0",
+				"@hookform/resolvers": "^5.2.2",
+				"@hugeicons/core-free-icons": "^3.1.1",
+				"@hugeicons/react": "^1.1.5",
+				"@lobehub/icons": "^4.6.0",
+				"@radix-ui/react-checkbox": "^1.3.3",
+				"@radix-ui/react-dialog": "^1.1.15",
+				"@radix-ui/react-dropdown-menu": "^2.1.16",
+				"@radix-ui/react-popover": "^1.1.15",
+				"@radix-ui/react-radio-group": "^1.3.8",
+				"@radix-ui/react-select": "^2.2.6",
+				"@radix-ui/react-slider": "^1.3.6",
+				"@radix-ui/react-switch": "^1.2.6",
+				"@radix-ui/react-tabs": "^1.1.13",
+				"@radix-ui/react-tooltip": "^1.2.8",
+				"@react-sigma/core": "^5.0.6",
+				"@tanstack/react-query": "^5.62.0",
+				"@tanstack/react-query-devtools": "^5.91.3",
+				"@tanstack/react-router": "^1.159.5",
+				"@tanstack/react-virtual": "^3.13.18",
+				"@tanstack/router-devtools": "^1.159.5",
+				"@xyflow/react": "^12.10.1",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"codemirror": "^6.0.2",
+				"framer-motion": "^12.34.0",
+				"graphology": "^0.26.0",
+				"graphology-layout-forceatlas2": "^0.10.1",
+				"graphology-types": "^0.24.8",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0",
+				"react-hook-form": "^7.71.1",
+				"react-markdown": "^10.1.0",
+				"recharts": "^3.7.0",
+				"rehype-raw": "^7.0.0",
+				"remark-gfm": "^4.0.1",
+				"sigma": "^3.0.2",
+				"smol-toml": "^1.6.0",
+				"sonner": "^2.0.7",
+				"zod": "^4.3.6"
+			},
+			"devDependencies": {
+				"@types/react": "^19.0.0",
+				"@types/react-dom": "^19.0.0",
+				"@vitejs/plugin-react": "^4.3.4",
+				"autoprefixer": "^10.4.18",
+				"postcss": "^8.4.36",
+				"sass": "^1.72.0",
+				"tailwindcss": "^3.4.1",
+				"tailwindcss-animate": "^1.0.7",
+				"typescript": "^5.6.2",
+				"vite": "^6.0.0"
+			}
+		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@ant-design/colors": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+			"integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/fast-color": "^3.0.0"
+			}
+		},
+		"node_modules/@ant-design/cssinjs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
+			"integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@emotion/hash": "^0.8.0",
+				"@emotion/unitless": "^0.7.5",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1",
+				"csstype": "^3.1.3",
+				"stylis": "^4.3.4"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@ant-design/cssinjs-utils": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
+			"integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.1.2",
+				"@babel/runtime": "^7.23.2",
+				"@rc-component/util": "^1.4.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@ant-design/fast-color": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+			"integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8.x"
+			}
+		},
+		"node_modules/@ant-design/icons": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
+			"integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/colors": "^8.0.0",
+				"@ant-design/icons-svg": "^4.4.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@ant-design/icons-svg": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+			"integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@ant-design/react-slick": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+			"integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"clsx": "^2.1.1",
+				"json2mq": "^0.2.0",
+				"throttle-debounce": "^5.0.0"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@antfu/install-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"package-manager-detector": "^1.3.0",
+				"tinyexec": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-self": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+			"integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-source": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+			"integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@base-ui/react": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.0.0.tgz",
+			"integrity": "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"@base-ui/utils": "0.2.3",
+				"@floating-ui/react-dom": "^2.1.6",
+				"@floating-ui/utils": "^0.2.10",
+				"reselect": "^5.1.1",
+				"tabbable": "^6.3.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.3.tgz",
+			"integrity": "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.28.4",
+				"@floating-ui/utils": "^0.2.10",
+				"reselect": "^5.1.1",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@chevrotain/cst-dts-gen": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+			"integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/gast": "11.1.2",
+				"@chevrotain/types": "11.1.2",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/@chevrotain/gast": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+			"integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/types": "11.1.2",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/@chevrotain/regexp-to-ast": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+			"integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@chevrotain/types": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@chevrotain/utils": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+			"integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "6.20.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+			"integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.17.0",
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+			"integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.6.0",
+				"@codemirror/view": "^6.27.0",
+				"@lezer/common": "^1.1.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+			"integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.23.0",
+				"@lezer/common": "^1.5.0",
+				"@lezer/highlight": "^1.0.0",
+				"@lezer/lr": "^1.0.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/legacy-modes": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+			"integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0"
+			}
+		},
+		"node_modules/@codemirror/lint": {
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+			"integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.35.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+			"integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.37.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+			"integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/theme-one-dark": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+			"integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0",
+				"@lezer/highlight": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+			"integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/state": "^6.6.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/modifiers": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+			"integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+			"integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.3.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emoji-mart/data": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+			"integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@emoji-mart/react": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+			"integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"emoji-mart": "^5.2",
+				"react": "^16.8 || ^17 || ^18"
+			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.3.3",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/cache/node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/css": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+			"integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.13.5",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.2",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/serialize/node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+			"license": "MIT"
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
+			}
+		},
+		"node_modules/@floating-ui/react": {
+			"version": "0.27.19",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+			"integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"tabbable": "^6.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=17.0.0",
+				"react-dom": ">=17.0.0"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.6"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+			"license": "MIT"
+		},
+		"node_modules/@fontsource/ibm-plex-sans": {
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+			"integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-common-types": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+			"integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/fontawesome-svg-core": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
+			"integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "7.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-brands-svg-icons": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.2.0.tgz",
+			"integrity": "sha512-VNG8xqOip1JuJcC3zsVsKRQ60oXG9+oYNDCosjoU/H9pgYmLTEwWw8pE0jhPz/JWdHeUuK6+NQ3qsM4gIbdbYQ==",
+			"license": "(CC-BY-4.0 AND MIT)",
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "7.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/free-solid-svg-icons": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
+			"integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
+			"license": "(CC-BY-4.0 AND MIT)",
+			"dependencies": {
+				"@fortawesome/fontawesome-common-types": "7.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@fortawesome/react-fontawesome": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.0.tgz",
+			"integrity": "sha512-EHmHeTf8WgO29sdY3iX/7ekE3gNUdlc2RW6mm/FzELlHFKfTrA9S4MlyquRR+RRCRCn8+jXfLFpLGB2l7wCWyw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"@fortawesome/fontawesome-svg-core": "~6 || ~7",
+				"react": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@giscus/react": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+			"integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+			"peer": true,
+			"dependencies": {
+				"giscus": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16 || ^17 || ^18 || ^19",
+				"react-dom": "^16 || ^17 || ^18 || ^19"
+			}
+		},
+		"node_modules/@hookform/resolvers": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+			"integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/utils": "^0.3.0"
+			},
+			"peerDependencies": {
+				"react-hook-form": "^7.55.0"
+			}
+		},
+		"node_modules/@hugeicons/core-free-icons": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@hugeicons/core-free-icons/-/core-free-icons-3.3.0.tgz",
+			"integrity": "sha512-qYyr4JQ2eQIHTSTbITvnJvs6ERNK64D9gpwZnf2IyuG0exzqfyABLO/oTB71FB3RZPfu1GbwycdiGSo46apjMQ==",
+			"license": "MIT"
+		},
+		"node_modules/@hugeicons/react": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.6.tgz",
+			"integrity": "sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.0.0"
+			}
+		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@iconify/utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+			"integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@antfu/install-pkg": "^1.1.0",
+				"@iconify/types": "^2.0.0",
+				"mlly": "^1.8.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@lezer/common": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+			"integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+			"license": "MIT"
+		},
+		"node_modules/@lezer/highlight": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.3.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@lezer/common": "^1.0.0"
+			}
+		},
+		"node_modules/@lit-labs/ssr-dom-shim": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+			"integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@lit/reactive-element": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+			"integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0"
+			}
+		},
+		"node_modules/@lobehub/emojilib": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/emojilib/-/emojilib-1.0.0.tgz",
+			"integrity": "sha512-s9KnjaPjsEefaNv150G3aifvB+J3P4eEKG+epY9zDPS2BeB6+V2jELWqAZll+nkogMaVovjEE813z3V751QwGw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@lobehub/fluent-emoji": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/fluent-emoji/-/fluent-emoji-4.1.0.tgz",
+			"integrity": "sha512-R1MB2lfUkDvB7XAQdRzY75c1dx/tB7gEvBPaEEMarzKfCJWmXm7rheS6caVzmgwAlq5sfmTbxPL+un99sp//Yw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@lobehub/emojilib": "^1.0.0",
+				"antd-style": "^4.1.0",
+				"emoji-regex": "^10.6.0",
+				"es-toolkit": "^1.43.0",
+				"lucide-react": "^0.562.0",
+				"url-join": "^5.0.0"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/icons": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@lobehub/icons/-/icons-4.12.0.tgz",
+			"integrity": "sha512-DVH7pVzM6wEvua2LXH+Iv10/cLeBbueggMFBHa8IlfQel5u3I6JzuaNXXxj2qJu5QYjUCNL5LTpSWuh4TnuLGw==",
+			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
+			"dependencies": {
+				"antd-style": "^4.1.0",
+				"lucide-react": "^0.469.0",
+				"polished": "^4.3.1"
+			},
+			"peerDependencies": {
+				"@lobehub/ui": "^4.3.3",
+				"antd": "^6.1.1",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/icons/node_modules/lucide-react": {
+			"version": "0.469.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+			"integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/ui": {
+			"version": "4.38.4",
+			"resolved": "https://registry.npmjs.org/@lobehub/ui/-/ui-4.38.4.tgz",
+			"integrity": "sha512-FYQeWkR0CoZCaPqEX9AUGrhaIfkYeuacW2KtV+1GS7eGVjREFNNOAgY5PLk20ZMYV/cRFsn9fNG0rqn9PxChxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.0.3",
+				"@base-ui/react": "1.0.0",
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/modifiers": "^9.0.0",
+				"@dnd-kit/sortable": "^10.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
+				"@emoji-mart/data": "^1.2.1",
+				"@emoji-mart/react": "^1.1.1",
+				"@emotion/is-prop-valid": "^1.4.0",
+				"@floating-ui/react": "^0.27.17",
+				"@giscus/react": "^3.1.0",
+				"@mdx-js/mdx": "^3.1.1",
+				"@mdx-js/react": "^3.1.1",
+				"@pierre/diffs": "^1.0.10",
+				"@radix-ui/react-slot": "^1.2.4",
+				"@shikijs/core": "^3.22.0",
+				"@shikijs/transformers": "^3.22.0",
+				"@splinetool/runtime": "0.9.526",
+				"ahooks": "^3.9.6",
+				"antd-style": "^4.1.0",
+				"chroma-js": "^3.2.0",
+				"class-variance-authority": "^0.7.1",
+				"clsx": "^2.1.1",
+				"dayjs": "^1.11.19",
+				"emoji-mart": "^5.6.0",
+				"es-toolkit": "^1.44.0",
+				"fast-deep-equal": "^3.1.3",
+				"immer": "^11.1.3",
+				"katex": "^0.16.28",
+				"leva": "^0.10.1",
+				"lucide-react": "^0.563.0",
+				"marked": "^17.0.1",
+				"mermaid": "^11.12.2",
+				"motion": "^12.30.0",
+				"numeral": "^2.0.6",
+				"polished": "^4.3.1",
+				"query-string": "^9.3.1",
+				"rc-collapse": "^4.0.0",
+				"rc-footer": "^0.6.8",
+				"rc-image": "^7.12.0",
+				"rc-input-number": "^9.5.0",
+				"rc-menu": "^9.16.1",
+				"re-resizable": "^6.11.2",
+				"react-avatar-editor": "^14.0.0",
+				"react-error-boundary": "^6.1.0",
+				"react-hotkeys-hook": "^5.2.4",
+				"react-markdown": "^10.1.0",
+				"react-merge-refs": "^3.0.2",
+				"react-rnd": "^10.5.2",
+				"react-zoom-pan-pinch": "^3.7.0",
+				"rehype-github-alerts": "^4.2.0",
+				"rehype-katex": "^7.0.1",
+				"rehype-raw": "^7.0.0",
+				"remark-breaks": "^4.0.0",
+				"remark-cjk-friendly": "^1.2.3",
+				"remark-gfm": "^4.0.1",
+				"remark-github": "^12.0.0",
+				"remark-math": "^6.0.0",
+				"remend": "^1.2.0",
+				"shiki": "^3.22.0",
+				"shiki-stream": "^0.1.4",
+				"swr": "^2.4.0",
+				"ts-md5": "^2.0.1",
+				"unified": "^11.0.5",
+				"url-join": "^5.0.0",
+				"use-merge-value": "^1.2.0",
+				"uuid": "^13.0.0",
+				"virtua": "^0.48.5"
+			},
+			"peerDependencies": {
+				"@lobehub/fluent-emoji": "^4.0.0",
+				"@lobehub/icons": "^4.0.0",
+				"antd": "^6.1.1",
+				"motion": "^12.0.0",
+				"react": "^19.0.0",
+				"react-dom": "^19.0.0"
+			}
+		},
+		"node_modules/@lobehub/ui/node_modules/lucide-react": {
+			"version": "0.563.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
+			"integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"license": "MIT"
+		},
+		"node_modules/@mdx-js/mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+			"integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdx": "^2.0.0",
+				"acorn": "^8.0.0",
+				"collapse-white-space": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-util-scope": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"markdown-extensions": "^2.0.0",
+				"recma-build-jsx": "^1.0.0",
+				"recma-jsx": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"rehype-recma": "^1.0.0",
+				"remark-mdx": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"source-map": "^0.7.0",
+				"unified": "^11.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@mdx-js/react": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdx": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16",
+				"react": ">=16"
+			}
+		},
+		"node_modules/@mermaid-js/parser": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
+			"integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"langium": "^4.0.0"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.3",
+				"is-glob": "^4.0.3",
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@pierre/diffs": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.1.6.tgz",
+			"integrity": "sha512-LgnbJNlc0fF9IbNVlbJ+DTg/Rl4l6FIendV7b68s1c9+RH639bp/osi9FtFpMXut8oXyzTDqM3X9GJG8+gkf2Q==",
+			"license": "apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@pierre/theme": "0.0.22",
+				"@shikijs/transformers": "^3.0.0",
+				"diff": "8.0.3",
+				"hast-util-to-html": "9.0.5",
+				"lru_map": "0.4.1",
+				"shiki": "^3.0.0"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1 || ^19.0.0",
+				"react-dom": "^18.3.1 || ^19.0.0"
+			}
+		},
+		"node_modules/@pierre/theme": {
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-0.0.22.tgz",
+			"integrity": "sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"vscode": "^1.0.0"
+			}
+		},
+		"node_modules/@primer/octicons": {
+			"version": "19.23.1",
+			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.23.1.tgz",
+			"integrity": "sha512-CzjGmxkmNhyst6EekrS3SJPdtzgIkUMP/LSJch65y99/kmiFXbO1a+q7zoYe3hnI9NaOM0IN+ydDIbOmd8YqcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/@radix-ui/number": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+			"integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+			"integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-arrow": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+			"integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-checkbox": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+			"integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-collection": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+			"integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+			"integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+			"integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.11",
+				"@radix-ui/react-focus-guards": "1.1.3",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-direction": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+			"integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+			"integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-escape-keydown": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu": {
+			"version": "2.1.16",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+			"integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-menu": "2.1.16",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+			"integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+			"integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+			"integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu": {
+			"version": "2.1.16",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+			"integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-collection": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-dismissable-layer": "1.1.11",
+				"@radix-ui/react-focus-guards": "1.1.3",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-popper": "1.2.8",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-roving-focus": "1.1.11",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-popover": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+			"integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.11",
+				"@radix-ui/react-focus-guards": "1.1.3",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-popper": "1.2.8",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-popper": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+			"integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.0.0",
+				"@radix-ui/react-arrow": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-layout-effect": "1.1.1",
+				"@radix-ui/react-use-rect": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1",
+				"@radix-ui/rect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+			"integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+			"integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-radio-group": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+			"integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-roving-focus": "1.1.11",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-roving-focus": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+			"integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-collection": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-controllable-state": "1.2.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-select": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+			"integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/number": "1.1.1",
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-collection": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-dismissable-layer": "1.1.11",
+				"@radix-ui/react-focus-guards": "1.1.3",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-popper": "1.2.8",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-visually-hidden": "1.2.3",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slider": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+			"integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/number": "1.1.1",
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-collection": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+			"integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-switch": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+			"integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-tabs": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+			"integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-roving-focus": "1.1.11",
+				"@radix-ui/react-use-controllable-state": "1.2.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-tooltip": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+			"integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.3",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.11",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-popper": "1.2.8",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-visually-hidden": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+			"integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-escape-keydown": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+			"integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-previous": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+			"integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-rect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+			"integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/rect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-size": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+			"integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-visually-hidden": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+			"integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/rect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+			"integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+			"license": "MIT"
+		},
+		"node_modules/@rc-component/async-validator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
+			"integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.24.4"
+			},
+			"engines": {
+				"node": ">=14.x"
+			}
+		},
+		"node_modules/@rc-component/cascader": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
+			"integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/select": "~1.6.0",
+				"@rc-component/tree": "~1.2.0",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/checkbox": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+			"integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/collapse": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+			"integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/color-picker": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
+			"integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/fast-color": "^3.0.1",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/context": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
+			"integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/dialog": {
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
+			"integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.3",
+				"@rc-component/portal": "^2.1.0",
+				"@rc-component/util": "^1.9.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/drawer": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+			"integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.1.3",
+				"@rc-component/util": "^1.9.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/dropdown": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+			"integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.11.0",
+				"react-dom": ">=16.11.0"
+			}
+		},
+		"node_modules/@rc-component/form": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.0.tgz",
+			"integrity": "sha512-eUD5KKYnIZWmJwRA0vnyO/ovYUfHGU1svydY1OrqU5fw8Oz9Tdqvxvrlh0wl6xI/EW69dT7II49xpgOWzK3T5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/async-validator": "^5.1.0",
+				"@rc-component/util": "^1.6.2",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/image": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.8.0.tgz",
+			"integrity": "sha512-Dr41bFevLB5NgVaJhEUmNvbEf+ynAhim6W98ZW2xvCsdFISc2TYP4ZvCVdie3eaZdum2kieVcvpNHu+UrzAAHA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.0.0",
+				"@rc-component/portal": "^2.1.2",
+				"@rc-component/util": "^1.10.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/input": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
+			"integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@rc-component/input-number": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+			"integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/mini-decimal": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mentions": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
+			"integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/input": "~1.1.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/textarea": "~1.1.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/menu": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
+			"integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mini-decimal": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
+			"integrity": "sha512-bk/FJ09fLf+NLODMAFll6CfYrHPBioTedhW6lxDBuuWucJEqFUd4l/D/5JgIi3dina6sYahB8iuPAZTNz2pMxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			}
+		},
+		"node_modules/@rc-component/motion": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
+			"integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/mutate-observer": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+			"integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/notification": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
+			"integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/overflow": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.0.tgz",
+			"integrity": "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/pagination": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
+			"integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/picker": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
+			"integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/trigger": "^3.6.15",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"date-fns": ">= 2.x",
+				"dayjs": ">= 1.x",
+				"luxon": ">= 3.x",
+				"moment": ">= 2.x",
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			},
+			"peerDependenciesMeta": {
+				"date-fns": {
+					"optional": true
+				},
+				"dayjs": {
+					"optional": true
+				},
+				"luxon": {
+					"optional": true
+				},
+				"moment": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rc-component/portal": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
+			"integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/progress": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+			"integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/qrcode": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
+			"integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/rate": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+			"integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/resize-observer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+			"integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/segmented": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+			"integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/@rc-component/select": {
+			"version": "1.6.15",
+			"resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
+			"integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/overflow": "^1.0.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.3.0",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/slider": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+			"integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/steps": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+			"integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/switch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+			"integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/table": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
+			"integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/context": "^2.0.1",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.1.0",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/tabs": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
+			"integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/dropdown": "~1.0.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/motion": "^1.1.3",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/textarea": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
+			"integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/input": "~1.1.0",
+				"@rc-component/resize-observer": "^1.0.0",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/tooltip": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+			"integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/trigger": "^3.7.1",
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/tour": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
+			"integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/portal": "^2.2.0",
+				"@rc-component/trigger": "^3.0.0",
+				"@rc-component/util": "^1.7.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/tree": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
+			"integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.0.0",
+				"@rc-component/util": "^1.8.1",
+				"@rc-component/virtual-list": "^1.0.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=10.x"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/tree-select": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
+			"integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/select": "~1.6.0",
+				"@rc-component/tree": "~1.2.0",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/@rc-component/trigger": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
+			"integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/motion": "^1.1.4",
+				"@rc-component/portal": "^2.2.0",
+				"@rc-component/resize-observer": "^1.1.1",
+				"@rc-component/util": "^1.2.1",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/upload": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
+			"integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@rc-component/util": "^1.3.0",
+				"clsx": "^2.1.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@rc-component/util": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.0.tgz",
+			"integrity": "sha512-aY9GLBuiUdpyfIUpAWSYer4Tu3mVaZCo5A0q9NtXcazT3MRiI3/WNHCR+DUn5VAtR6iRRf0ynCqQUcHli5UdYw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-mobile": "^5.0.0",
+				"react-is": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/@rc-component/util/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT"
+		},
+		"node_modules/@rc-component/virtual-list": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
+			"integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.0",
+				"@rc-component/resize-observer": "^1.0.1",
+				"@rc-component/util": "^1.4.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/@react-sigma/core": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@react-sigma/core/-/core-5.0.6.tgz",
+			"integrity": "sha512-Xu2qXyvDZIhmvGC1n8d7Kcxm5Ntcz4HbPIM7CPDD2e4h3s/oxVpVPX7wtsNreJRRPj9mK+3oqB6SWXNI4mTqVg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"graphology": "^0.26.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"sigma": "^3.0.2"
+			}
+		},
+		"node_modules/@reduxjs/toolkit": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+			"integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/utils": "^0.3.0",
+				"immer": "^11.0.0",
+				"redux": "^5.0.1",
+				"redux-thunk": "^3.1.0",
+				"reselect": "^5.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+				"react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-redux": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-beta.27",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+			"integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+			"integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+			"integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+			"integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+			"integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+			"integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+			"integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+			"integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+			"integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+			"integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+			"integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+			"integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+			"integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+			"integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+			"integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+			"integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+			"integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+			"integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+			"integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+			"integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+			"integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+			"integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+			"integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+			"integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+			"integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+			"integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@shikijs/core": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+			"integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+			"integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.4"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/transformers": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
+			"integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "3.23.0",
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@splinetool/runtime": {
+			"version": "0.9.526",
+			"resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-0.9.526.tgz",
+			"integrity": "sha512-qznHbXA5aKwDbCgESAothCNm1IeEZcmNWG145p5aXj4w5uoqR1TZ9qkTHTKLTsUbHeitCwdhzmRqan1kxboLgQ==",
+			"peer": true,
+			"dependencies": {
+				"on-change": "^4.0.0",
+				"semver-compare": "^1.0.0"
+			}
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+			"license": "MIT"
+		},
+		"node_modules/@stitches/react": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+			"integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">= 16.3.0"
+			}
+		},
+		"node_modules/@tanstack/history": {
+			"version": "1.161.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
+			"integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/query-core": {
+			"version": "5.95.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+			"integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/query-devtools": {
+			"version": "5.95.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.95.2.tgz",
+			"integrity": "sha512-QfaoqBn9uAZ+ICkA8brd1EHj+qBF6glCFgt94U8XP5BT6ppSsDBI8IJ00BU+cAGjQzp6wcKJL2EmRYvxy0TWIg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/react-query": {
+			"version": "5.95.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+			"integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/query-core": "5.95.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19"
+			}
+		},
+		"node_modules/@tanstack/react-query-devtools": {
+			"version": "5.95.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.95.2.tgz",
+			"integrity": "sha512-AFQFmbznVkbtfpx8VJ2DylW17wWagQel/qLstVLkYmNRo2CmJt3SNej5hvl6EnEeljJIdC3BTB+W7HZtpsH+3g==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/query-devtools": "5.95.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@tanstack/react-query": "^5.95.2",
+				"react": "^18 || ^19"
+			}
+		},
+		"node_modules/@tanstack/react-router": {
+			"version": "1.168.7",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.168.7.tgz",
+			"integrity": "sha512-fW/HvQja4PQeu9lsoyh+pXpZ0UXezbpQkkJvCuH6tHAaW3jvPkjh14lfadrNNiY+pXT7WiMTB3afGhTCC78PDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.161.6",
+				"@tanstack/react-store": "^0.9.3",
+				"@tanstack/router-core": "1.168.6",
+				"isbot": "^5.1.22"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			}
+		},
+		"node_modules/@tanstack/react-router-devtools": {
+			"version": "1.166.11",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.166.11.tgz",
+			"integrity": "sha512-WYR3q4Xui5yPT/5PXtQh8i03iUA7q8dONBjWpV3nsGdM8Cs1FxpfhLstW0wZO1dOvSyElscwTRCJ6nO5N8r3Lg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/router-devtools-core": "1.167.1"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@tanstack/react-router": "^1.168.2",
+				"@tanstack/router-core": "^1.168.2",
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@tanstack/router-core": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/react-store": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+			"integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/store": "0.9.3",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.13.23",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+			"integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.13.23"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/router-core": {
+			"version": "1.168.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.6.tgz",
+			"integrity": "sha512-okCno3pImpLFQMJ/4zqEIGjIV5yhxLGj0JByrzQDQehORN1y1q6lJUezT0KPK5qCQiKUApeWaboLPjgBVx1kaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/history": "1.161.6",
+				"cookie-es": "^2.0.0",
+				"seroval": "^1.4.2",
+				"seroval-plugins": "^1.4.2"
+			},
+			"bin": {
+				"intent": "bin/intent.js"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/router-devtools": {
+			"version": "1.166.11",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.166.11.tgz",
+			"integrity": "sha512-jvFKr1fQ5pWMOZTILhitJc1kJt1wj8qqtRClVJvyD1AjHc1XINihkqK+R6+FmC8F2m+XOhKME4CSnTtJ6Nf34w==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/react-router-devtools": "1.166.11",
+				"clsx": "^2.1.1",
+				"goober": "^2.1.16"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@tanstack/react-router": "^1.168.2",
+				"csstype": "^3.0.10",
+				"react": ">=18.0.0 || >=19.0.0",
+				"react-dom": ">=18.0.0 || >=19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"csstype": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/router-devtools-core": {
+			"version": "1.167.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.167.1.tgz",
+			"integrity": "sha512-ECMM47J4KmifUvJguGituSiBpfN8SyCUEoxQks5RY09hpIBfR2eswCv2e6cJimjkKwBQXOVTPkTUk/yRvER+9w==",
+			"license": "MIT",
+			"dependencies": {
+				"clsx": "^2.1.1",
+				"goober": "^2.1.16"
+			},
+			"engines": {
+				"node": ">=20.19"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@tanstack/router-core": "^1.168.2",
+				"csstype": "^3.0.10"
+			},
+			"peerDependenciesMeta": {
+				"csstype": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/store": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+			"integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.13.23",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+			"integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			}
+		},
+		"node_modules/@types/d3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/d3-axis": "*",
+				"@types/d3-brush": "*",
+				"@types/d3-chord": "*",
+				"@types/d3-color": "*",
+				"@types/d3-contour": "*",
+				"@types/d3-delaunay": "*",
+				"@types/d3-dispatch": "*",
+				"@types/d3-drag": "*",
+				"@types/d3-dsv": "*",
+				"@types/d3-ease": "*",
+				"@types/d3-fetch": "*",
+				"@types/d3-force": "*",
+				"@types/d3-format": "*",
+				"@types/d3-geo": "*",
+				"@types/d3-hierarchy": "*",
+				"@types/d3-interpolate": "*",
+				"@types/d3-path": "*",
+				"@types/d3-polygon": "*",
+				"@types/d3-quadtree": "*",
+				"@types/d3-random": "*",
+				"@types/d3-scale": "*",
+				"@types/d3-scale-chromatic": "*",
+				"@types/d3-selection": "*",
+				"@types/d3-shape": "*",
+				"@types/d3-time": "*",
+				"@types/d3-time-format": "*",
+				"@types/d3-timer": "*",
+				"@types/d3-transition": "*",
+				"@types/d3-zoom": "*"
+			}
+		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-axis": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-brush": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-chord": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-dispatch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-drag": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+			"integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-dsv": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-fetch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/d3-dsv": "*"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-format": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-polygon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-quadtree": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-random": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-selection": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-time-format": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-transition": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+			"integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-zoom": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+			"integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-interpolate": "*",
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/estree-jsx": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+			"integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/js-cookie": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+			"integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/mdx": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+			"integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/react": {
+			"version": "19.2.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.2.2"
+			}
+		},
+		"node_modules/@types/react-dom": {
+			"version": "19.2.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"devOptional": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.2.0"
+			}
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+			"integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+			"license": "MIT"
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"license": "ISC"
+		},
+		"node_modules/@upsetjs/venn.js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+			"license": "MIT",
+			"peer": true,
+			"optionalDependencies": {
+				"d3-selection": "^3.0.0",
+				"d3-transition": "^3.0.1"
+			}
+		},
+		"node_modules/@use-gesture/core": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+			"integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@use-gesture/react": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+			"integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@use-gesture/core": "10.3.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8.0"
+			}
+		},
+		"node_modules/@vitejs/plugin-react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+			"integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.28.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
+				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
+				"@rolldown/pluginutils": "1.0.0-beta.27",
+				"@types/babel__core": "^7.20.5",
+				"react-refresh": "^0.17.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"node_modules/@xyflow/react": {
+			"version": "12.10.2",
+			"resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+			"integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@xyflow/system": "0.0.76",
+				"classcat": "^5.0.3",
+				"zustand": "^4.4.0"
+			},
+			"peerDependencies": {
+				"react": ">=17",
+				"react-dom": ">=17"
+			}
+		},
+		"node_modules/@xyflow/system": {
+			"version": "0.0.76",
+			"resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+			"integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-drag": "^3.0.7",
+				"@types/d3-interpolate": "^3.0.4",
+				"@types/d3-selection": "^3.0.10",
+				"@types/d3-transition": "^3.0.8",
+				"@types/d3-zoom": "^3.0.8",
+				"d3-drag": "^3.0.0",
+				"d3-interpolate": "^3.0.1",
+				"d3-selection": "^3.0.0",
+				"d3-zoom": "^3.0.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/ahooks": {
+			"version": "3.9.7",
+			"resolved": "https://registry.npmjs.org/ahooks/-/ahooks-3.9.7.tgz",
+			"integrity": "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.21.0",
+				"@types/js-cookie": "^3.0.6",
+				"dayjs": "^1.9.1",
+				"intersection-observer": "^0.12.0",
+				"js-cookie": "^3.0.5",
+				"lodash": "^4.17.21",
+				"react-fast-compare": "^3.2.2",
+				"resize-observer-polyfill": "^1.5.1",
+				"screenfull": "^5.0.0",
+				"tslib": "^2.4.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/antd": {
+			"version": "6.3.4",
+			"resolved": "https://registry.npmjs.org/antd/-/antd-6.3.4.tgz",
+			"integrity": "sha512-Bu6JivPP7bFfYIdVj+61dxhwSOz+A3m0W7PlDasFGC3H3sNMYQ9gJXZoo11/rQh7pTlOQa351q5Ig/zjI98XYw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@ant-design/colors": "^8.0.1",
+				"@ant-design/cssinjs": "^2.1.2",
+				"@ant-design/cssinjs-utils": "^2.1.2",
+				"@ant-design/fast-color": "^3.0.1",
+				"@ant-design/icons": "^6.1.0",
+				"@ant-design/react-slick": "~2.0.0",
+				"@babel/runtime": "^7.28.4",
+				"@rc-component/cascader": "~1.14.0",
+				"@rc-component/checkbox": "~2.0.0",
+				"@rc-component/collapse": "~1.2.0",
+				"@rc-component/color-picker": "~3.1.1",
+				"@rc-component/dialog": "~1.8.4",
+				"@rc-component/drawer": "~1.4.2",
+				"@rc-component/dropdown": "~1.0.2",
+				"@rc-component/form": "~1.8.0",
+				"@rc-component/image": "~1.8.0",
+				"@rc-component/input": "~1.1.2",
+				"@rc-component/input-number": "~1.6.2",
+				"@rc-component/mentions": "~1.6.0",
+				"@rc-component/menu": "~1.2.0",
+				"@rc-component/motion": "^1.3.1",
+				"@rc-component/mutate-observer": "^2.0.1",
+				"@rc-component/notification": "~1.2.0",
+				"@rc-component/pagination": "~1.2.0",
+				"@rc-component/picker": "~1.9.1",
+				"@rc-component/progress": "~1.0.2",
+				"@rc-component/qrcode": "~1.1.1",
+				"@rc-component/rate": "~1.0.1",
+				"@rc-component/resize-observer": "^1.1.1",
+				"@rc-component/segmented": "~1.3.0",
+				"@rc-component/select": "~1.6.15",
+				"@rc-component/slider": "~1.0.1",
+				"@rc-component/steps": "~1.2.2",
+				"@rc-component/switch": "~1.0.3",
+				"@rc-component/table": "~1.9.1",
+				"@rc-component/tabs": "~1.7.0",
+				"@rc-component/textarea": "~1.1.2",
+				"@rc-component/tooltip": "~1.4.0",
+				"@rc-component/tour": "~2.3.0",
+				"@rc-component/tree": "~1.2.4",
+				"@rc-component/tree-select": "~1.8.0",
+				"@rc-component/trigger": "^3.9.0",
+				"@rc-component/upload": "~1.1.0",
+				"@rc-component/util": "^1.10.0",
+				"clsx": "^2.1.1",
+				"dayjs": "^1.11.11",
+				"scroll-into-view-if-needed": "^3.1.0",
+				"throttle-debounce": "^5.0.2"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ant-design"
+			},
+			"peerDependencies": {
+				"react": ">=18.0.0",
+				"react-dom": ">=18.0.0"
+			}
+		},
+		"node_modules/antd-style": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/antd-style/-/antd-style-4.1.0.tgz",
+			"integrity": "sha512-vnPBGg0OVlSz90KRYZhxd89aZiOImTiesF+9MQqN8jsLGZUQTjbP04X9jTdEfsztKUuMbBWg/RmB/wHTakbtMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ant-design/cssinjs": "^2.0.0",
+				"@babel/runtime": "^7.24.1",
+				"@emotion/cache": "^11.11.0",
+				"@emotion/css": "^11.11.2",
+				"@emotion/react": "^11.11.4",
+				"@emotion/serialize": "^1.1.3",
+				"@emotion/utils": "^1.2.1",
+				"use-merge-value": "^1.2.0"
+			},
+			"peerDependencies": {
+				"antd": ">=6.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/astring": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+			"integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"astring": "bin/astring"
+			}
+		},
+		"node_modules/attr-accept": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+			"integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/autoprefixer": {
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.28.1",
+				"caniuse-lite": "^1.0.30001774",
+				"fraction.js": "^5.3.4",
+				"picocolors": "^1.1.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"bin": {
+				"autoprefixer": "bin/autoprefixer"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.11",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
+			"integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001781",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+			"integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
+		"node_modules/ccount": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-html4": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/chevrotain": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+			"integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@chevrotain/cst-dts-gen": "11.1.2",
+				"@chevrotain/gast": "11.1.2",
+				"@chevrotain/regexp-to-ast": "11.1.2",
+				"@chevrotain/types": "11.1.2",
+				"@chevrotain/utils": "11.1.2",
+				"lodash-es": "4.17.23"
+			}
+		},
+		"node_modules/chevrotain-allstar": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lodash-es": "^4.17.21"
+			},
+			"peerDependencies": {
+				"chevrotain": "^11.0.0"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/chroma-js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+			"integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
+			"license": "(BSD-3-Clause AND Apache-2.0)",
+			"peer": true
+		},
+		"node_modules/class-variance-authority": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"clsx": "^2.1.1"
+			},
+			"funding": {
+				"url": "https://polar.sh/cva"
+			}
+		},
+		"node_modules/classcat": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+			"integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+			"license": "MIT"
+		},
+		"node_modules/classnames": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/codemirror": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+			"integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/commands": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/lint": "^6.0.0",
+				"@codemirror/search": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/comma-separated-tokens": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/compute-scroll-into-view": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+			"integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cookie-es": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
+			"integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
+			"license": "MIT"
+		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
+		},
+		"node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/yaml": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"license": "MIT"
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"license": "MIT"
+		},
+		"node_modules/cytoscape": {
+			"version": "3.33.1",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+			"integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-drag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+			"integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-selection": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-selection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-transition": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+			"integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-dispatch": "1 - 3",
+				"d3-ease": "1 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"d3-selection": "2 - 3"
+			}
+		},
+		"node_modules/d3-zoom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+			"integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "2 - 3",
+				"d3-transition": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
+			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+			"license": "MIT"
+		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/decode-uri-component": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+			"integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"license": "MIT"
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/didyoumean": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dompurify": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"peer": true,
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.328",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+			"integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/emoji-mart": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+			"integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-toolkit": {
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+			"integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
+		"node_modules/esast-util-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+			"integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/esast-util-from-js": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+			"integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"acorn": "^8.0.0",
+				"esast-util-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.25.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.25.12",
+				"@esbuild/android-arm": "0.25.12",
+				"@esbuild/android-arm64": "0.25.12",
+				"@esbuild/android-x64": "0.25.12",
+				"@esbuild/darwin-arm64": "0.25.12",
+				"@esbuild/darwin-x64": "0.25.12",
+				"@esbuild/freebsd-arm64": "0.25.12",
+				"@esbuild/freebsd-x64": "0.25.12",
+				"@esbuild/linux-arm": "0.25.12",
+				"@esbuild/linux-arm64": "0.25.12",
+				"@esbuild/linux-ia32": "0.25.12",
+				"@esbuild/linux-loong64": "0.25.12",
+				"@esbuild/linux-mips64el": "0.25.12",
+				"@esbuild/linux-ppc64": "0.25.12",
+				"@esbuild/linux-riscv64": "0.25.12",
+				"@esbuild/linux-s390x": "0.25.12",
+				"@esbuild/linux-x64": "0.25.12",
+				"@esbuild/netbsd-arm64": "0.25.12",
+				"@esbuild/netbsd-x64": "0.25.12",
+				"@esbuild/openbsd-arm64": "0.25.12",
+				"@esbuild/openbsd-x64": "0.25.12",
+				"@esbuild/openharmony-arm64": "0.25.12",
+				"@esbuild/sunos-x64": "0.25.12",
+				"@esbuild/win32-arm64": "0.25.12",
+				"@esbuild/win32-ia32": "0.25.12",
+				"@esbuild/win32-x64": "0.25.12"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/estree-util-attach-comments": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+			"integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-build-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+			"integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"estree-walker": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-is-identifier-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+			"integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-scope": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+			"integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-to-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+			"integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"astring": "^1.8.0",
+				"source-map": "^0.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-util-visit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+			"integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"license": "MIT"
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
+		"node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend-shallow/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/file-selector": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.5.0.tgz",
+			"integrity": "sha512-s8KNnmIDTBoD0p9uJ9uD0XY38SCeBOtj0UMXyQSLg1Ypfrfj8+dAvwsLjYQkQ2GjhVtp2HrnF5cJzMhBjfD8HA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/filter-obj": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+			"integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"license": "MIT"
+		},
+		"node_modules/for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fraction.js": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
+		"node_modules/framer-motion": {
+			"version": "12.38.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+			"integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+			"license": "MIT",
+			"dependencies": {
+				"motion-dom": "^12.38.0",
+				"motion-utils": "^12.36.0",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/giscus": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+			"integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lit": "^3.2.1"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/goober": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+			"integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"csstype": "^3.0.10"
+			}
+		},
+		"node_modules/graphology": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+			"integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+			"license": "MIT",
+			"dependencies": {
+				"events": "^3.3.0"
+			},
+			"peerDependencies": {
+				"graphology-types": ">=0.24.0"
+			}
+		},
+		"node_modules/graphology-layout-forceatlas2": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/graphology-layout-forceatlas2/-/graphology-layout-forceatlas2-0.10.1.tgz",
+			"integrity": "sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"graphology-utils": "^2.1.0"
+			},
+			"peerDependencies": {
+				"graphology-types": ">=0.19.0"
+			}
+		},
+		"node_modules/graphology-types": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+			"integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+			"license": "MIT"
+		},
+		"node_modules/graphology-utils": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+			"integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"graphology-types": ">=0.23.0"
+			}
+		},
+		"node_modules/hachure-fill": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hast-util-from-dom": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+			"integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hastscript": "^9.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"devlop": "^1.1.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"parse5": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html-isomorphic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+			"integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-from-dom": "^5.0.0",
+				"hast-util-from-html": "^2.0.0",
+				"unist-util-remove-position": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-parse5": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+			"integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"property-information": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-location": "^5.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-is-element": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+			"integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+			"integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"hast-util-to-parse5": "^8.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"parse5": "^7.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-estree": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+			"integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-attach-comments": "^3.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-jsx-runtime": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+			"integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"style-to-js": "^1.0.0",
+				"unist-util-position": "^5.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+			"integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-text": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+			"integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"unist-util-find-after": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-whitespace": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hastscript": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+			"integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hoist-non-react-statics": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"react-is": "^16.7.0"
+			}
+		},
+		"node_modules/hoist-non-react-statics/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT"
+		},
+		"node_modules/html-url-attributes": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+			"integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/immer": {
+			"version": "11.1.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+			"integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/immutable": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/inline-style-parser": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+			"license": "MIT"
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/intersection-observer": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.12.2.tgz",
+			"integrity": "sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==",
+			"deprecated": "The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"license": "MIT"
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-extendable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-mobile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+			"integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+			"license": "MIT"
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"isobject": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isbot": {
+			"version": "5.1.36",
+			"resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.36.tgz",
+			"integrity": "sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==",
+			"license": "Unlicense",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
+		"node_modules/js-cookie": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"license": "MIT"
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"license": "MIT"
+		},
+		"node_modules/json2mq": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+			"integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"string-convert": "^0.2.0"
+			}
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/katex": {
+			"version": "0.16.44",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
+			"integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+			"peer": true
+		},
+		"node_modules/langium": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+			"integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"chevrotain": "~11.1.1",
+				"chevrotain-allstar": "~0.3.1",
+				"vscode-languageserver": "~9.0.1",
+				"vscode-languageserver-textdocument": "~1.0.11",
+				"vscode-uri": "~3.1.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/leva": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
+			"integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@radix-ui/react-portal": "^1.1.4",
+				"@radix-ui/react-tooltip": "^1.1.8",
+				"@stitches/react": "^1.2.8",
+				"@use-gesture/react": "^10.2.5",
+				"colord": "^2.9.2",
+				"dequal": "^2.0.2",
+				"merge-value": "^1.0.0",
+				"react-colorful": "^5.5.1",
+				"react-dropzone": "^12.0.0",
+				"v8n": "^1.3.3",
+				"zustand": "^3.6.9"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/leva/node_modules/zustand": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+			"integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"license": "MIT"
+		},
+		"node_modules/lit": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+			"integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit/reactive-element": "^2.1.0",
+				"lit-element": "^4.2.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-element": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+			"integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@lit-labs/ssr-dom-shim": "^1.5.0",
+				"@lit/reactive-element": "^2.1.0",
+				"lit-html": "^3.3.0"
+			}
+		},
+		"node_modules/lit-html": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+			"integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lodash-es": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru_map": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+			"integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lucide-react": {
+			"version": "0.562.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+			"integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/markdown-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+			"integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdown-table": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/marked": {
+			"version": "17.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+			"integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-gfm-autolink-literal": "^2.0.0",
+				"mdast-util-gfm-footnote": "^2.0.0",
+				"mdast-util-gfm-strikethrough": "^2.0.0",
+				"mdast-util-gfm-table": "^2.0.0",
+				"mdast-util-gfm-task-list-item": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-autolink-literal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"micromark-util-character": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-strikethrough": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"markdown-table": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-task-list-item": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-math": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+			"integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.1.0",
+				"unist-util-remove-position": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+			"integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-mdx-expression": "^2.0.0",
+				"mdast-util-mdx-jsx": "^3.0.0",
+				"mdast-util-mdxjs-esm": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-expression": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+			"integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdx-jsx": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+			"integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"parse-entities": "^4.0.0",
+				"stringify-entities": "^4.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-mdxjs-esm": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+			"integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree-jsx": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-newline-to-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+			"integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-hast": {
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+			"integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"trim-lines": "^3.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/merge-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
+			"integrity": "sha512-fJMmvat4NeKz63Uv9iHWcPDjCWcCkoiRoajRTEO8hlhUC6rwaHg0QCF9hBOTjZmm4JuglPckPSTtcuJL5kp0TQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"get-value": "^2.0.6",
+				"is-extendable": "^1.0.0",
+				"mixin-deep": "^1.2.0",
+				"set-value": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/mermaid": {
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
+			"integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@braintree/sanitize-url": "^7.1.1",
+				"@iconify/utils": "^3.0.2",
+				"@mermaid-js/parser": "^1.0.1",
+				"@types/d3": "^7.4.3",
+				"@upsetjs/venn.js": "^2.0.0",
+				"cytoscape": "^3.33.1",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"cytoscape-fcose": "^2.2.0",
+				"d3": "^7.9.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.14",
+				"dayjs": "^1.11.19",
+				"dompurify": "^3.3.1",
+				"katex": "^0.16.25",
+				"khroma": "^2.1.0",
+				"lodash-es": "^4.17.23",
+				"marked": "^16.3.0",
+				"roughjs": "^4.6.6",
+				"stylis": "^4.3.6",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^11.1.0"
+			}
+		},
+		"node_modules/mermaid/node_modules/marked": {
+			"version": "16.4.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/mermaid/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-cjk-friendly": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
+			"integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"devlop": "^1.1.0",
+				"micromark-extension-cjk-friendly-util": "2.1.1",
+				"micromark-util-chunked": "^2.0.1",
+				"micromark-util-resolve-all": "^2.0.1",
+				"micromark-util-symbol": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"micromark": "^4.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"micromark-util-types": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/micromark-extension-cjk-friendly-util": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-2.1.1.tgz",
+			"integrity": "sha512-egs6+12JU2yutskHY55FyR48ZiEcFOJFyk9rsiyIhcJ6IvWB6ABBqVrBw8IobqJTDZ/wdSr9eoXDPb5S2nW1bg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"get-east-asian-width": "^1.3.0",
+				"micromark-util-character": "^2.1.1",
+				"micromark-util-symbol": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependenciesMeta": {
+				"micromark-util-types": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/micromark-extension-gfm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-extension-gfm-autolink-literal": "^2.0.0",
+				"micromark-extension-gfm-footnote": "^2.0.0",
+				"micromark-extension-gfm-strikethrough": "^2.0.0",
+				"micromark-extension-gfm-table": "^2.0.0",
+				"micromark-extension-gfm-tagfilter": "^2.0.0",
+				"micromark-extension-gfm-task-list-item": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-strikethrough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-tagfilter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-task-list-item": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-math": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+			"integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/katex": "^0.16.0",
+				"devlop": "^1.0.0",
+				"katex": "^0.16.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-expression": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+			"integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-mdx-jsx": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+			"integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-is-identifier-name": "^3.0.0",
+				"micromark-factory-mdx-expression": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdx-md": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+			"integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+			"integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.0.0",
+				"acorn-jsx": "^5.0.0",
+				"micromark-extension-mdx-expression": "^3.0.0",
+				"micromark-extension-mdx-jsx": "^3.0.0",
+				"micromark-extension-mdx-md": "^2.0.0",
+				"micromark-extension-mdxjs-esm": "^3.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-mdxjs-esm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+			"integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-mdx-expression": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+			"integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-events-to-acorn": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-position-from-estree": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-events-to-acorn": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+			"integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"estree-util-visit": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+			"integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.3"
+			}
+		},
+		"node_modules/motion": {
+			"version": "12.38.0",
+			"resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+			"integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"framer-motion": "^12.38.0",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/motion-dom": {
+			"version": "12.38.0",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+			"integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+			"license": "MIT",
+			"dependencies": {
+				"motion-utils": "^12.36.0"
+			}
+		},
+		"node_modules/motion-utils": {
+			"version": "12.36.0",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+			"integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+			"license": "MIT"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.36",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/on-change": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.2.tgz",
+			"integrity": "sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/on-change?sponsor=1"
+			}
+		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+			"integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+			"integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"oniguruma-parser": "^0.12.1",
+				"regex": "^6.1.0",
+				"regex-recursion": "^6.0.2"
+			}
+		},
+		"node_modules/package-manager-detector": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/parse-entities/node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/path-data-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"license": "MIT"
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/points-on-curve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/points-on-path": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-data-parser": "0.1.0",
+				"points-on-curve": "0.2.0"
+			}
+		},
+		"node_modules/polished": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+			"integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.17.8"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-import": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-js": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+			"integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"camelcase-css": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || >= 16"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
+			}
+		},
+		"node_modules/postcss-nested": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.14"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/prop-types/node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/property-information": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+			"integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/query-string": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
+			"integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"decode-uri-component": "^0.4.1",
+				"filter-obj": "^5.1.0",
+				"split-on-first": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/rc-collapse": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-4.0.0.tgz",
+			"integrity": "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"classnames": "2.x",
+				"rc-motion": "^2.3.4",
+				"rc-util": "^5.27.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-dialog": {
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+			"integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/portal": "^1.0.0-8",
+				"classnames": "^2.2.6",
+				"rc-motion": "^2.3.0",
+				"rc-util": "^5.21.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-dialog/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-footer": {
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/rc-footer/-/rc-footer-0.6.8.tgz",
+			"integrity": "sha512-JBZ+xcb6kkex8XnBd4VHw1ZxjV6kmcwUumSHaIFdka2qzMCo7Klcy4sI6G0XtUpG/vtpislQCc+S9Bc+NLHYMg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/rc-image": {
+			"version": "7.12.0",
+			"resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
+			"integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.2",
+				"@rc-component/portal": "^1.0.2",
+				"classnames": "^2.2.6",
+				"rc-dialog": "~9.6.0",
+				"rc-motion": "^2.6.2",
+				"rc-util": "^5.34.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-image/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-input": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
+			"integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.18.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.0.0",
+				"react-dom": ">=16.0.0"
+			}
+		},
+		"node_modules/rc-input-number": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
+			"integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/mini-decimal": "^1.0.1",
+				"classnames": "^2.2.5",
+				"rc-input": "~1.8.0",
+				"rc-util": "^5.40.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu": {
+			"version": "9.16.1",
+			"resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
+			"integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.10.1",
+				"@rc-component/trigger": "^2.0.0",
+				"classnames": "2.x",
+				"rc-motion": "^2.4.3",
+				"rc-overflow": "^1.3.1",
+				"rc-util": "^5.27.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu/node_modules/@rc-component/portal": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+			"integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.0",
+				"classnames": "^2.3.2",
+				"rc-util": "^5.24.4"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-menu/node_modules/@rc-component/trigger": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
+			"integrity": "sha512-ORENF39PeXTzM+gQEshuk460Z8N4+6DkjpxlpE7Q3gYy1iBpLrx0FOJz3h62ryrJZ/3zCAUIkT1Pb/8hHWpb3A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.23.2",
+				"@rc-component/portal": "^1.1.0",
+				"classnames": "^2.3.2",
+				"rc-motion": "^2.0.0",
+				"rc-resize-observer": "^1.3.1",
+				"rc-util": "^5.44.0"
+			},
+			"engines": {
+				"node": ">=8.x"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-motion": {
+			"version": "2.9.5",
+			"resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
+			"integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.44.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-overflow": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
+			"integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.11.1",
+				"classnames": "^2.2.1",
+				"rc-resize-observer": "^1.0.0",
+				"rc-util": "^5.37.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-resize-observer": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+			"integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.20.7",
+				"classnames": "^2.2.1",
+				"rc-util": "^5.44.1",
+				"resize-observer-polyfill": "^1.5.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-util": {
+			"version": "5.44.4",
+			"resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+			"integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"react-is": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.9.0",
+				"react-dom": ">=16.9.0"
+			}
+		},
+		"node_modules/rc-util/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/re-resizable": {
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+			"integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react": {
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-avatar-editor": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/react-avatar-editor/-/react-avatar-editor-14.0.0.tgz",
+			"integrity": "sha512-NaQM3oo4u0a1/Njjutc2FjwKX35vQV+t6S8hovsbAlMpBN1ntIwP/g+Yr9eDIIfaNtRXL0AqboTnPmRxhD/i8A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^0.14.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-colorful": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+			"license": "MIT",
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.4"
+			}
+		},
+		"node_modules/react-draggable": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+			"integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"clsx": "^2.1.1",
+				"prop-types": "^15.8.1"
+			},
+			"peerDependencies": {
+				"react": ">= 16.3.0",
+				"react-dom": ">= 16.3.0"
+			}
+		},
+		"node_modules/react-dropzone": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-12.1.0.tgz",
+			"integrity": "sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"attr-accept": "^2.2.2",
+				"file-selector": "^0.5.0",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">= 10.13"
+			},
+			"peerDependencies": {
+				"react": ">= 16.8"
+			}
+		},
+		"node_modules/react-error-boundary": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+			"integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/react-fast-compare": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+			"integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/react-hook-form": {
+			"version": "7.72.0",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+			"integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-hook-form"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17 || ^18 || ^19"
+			}
+		},
+		"node_modules/react-hotkeys-hook": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.2.4.tgz",
+			"integrity": "sha512-BgKg+A1+TawkYluh5Bo4cTmcgMN5L29uhJbDUQdHwPX+qgXRjIPYU5kIDHyxnAwCkCBiu9V5OpB2mpyeluVF2A==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/react-is": {
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+			"integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/react-markdown": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+			"integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"hast-util-to-jsx-runtime": "^2.0.0",
+				"html-url-attributes": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-rehype": "^11.0.0",
+				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"@types/react": ">=18",
+				"react": ">=18"
+			}
+		},
+		"node_modules/react-merge-refs": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-3.0.2.tgz",
+			"integrity": "sha512-MSZAfwFfdbEvwkKWP5EI5chuLYnNUxNS7vyS0i1Jp+wtd8J4Ga2ddzhaE68aMol2Z4vCnRM/oGOo1a3V75UPlw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/gregberge"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-redux": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/use-sync-external-store": "^0.0.6",
+				"use-sync-external-store": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.2.25 || ^19",
+				"react": "^18.0 || ^19",
+				"redux": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"redux": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-refresh": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+			"integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.2",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-rnd": {
+			"version": "10.5.3",
+			"resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.3.tgz",
+			"integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"re-resizable": "^6.11.2",
+				"react-draggable": "^4.5.0",
+				"tslib": "2.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.3.0",
+				"react-dom": ">=16.3.0"
+			}
+		},
+		"node_modules/react-rnd/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-zoom-pan-pinch": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+			"integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8",
+				"npm": ">=5"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-dom": "*"
+			}
+		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/recharts": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+			"license": "MIT",
+			"workspaces": [
+				"www"
+			],
+			"dependencies": {
+				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+				"clsx": "^2.1.1",
+				"decimal.js-light": "^2.5.1",
+				"es-toolkit": "^1.39.3",
+				"eventemitter3": "^5.0.1",
+				"immer": "^10.1.1",
+				"react-redux": "8.x.x || 9.x.x",
+				"reselect": "5.1.1",
+				"tiny-invariant": "^1.3.3",
+				"use-sync-external-store": "^1.2.2",
+				"victory-vendor": "^37.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/recharts/node_modules/immer": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/recma-build-jsx": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+			"integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-build-jsx": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-jsx": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+			"integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"acorn-jsx": "^5.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"recma-parse": "^1.0.0",
+				"recma-stringify": "^1.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			},
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/recma-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+			"integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"esast-util-from-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/recma-stringify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+			"integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-util-to-js": "^2.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/redux": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"license": "MIT"
+		},
+		"node_modules/redux-thunk": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"redux": "^5.0.0"
+			}
+		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/rehype-github-alerts": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/rehype-github-alerts/-/rehype-github-alerts-4.2.0.tgz",
+			"integrity": "sha512-6di6kEu9WUHKLKrkKG2xX6AOuaCMGghg0Wq7MEuM/jBYUPVIq6PJpMe00dxMfU+/YSBtDXhffpDimgDi+BObIQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@primer/octicons": "^19.20.0",
+				"hast-util-from-html": "^2.0.3",
+				"hast-util-is-element": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/chrisweb"
+			}
+		},
+		"node_modules/rehype-katex": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+			"integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/katex": "^0.16.0",
+				"hast-util-from-html-isomorphic": "^2.0.0",
+				"hast-util-to-text": "^4.0.0",
+				"katex": "^0.16.0",
+				"unist-util-visit-parents": "^6.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-raw": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+			"integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-raw": "^9.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-recma": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+			"integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"@types/hast": "^3.0.0",
+				"hast-util-to-estree": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-breaks": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+			"integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-newline-to-break": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-cjk-friendly": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
+			"integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"micromark-extension-cjk-friendly": "1.2.3"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"@types/mdast": "^4.0.0",
+				"unified": "^11.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/mdast": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/remark-gfm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-gfm": "^3.0.0",
+				"micromark-extension-gfm": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-github": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/remark-github/-/remark-github-12.0.0.tgz",
+			"integrity": "sha512-ByefQKFN184LeiGRCabfl7zUJsdlMYWEhiLX1gpmQ11yFg6xSuOTW7LVCv0oc1x+YvUMJW23NU36sJX2RWGgvg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"to-vfile": "^8.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-math": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+			"integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-math": "^3.0.0",
+				"micromark-extension-math": "^3.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-mdx": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+			"integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mdast-util-mdx": "^3.0.0",
+				"micromark-extension-mdxjs": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-rehype": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+			"integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"unified": "^11.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remend": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz",
+			"integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/reselect": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"license": "MIT"
+		},
+		"node_modules/resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"license": "Unlicense",
+			"peer": true
+		},
+		"node_modules/rollup": {
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+			"integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.60.0",
+				"@rollup/rollup-android-arm64": "4.60.0",
+				"@rollup/rollup-darwin-arm64": "4.60.0",
+				"@rollup/rollup-darwin-x64": "4.60.0",
+				"@rollup/rollup-freebsd-arm64": "4.60.0",
+				"@rollup/rollup-freebsd-x64": "4.60.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.0",
+				"@rollup/rollup-linux-arm64-musl": "4.60.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.0",
+				"@rollup/rollup-linux-loong64-musl": "4.60.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.0",
+				"@rollup/rollup-linux-x64-gnu": "4.60.0",
+				"@rollup/rollup-linux-x64-musl": "4.60.0",
+				"@rollup/rollup-openbsd-x64": "4.60.0",
+				"@rollup/rollup-openharmony-arm64": "4.60.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.0",
+				"@rollup/rollup-win32-x64-gnu": "4.60.0",
+				"@rollup/rollup-win32-x64-msvc": "4.60.0",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/roughjs": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"hachure-fill": "^0.5.2",
+				"path-data-parser": "^0.1.0",
+				"points-on-curve": "^0.2.0",
+				"points-on-path": "^0.2.1"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/sass": {
+			"version": "1.98.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+			"integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^4.0.0",
+				"immutable": "^5.1.5",
+				"source-map-js": ">=0.6.2 <2.0.0"
+			},
+			"bin": {
+				"sass": "sass.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher": "^2.4.1"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT"
+		},
+		"node_modules/screenfull": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+			"integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/scroll-into-view-if-needed": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+			"integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"compute-scroll-into-view": "^3.0.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/seroval": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
+			"integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/seroval-plugins": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.1.tgz",
+			"integrity": "sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"seroval": "^1.0"
+			}
+		},
+		"node_modules/set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+			"integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "3.23.0",
+				"@shikijs/engine-javascript": "3.23.0",
+				"@shikijs/engine-oniguruma": "3.23.0",
+				"@shikijs/langs": "3.23.0",
+				"@shikijs/themes": "3.23.0",
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/shiki-stream": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/shiki-stream/-/shiki-stream-0.1.4.tgz",
+			"integrity": "sha512-4pz6JGSDmVTTkPJ/ueixHkFAXY4ySCc+unvCaDZV7hqq/sdJZirRxgIXSuNSKgiFlGTgRR97sdu2R8K55sPsrw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@shikijs/core": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"react": "^19.0.0",
+				"solid-js": "^1.9.0",
+				"vue": "^3.2.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/sigma": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.2.tgz",
+			"integrity": "sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ==",
+			"license": "MIT",
+			"dependencies": {
+				"events": "^3.3.0",
+				"graphology-utils": "^2.5.2"
+			}
+		},
+		"node_modules/smol-toml": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
+		"node_modules/sonner": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+			"integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+				"react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/space-separated-tokens": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/split-on-first": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+			"integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"extend-shallow": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split-string/node_modules/extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string-convert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+			"integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/stringify-entities": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+			"license": "MIT",
+			"dependencies": {
+				"character-entities-html4": "^2.0.0",
+				"character-entities-legacy": "^3.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"license": "MIT"
+		},
+		"node_modules/style-to-js": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"style-to-object": "1.0.14"
+			}
+		},
+		"node_modules/style-to-object": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+			"license": "MIT",
+			"dependencies": {
+				"inline-style-parser": "0.2.7"
+			}
+		},
+		"node_modules/stylis": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+			"license": "MIT"
+		},
+		"node_modules/sucrase": {
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+			"integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"commander": "^4.0.0",
+				"lines-and-columns": "^1.1.6",
+				"mz": "^2.7.0",
+				"pirates": "^4.0.1",
+				"tinyglobby": "^0.2.11",
+				"ts-interface-checker": "^0.1.9"
+			},
+			"bin": {
+				"sucrase": "bin/sucrase",
+				"sucrase-node": "bin/sucrase-node"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/sucrase/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/swr": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+			"integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tailwindcss": {
+			"version": "3.4.19",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+			"integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
+				"arg": "^5.0.2",
+				"chokidar": "^3.6.0",
+				"didyoumean": "^1.2.2",
+				"dlv": "^1.1.3",
+				"fast-glob": "^3.3.2",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"jiti": "^1.21.7",
+				"lilconfig": "^3.1.3",
+				"micromatch": "^4.0.8",
+				"normalize-path": "^3.0.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.1.1",
+				"postcss": "^8.4.47",
+				"postcss-import": "^15.1.0",
+				"postcss-js": "^4.0.1",
+				"postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+				"postcss-nested": "^6.2.0",
+				"postcss-selector-parser": "^6.1.2",
+				"resolve": "^1.22.8",
+				"sucrase": "^3.35.0"
+			},
+			"bin": {
+				"tailwind": "lib/cli.js",
+				"tailwindcss": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tailwindcss-animate": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+			"integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"tailwindcss": ">=3.0.0 || insiders"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/postcss-load-config": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^3.1.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"jiti": ">=1.21.0",
+				"postcss": ">=8.0.9",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tailwindcss/node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/throttle-debounce": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+			"integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.22"
+			}
+		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/to-vfile": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-8.0.0.tgz",
+			"integrity": "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/trim-lines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
+		"node_modules/ts-interface-checker": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/ts-md5": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
+			"integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/ufo": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-find-after": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+			"integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-position-from-estree": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+			"integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove-position": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+			"integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-merge-value": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-merge-value/-/use-merge-value-1.2.0.tgz",
+			"integrity": "sha512-DXgG0kkgJN45TcyoXL49vJnn55LehnrmoHc7MbKi+QDBvr8dsesqws8UlyIWGHMR+JXgxc1nvY+jDGMlycsUcw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">= 16.x"
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/v8n": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/v8n/-/v8n-1.5.1.tgz",
+			"integrity": "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-location": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+			"integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/victory-vendor": {
+			"version": "37.3.6",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+			"integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+			"license": "MIT AND ISC",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
+			}
+		},
+		"node_modules/virtua": {
+			"version": "0.48.8",
+			"resolved": "https://registry.npmjs.org/virtua/-/virtua-0.48.8.tgz",
+			"integrity": "sha512-jpsxOw5V4B6hg44JePRLo9DL0TV7N1lBEVtPjKpAJebXyhI2s9lfiXJESaLapNtr3vtiSk/pWHiLf7B2a6UcgQ==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"react": ">=16.14.0",
+				"react-dom": ">=16.14.0",
+				"solid-js": ">=1.0",
+				"svelte": ">=5.0",
+				"vue": ">=3.2"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"solid-js": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2",
+				"postcss": "^8.5.3",
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.13"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"jiti": ">=1.21.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"license": "MIT"
+		},
+		"node_modules/web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zustand": {
+			"version": "4.5.7",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+			"integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+			"license": "MIT",
+			"dependencies": {
+				"use-sync-external-store": "^1.2.2"
+			},
+			"engines": {
+				"node": ">=12.7.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8",
+				"immer": ">=9.0.6",
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		}
+	}
+}

--- a/interface/src/components/AgentTabs.tsx
+++ b/interface/src/components/AgentTabs.tsx
@@ -2,14 +2,13 @@ import { Link, useMatchRoute } from "@tanstack/react-router";
 import { motion } from "framer-motion";
 
 const tabs = [
-	{ label: "Overview", to: "/agents/$agentId" as const, exact: true },
+	{ label: "Board", to: "/agents/$agentId" as const, exact: true },
+	{ label: "Overview", to: "/agents/$agentId/overview" as const, exact: false },
 	{ label: "Chat", to: "/agents/$agentId/chat" as const, exact: false },
 	{ label: "Channels", to: "/agents/$agentId/channels" as const, exact: false },
 	{ label: "Memories", to: "/agents/$agentId/memories" as const, exact: false },
-	{ label: "Ingest", to: "/agents/$agentId/ingest" as const, exact: false },
 	{ label: "Workers", to: "/agents/$agentId/workers" as const, exact: false },
 	{ label: "Projects", to: "/agents/$agentId/projects" as const, exact: false },
-	{ label: "Tasks", to: "/agents/$agentId/tasks" as const, exact: false },
 	{ label: "Cortex", to: "/agents/$agentId/cortex" as const, exact: false },
 	{ label: "Skills", to: "/agents/$agentId/skills" as const, exact: false },
 	{ label: "Cron", to: "/agents/$agentId/cron" as const, exact: false },

--- a/interface/src/components/DiffViewer.tsx
+++ b/interface/src/components/DiffViewer.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+
+interface DiffViewerProps {
+	diff: string;
+	maxHeight?: string;
+}
+
+interface DiffLine {
+	type: "add" | "remove" | "context" | "header" | "hunk";
+	content: string;
+	lineNumber?: number;
+}
+
+export function DiffViewer({ diff, maxHeight = "400px" }: DiffViewerProps) {
+	const lines = useMemo(() => parseDiff(diff), [diff]);
+
+	if (!diff.trim()) {
+		return (
+			<div className="flex items-center justify-center rounded-md border border-app-line bg-app-darkBox p-4 text-sm text-ink-faint">
+				No changes to display
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="overflow-auto rounded-md border border-app-line bg-app-darkBox font-mono text-xs"
+			style={{ maxHeight }}
+		>
+			{lines.map((line, i) => (
+				<div
+					key={i}
+					className={`whitespace-pre px-3 py-0.5 ${lineClass(line.type)}`}
+				>
+					{line.content}
+				</div>
+			))}
+		</div>
+	);
+}
+
+function lineClass(type: DiffLine["type"]): string {
+	switch (type) {
+		case "add":
+			return "bg-emerald-500/10 text-emerald-300";
+		case "remove":
+			return "bg-red-500/10 text-red-300";
+		case "header":
+			return "bg-accent/10 text-accent font-semibold sticky top-0";
+		case "hunk":
+			return "bg-app-box text-ink-faint";
+		default:
+			return "text-ink-dull";
+	}
+}
+
+function parseDiff(raw: string): DiffLine[] {
+	return raw.split("\n").map((content) => {
+		if (content.startsWith("+++") || content.startsWith("---")) {
+			return { type: "header" as const, content };
+		}
+		if (content.startsWith("diff ")) {
+			return { type: "header" as const, content };
+		}
+		if (content.startsWith("@@")) {
+			return { type: "hunk" as const, content };
+		}
+		if (content.startsWith("+")) {
+			return { type: "add" as const, content };
+		}
+		if (content.startsWith("-")) {
+			return { type: "remove" as const, content };
+		}
+		return { type: "context" as const, content };
+	});
+}

--- a/interface/src/components/Sidebar.tsx
+++ b/interface/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { api } from "@/api/client";
 import type { ChannelLiveState } from "@/hooks/useChannelLiveState";
 import { useAgentOrder } from "@/hooks/useAgentOrder";
-import { DashboardSquare01Icon, Settings01Icon } from "@hugeicons/core-free-icons";
+import { DashboardSquare01Icon, Settings01Icon, Dollar02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CreateAgentDialog } from "@/components/CreateAgentDialog";
 import { ProfileAvatar } from "@/components/ProfileAvatar";
@@ -112,6 +112,7 @@ export function Sidebar({ liveStates: _liveStates }: SidebarProps) {
 	const matchRoute = useMatchRoute();
 	const isOverview = matchRoute({ to: "/" });
 	const isSettings = matchRoute({ to: "/settings" });
+	const isPricing = matchRoute({ to: "/pricing" });
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
@@ -155,6 +156,15 @@ export function Sidebar({ liveStates: _liveStates }: SidebarProps) {
 					title="Settings"
 				>
 					<HugeiconsIcon icon={Settings01Icon} className="h-4 w-4" />
+				</Link>
+				<Link
+					to="/pricing"
+					className={`flex h-8 w-8 items-center justify-center rounded-md ${
+						isPricing ? "bg-sidebar-selected text-sidebar-ink" : "text-sidebar-inkDull hover:bg-sidebar-selected/50"
+					}`}
+					title="Pricing"
+				>
+					<HugeiconsIcon icon={Dollar02Icon} className="h-4 w-4" />
 				</Link>
 				<div className="my-1 h-px w-5 bg-sidebar-line" />
 				<DndContext

--- a/interface/src/components/TaskDependencyGraph.tsx
+++ b/interface/src/components/TaskDependencyGraph.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useRef, useCallback, useState } from "react";
+import Graph from "graphology";
+import Sigma from "sigma";
+import { EdgeArrowProgram } from "sigma/rendering";
+import type { TaskItem } from "@/api/client";
+
+const STATUS_COLORS: Record<string, string> = {
+	pending_approval: "#f59e0b",
+	backlog: "#6b7280",
+	ready: "#3b82f6",
+	in_progress: "#a855f7",
+	done: "#22c55e",
+};
+
+const PRIORITY_SIZES: Record<string, number> = {
+	critical: 14,
+	high: 11,
+	medium: 8,
+	low: 6,
+};
+
+interface TaskDependencyGraphProps {
+	tasks: TaskItem[];
+	onSelectTask?: (taskNumber: number) => void;
+}
+
+export function TaskDependencyGraph({
+	tasks,
+	onSelectTask,
+}: TaskDependencyGraphProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const sigmaRef = useRef<Sigma | null>(null);
+	const graphRef = useRef<Graph | null>(null);
+	const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+
+	const buildGraph = useCallback(() => {
+		const graph = new Graph({ type: "directed" });
+
+		// Add nodes
+		for (const task of tasks) {
+			const key = String(task.task_number);
+			const deps = getDeps(task);
+			const isBlocked =
+				deps.length > 0 &&
+				deps.some((d) => {
+					const dt = tasks.find((t) => t.task_number === d);
+					return dt && dt.status !== "done";
+				});
+
+			graph.addNode(key, {
+				label: `#${task.task_number} ${task.title.slice(0, 25)}${task.title.length > 25 ? "…" : ""}`,
+				size: PRIORITY_SIZES[task.priority] ?? 8,
+				color: isBlocked ? "#ef4444" : (STATUS_COLORS[task.status] ?? "#6b7280"),
+				x: Math.random() * 10,
+				y: Math.random() * 10,
+			});
+		}
+
+		// Add edges (dependency → task)
+		for (const task of tasks) {
+			const deps = getDeps(task);
+			for (const depNum of deps) {
+				const depKey = String(depNum);
+				const taskKey = String(task.task_number);
+				if (graph.hasNode(depKey) && graph.hasNode(taskKey)) {
+					const edgeKey = `${depKey}->${taskKey}`;
+					if (!graph.hasEdge(edgeKey)) {
+						graph.addEdgeWithKey(edgeKey, depKey, taskKey, {
+							color: "#555555",
+							size: 2,
+						});
+					}
+				}
+			}
+		}
+
+		return graph;
+	}, [tasks]);
+
+	// Simple force-directed layout (no worker needed for small graphs)
+	const applyLayout = useCallback((graph: Graph) => {
+		const nodes = graph.nodes();
+		const positions: Record<string, { x: number; y: number }> = {};
+
+		// Initialize positions
+		for (const node of nodes) {
+			positions[node] = {
+				x: graph.getNodeAttribute(node, "x"),
+				y: graph.getNodeAttribute(node, "y"),
+			};
+		}
+
+		// Simple force iterations
+		for (let iter = 0; iter < 100; iter++) {
+			// Repulsion between all nodes
+			for (let i = 0; i < nodes.length; i++) {
+				for (let j = i + 1; j < nodes.length; j++) {
+					const a = positions[nodes[i]];
+					const b = positions[nodes[j]];
+					const dx = b.x - a.x;
+					const dy = b.y - a.y;
+					const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 0.1);
+					const force = 2 / (dist * dist);
+					const fx = (dx / dist) * force;
+					const fy = (dy / dist) * force;
+					a.x -= fx;
+					a.y -= fy;
+					b.x += fx;
+					b.y += fy;
+				}
+			}
+
+			// Attraction along edges
+			graph.forEachEdge((_edge, _attrs, source, target) => {
+				const a = positions[source];
+				const b = positions[target];
+				const dx = b.x - a.x;
+				const dy = b.y - a.y;
+				const dist = Math.sqrt(dx * dx + dy * dy);
+				const force = dist * 0.05;
+				const fx = (dx / Math.max(dist, 0.1)) * force;
+				const fy = (dy / Math.max(dist, 0.1)) * force;
+				a.x += fx;
+				a.y += fy;
+				b.x -= fx;
+				b.y -= fy;
+			});
+		}
+
+		// Apply positions
+		for (const node of nodes) {
+			graph.setNodeAttribute(node, "x", positions[node].x);
+			graph.setNodeAttribute(node, "y", positions[node].y);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (!containerRef.current) return;
+
+		// Only show graph if there are dependencies
+		const hasDeps = tasks.some((t) => getDeps(t).length > 0);
+		if (!hasDeps) return;
+
+		const graph = buildGraph();
+		applyLayout(graph);
+		graphRef.current = graph;
+
+		const sigma = new Sigma(graph, containerRef.current, {
+			defaultEdgeType: "arrow",
+			edgeProgramClasses: { arrow: EdgeArrowProgram },
+			labelColor: { color: "#e0e0e0" },
+			labelFont: "JetBrains Mono, monospace",
+			labelSize: 11,
+			labelRenderedSizeThreshold: 4,
+			defaultNodeColor: "#6b7280",
+			defaultEdgeColor: "#555555",
+			stagePadding: 40,
+		});
+
+		sigma.on("clickNode", ({ node }) => {
+			onSelectTask?.(parseInt(node, 10));
+		});
+
+		sigma.on("enterNode", ({ node }) => setHoveredNode(node));
+		sigma.on("leaveNode", () => setHoveredNode(null));
+
+		sigmaRef.current = sigma;
+
+		return () => {
+			sigma.kill();
+			sigmaRef.current = null;
+			graphRef.current = null;
+		};
+	}, [tasks, buildGraph, applyLayout, onSelectTask]);
+
+	const hasDeps = tasks.some((t) => getDeps(t).length > 0);
+
+	if (!hasDeps) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-ink-faint">
+				No task dependencies to visualize
+			</div>
+		);
+	}
+
+	return (
+		<div className="relative h-full w-full">
+			<div ref={containerRef} className="h-full w-full" />
+			{/* Legend */}
+			<div className="absolute bottom-3 left-3 flex flex-wrap gap-2 rounded-md bg-app/80 px-3 py-2 backdrop-blur-sm">
+				{Object.entries(STATUS_COLORS).map(([status, color]) => (
+					<div key={status} className="flex items-center gap-1">
+						<span
+							className="inline-block h-2.5 w-2.5 rounded-full"
+							style={{ backgroundColor: color }}
+						/>
+						<span className="text-tiny text-ink-faint">
+							{status.replace("_", " ")}
+						</span>
+					</div>
+				))}
+				<div className="flex items-center gap-1">
+					<span className="inline-block h-2.5 w-2.5 rounded-full bg-red-500" />
+					<span className="text-tiny text-ink-faint">blocked</span>
+				</div>
+			</div>
+			{/* Hover tooltip */}
+			{hoveredNode && (
+				<div className="absolute right-3 top-3 rounded-md bg-app-box/90 px-3 py-2 text-xs text-ink backdrop-blur-sm">
+					Task #{hoveredNode}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function getDeps(task: TaskItem): number[] {
+	const deps = task.metadata?.depends_on;
+	if (Array.isArray(deps))
+		return deps.filter((n): n is number => typeof n === "number");
+	return [];
+}

--- a/interface/src/hooks/useSpacebotConfig.ts
+++ b/interface/src/hooks/useSpacebotConfig.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+export interface SpacebotConfig {
+	// Routing
+	workerModel: string;
+	channelModel: string;
+	cortexModel: string;
+
+	// Tuning
+	maxConcurrentWorkers: number;
+	maxConcurrentBranches: number;
+
+	// Projects
+	useWorktrees: boolean;
+	autoCreateWorktrees: boolean;
+
+	// Messaging platforms
+	enabledPlatforms: string[];
+
+	// Auth
+	hasProvider: boolean;
+	isAnthropic: boolean;
+
+	// Loading state
+	isReady: boolean;
+}
+
+export function useSpacebotConfig(agentId: string): SpacebotConfig {
+	const { data: configData } = useQuery({
+		queryKey: ["agent-config", agentId],
+		queryFn: () => api.agentConfig(agentId),
+		staleTime: 60_000,
+	});
+
+	const { data: messagingData } = useQuery({
+		queryKey: ["messaging-status"],
+		queryFn: api.messagingStatus,
+		staleTime: 30_000,
+	});
+
+	const { data: providersData } = useQuery({
+		queryKey: ["providers"],
+		queryFn: api.providers,
+		staleTime: 30_000,
+	});
+
+	const enabledPlatforms: string[] = [];
+	if (messagingData) {
+		for (const inst of messagingData.instances ?? []) {
+			if (inst.enabled && inst.platform) {
+				enabledPlatforms.push(inst.platform);
+			}
+		}
+	}
+
+	return {
+		workerModel: configData?.routing?.worker ?? "",
+		channelModel: configData?.routing?.channel ?? "",
+		cortexModel: configData?.routing?.cortex ?? "",
+		maxConcurrentWorkers: configData?.tuning?.max_concurrent_workers ?? 2,
+		maxConcurrentBranches: configData?.tuning?.max_concurrent_branches ?? 5,
+		useWorktrees: configData?.projects?.use_worktrees ?? false,
+		autoCreateWorktrees: configData?.projects?.auto_create_worktrees ?? false,
+		enabledPlatforms,
+		hasProvider: providersData?.has_any ?? false,
+		isAnthropic: providersData?.providers?.anthropic ?? false,
+		isReady: !!configData && !!providersData,
+	};
+}

--- a/interface/src/hooks/useTheme.ts
+++ b/interface/src/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 
-export type ThemeId = "default" | "vanilla" | "midnight" | "noir";
+export type ThemeId = "default" | "vanilla" | "midnight" | "noir" | "ember";
 
 export interface ThemeOption {
 	id: ThemeId;
@@ -33,6 +33,12 @@ export const THEMES: ThemeOption[] = [
 		name: "Noir",
 		description: "Pure black and white theme",
 		className: "noir-theme",
+	},
+	{
+		id: "ember",
+		name: "Ember",
+		description: "Dark red and orange accent theme",
+		className: "ember-theme",
 	},
 ];
 

--- a/interface/src/router.tsx
+++ b/interface/src/router.tsx
@@ -25,6 +25,7 @@ import {AgentTasks} from "@/routes/AgentTasks";
 import {AgentChat} from "@/routes/AgentChat";
 import {Settings} from "@/routes/Settings";
 import {Pricing} from "@/routes/Pricing";
+import {Welcome} from "@/routes/Welcome";
 import {useLiveContext} from "@/hooks/useLiveContext";
 import {AgentTabs} from "@/components/AgentTabs";
 
@@ -105,6 +106,14 @@ const settingsRoute = createRoute({
 	},
 	component: function SettingsPage() {
 		return <Settings />;
+	},
+});
+
+const welcomeRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: "/welcome",
+	component: function WelcomePage() {
+		return <Welcome />;
 	},
 });
 
@@ -362,6 +371,7 @@ const channelRoute = createRoute({
 const routeTree = rootRoute.addChildren([
 	indexRoute,
 	settingsRoute,
+	welcomeRoute,
 	pricingRoute,
 	logsRoute,
 	agentRoute,

--- a/interface/src/router.tsx
+++ b/interface/src/router.tsx
@@ -24,6 +24,7 @@ import {AgentProjects} from "@/routes/AgentProjects";
 import {AgentTasks} from "@/routes/AgentTasks";
 import {AgentChat} from "@/routes/AgentChat";
 import {Settings} from "@/routes/Settings";
+import {Pricing} from "@/routes/Pricing";
 import {useLiveContext} from "@/hooks/useLiveContext";
 import {AgentTabs} from "@/components/AgentTabs";
 
@@ -104,6 +105,14 @@ const settingsRoute = createRoute({
 	},
 	component: function SettingsPage() {
 		return <Settings />;
+	},
+});
+
+const pricingRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: "/pricing",
+	component: function PricingPage() {
+		return <Pricing />;
 	},
 });
 
@@ -353,6 +362,7 @@ const channelRoute = createRoute({
 const routeTree = rootRoute.addChildren([
 	indexRoute,
 	settingsRoute,
+	pricingRoute,
 	logsRoute,
 	agentRoute,
 	agentChatRoute,

--- a/interface/src/router.tsx
+++ b/interface/src/router.tsx
@@ -147,6 +147,22 @@ const agentRoute = createRoute({
 	path: "/agents/$agentId",
 	component: function AgentPage() {
 		const {agentId} = agentRoute.useParams();
+		return (
+			<div className="flex h-full flex-col">
+				<AgentTopBar agentId={agentId} />
+				<div className="flex-1 overflow-hidden">
+					<AgentTasks agentId={agentId} />
+				</div>
+			</div>
+		);
+	},
+});
+
+const agentOverviewRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: "/agents/$agentId/overview",
+	component: function AgentOverviewPage() {
+		const {agentId} = agentOverviewRoute.useParams();
 		const {liveStates} = useLiveContext();
 		return (
 			<div className="flex h-full flex-col">
@@ -375,6 +391,7 @@ const routeTree = rootRoute.addChildren([
 	pricingRoute,
 	logsRoute,
 	agentRoute,
+	agentOverviewRoute,
 	agentChatRoute,
 	agentChannelsRoute,
 	agentMemoriesRoute,

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -249,7 +249,7 @@ export function AgentTasks({ agentId }: { agentId: string }) {
       )}
 
       {/* Kanban Board */}
-      <div className={`flex flex-1 flex-wrap content-start gap-3 overflow-y-auto p-4 ${viewMode === "graph" ? "hidden" : ""}`}
+      <div className={`flex flex-1 flex-wrap content-start gap-3 overflow-y-auto p-4 ${viewMode === "graph" ? "hidden" : ""}`}>
         {COLUMNS.map(({ status, label }) => (
           <KanbanColumn
             key={status}
@@ -441,12 +441,12 @@ function TaskCard({
             {"\u2699"} {task.worker_id.slice(0, 8)}
           </Badge>
         )}
-        {task.metadata?.worktree && (
+        {!!task.metadata?.worktree && (
           <Badge variant="outline" size="sm" title={String(task.metadata.worktree)}>
             {"\uD83C\uDF33"} worktree
           </Badge>
         )}
-        {task.metadata?.assigned_agent && (
+        {!!task.metadata?.assigned_agent && (
           <Badge variant="accent" size="sm">
             {String(task.metadata.assigned_agent)}
           </Badge>
@@ -711,12 +711,12 @@ function TaskDetailDialog({
                 Worker: {task.worker_id.slice(0, 8)}
               </Badge>
             )}
-            {task.metadata?.assigned_agent && (
+            {!!task.metadata?.assigned_agent && (
               <Badge variant="accent" size="md">
                 Agent: {String(task.metadata.assigned_agent)}
               </Badge>
             )}
-            {task.metadata?.worktree && (
+            {!!task.metadata?.worktree && (
               <Badge variant="default" size="md">
                 Worktree: {String(task.metadata.worktree)}
               </Badge>

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/ui/Dialog";
 import { Markdown } from "@/components/Markdown";
 import { TaskDependencyGraph } from "@/components/TaskDependencyGraph";
+import { DiffViewer } from "@/components/DiffViewer";
 import { formatTimeAgo } from "@/lib/format";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -282,6 +283,7 @@ export function AgentTasks({ agentId }: { agentId: string }) {
         <TaskDetailDialog
           task={selectedTask}
           allTasks={tasks}
+          agentId={agentId}
           onClose={() => setSelectedTaskNumber(null)}
           onApprove={() => approveMutation.mutate(selectedTask.task_number)}
           onExecute={() => executeMutation.mutate(selectedTask.task_number)}
@@ -649,6 +651,7 @@ function CreateTaskDialog({
 function TaskDetailDialog({
   task,
   allTasks,
+  agentId,
   onClose,
   onApprove,
   onExecute,
@@ -657,6 +660,7 @@ function TaskDetailDialog({
 }: {
   task: TaskItem;
   allTasks: TaskItem[];
+  agentId: string;
   onClose: () => void;
   onApprove: () => void;
   onExecute: () => void;
@@ -665,6 +669,26 @@ function TaskDetailDialog({
 }) {
   const deps = getDependencies(task);
   const blocked = isBlocked(task, allTasks);
+
+  // Fetch diff if task has worktree or branch metadata
+  const hasDiffSource = task.metadata?.worktree || task.metadata?.branch;
+  const { data: diffData } = useQuery({
+    queryKey: ["task-diff", agentId, task.task_number],
+    queryFn: async () => {
+      const resp = await fetch(
+        `/api/agents/tasks/${task.task_number}/diff?agent_id=${agentId}`
+      );
+      if (!resp.ok) return { diff: "", branch: null, worktree: null };
+      return resp.json() as Promise<{
+        diff: string;
+        branch: string | null;
+        worktree: string | null;
+      }>;
+    },
+    enabled: !!hasDiffSource,
+    staleTime: 10_000,
+  });
+
   return (
     <Dialog open={true} onOpenChange={(v) => !v && onClose()}>
       <DialogContent className="!flex max-h-[85vh] max-w-lg !flex-col overflow-hidden">
@@ -772,6 +796,17 @@ function TaskDetailDialog({
                   </li>
                 ))}
               </ul>
+            </div>
+          )}
+
+          {/* Inline Diff Review */}
+          {diffData?.diff && (
+            <div>
+              <label className="mb-1 block text-xs text-ink-dull">
+                Changes {diffData.branch && `(branch: ${diffData.branch})`}
+                {diffData.worktree && `(worktree)`}
+              </label>
+              <DiffViewer diff={diffData.diff} maxHeight="300px" />
             </div>
           )}
 

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -57,6 +57,23 @@ const PRIORITY_COLORS: Record<
   low: "outline",
 };
 
+/** Extract dependency task numbers from metadata */
+function getDependencies(task: TaskItem): number[] {
+  const deps = task.metadata?.depends_on;
+  if (Array.isArray(deps)) return deps.filter((n): n is number => typeof n === "number");
+  return [];
+}
+
+/** Check if a task is blocked (has incomplete dependencies) */
+function isBlocked(task: TaskItem, allTasks: TaskItem[]): boolean {
+  const deps = getDependencies(task);
+  if (deps.length === 0) return false;
+  return deps.some((depNum) => {
+    const depTask = allTasks.find((t) => t.task_number === depNum);
+    return depTask && depTask.status !== "done";
+  });
+}
+
 export function AgentTasks({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient();
   const { taskEventVersion } = useLiveContext();
@@ -165,12 +182,25 @@ export function AgentTasks({ agentId }: { agentId: string }) {
           </span>
           {tasksByStatus.pending_approval.length > 0 && (
             <Badge variant="amber" size="sm">
-              {tasksByStatus.pending_approval.length} pending approval
+              {tasksByStatus.pending_approval.length} pending
             </Badge>
           )}
           {tasksByStatus.in_progress.length > 0 && (
             <Badge variant="violet" size="sm">
-              {tasksByStatus.in_progress.length} in progress
+              {tasksByStatus.in_progress.length} active
+            </Badge>
+          )}
+          {(() => {
+            const blockedCount = tasks.filter((t) => isBlocked(t, tasks)).length;
+            return blockedCount > 0 ? (
+              <Badge variant="red" size="sm">
+                {blockedCount} blocked
+              </Badge>
+            ) : null;
+          })()}
+          {tasksByStatus.done.length > 0 && (
+            <Badge variant="green" size="sm">
+              {tasksByStatus.done.length} done
             </Badge>
           )}
         </div>
@@ -187,6 +217,7 @@ export function AgentTasks({ agentId }: { agentId: string }) {
             status={status}
             label={label}
             tasks={tasksByStatus[status]}
+            allTasks={tasks}
             onSelect={(task) => setSelectedTaskNumber(task.task_number)}
             onApprove={(task) => approveMutation.mutate(task.task_number)}
             onExecute={(task) => executeMutation.mutate(task.task_number)}
@@ -212,6 +243,7 @@ export function AgentTasks({ agentId }: { agentId: string }) {
       {selectedTask && (
         <TaskDetailDialog
           task={selectedTask}
+          allTasks={tasks}
           onClose={() => setSelectedTaskNumber(null)}
           onApprove={() => approveMutation.mutate(selectedTask.task_number)}
           onExecute={() => executeMutation.mutate(selectedTask.task_number)}
@@ -234,6 +266,7 @@ function KanbanColumn({
   status,
   label,
   tasks,
+  allTasks,
   onSelect,
   onApprove,
   onExecute,
@@ -242,6 +275,7 @@ function KanbanColumn({
   status: TaskStatus;
   label: string;
   tasks: TaskItem[];
+  allTasks: TaskItem[];
   onSelect: (task: TaskItem) => void;
   onApprove: (task: TaskItem) => void;
   onExecute: (task: TaskItem) => void;
@@ -264,6 +298,7 @@ function KanbanColumn({
             <TaskCard
               key={task.id}
               task={task}
+              allTasks={allTasks}
               onSelect={() => onSelect(task)}
               onApprove={() => onApprove(task)}
               onExecute={() => onExecute(task)}
@@ -285,12 +320,14 @@ function KanbanColumn({
 
 function TaskCard({
   task,
+  allTasks,
   onSelect,
   onApprove,
   onExecute,
   onStatusChange,
 }: {
   task: TaskItem;
+  allTasks: TaskItem[];
   onSelect: () => void;
   onApprove: () => void;
   onExecute: () => void;
@@ -298,6 +335,8 @@ function TaskCard({
 }) {
   const subtasksDone = task.subtasks.filter((s) => s.completed).length;
   const subtasksTotal = task.subtasks.length;
+  const deps = getDependencies(task);
+  const blocked = isBlocked(task, allTasks);
 
   return (
     <motion.div
@@ -306,7 +345,11 @@ function TaskCard({
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
       transition={{ duration: 0.15 }}
-      className="cursor-pointer rounded-md border border-app-line/30 bg-app p-3 transition-colors hover:border-app-line"
+      className={`cursor-pointer rounded-md border p-3 transition-colors hover:border-app-line ${
+        blocked
+          ? "border-red-500/30 bg-red-950/10"
+          : "border-app-line/30 bg-app"
+      }`}
       onClick={onSelect}
     >
       {/* Title row */}
@@ -314,7 +357,34 @@ function TaskCard({
         <span className="text-sm font-medium text-ink leading-tight">
           #{task.task_number} {task.title}
         </span>
+        {blocked && (
+          <span className="shrink-0 text-tiny text-red-400" title="Blocked by dependencies">
+            Blocked
+          </span>
+        )}
       </div>
+
+      {/* Dependencies */}
+      {deps.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {deps.map((depNum) => {
+            const depTask = allTasks.find((t) => t.task_number === depNum);
+            const depDone = depTask?.status === "done";
+            return (
+              <span
+                key={depNum}
+                className={`inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-tiny ${
+                  depDone
+                    ? "bg-emerald-500/10 text-emerald-400"
+                    : "bg-amber-500/10 text-amber-400"
+                }`}
+              >
+                {depDone ? "\u2713" : "\u23F3"} #{depNum}
+              </span>
+            );
+          })}
+        </div>
+      )}
 
       {/* Meta row */}
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -396,20 +466,27 @@ function CreateTaskDialog({
   const [description, setDescription] = useState("");
   const [priority, setPriority] = useState<TaskPriority>("medium");
   const [status, setStatus] = useState<TaskStatus>("backlog");
+  const [dependsOn, setDependsOn] = useState("");
 
   const handleSubmit = useCallback(() => {
     if (!title.trim()) return;
+    const deps = dependsOn
+      .split(",")
+      .map((s) => parseInt(s.trim().replace("#", ""), 10))
+      .filter((n) => !isNaN(n));
     onCreate({
       title: title.trim(),
       description: description.trim() || undefined,
       priority,
       status,
+      metadata: deps.length > 0 ? { depends_on: deps } : undefined,
     });
     setTitle("");
     setDescription("");
     setPriority("medium");
     setStatus("backlog");
-  }, [title, description, priority, status, onCreate]);
+    setDependsOn("");
+  }, [title, description, priority, status, dependsOn, onCreate]);
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
@@ -439,6 +516,17 @@ function CreateTaskDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs text-ink-dull">
+              Depends On
+            </label>
+            <input
+              className="w-full rounded-md border border-app-line bg-app-darkBox px-3 py-2 text-sm text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
+              placeholder="Task numbers, e.g. #1, #3"
+              value={dependsOn}
+              onChange={(e) => setDependsOn(e.target.value)}
             />
           </div>
           <div className="flex gap-4">
@@ -494,6 +582,7 @@ function CreateTaskDialog({
 
 function TaskDetailDialog({
   task,
+  allTasks,
   onClose,
   onApprove,
   onExecute,
@@ -501,12 +590,15 @@ function TaskDetailDialog({
   onStatusChange,
 }: {
   task: TaskItem;
+  allTasks: TaskItem[];
   onClose: () => void;
   onApprove: () => void;
   onExecute: () => void;
   onDelete: () => void;
   onStatusChange: (status: TaskStatus) => void;
 }) {
+  const deps = getDependencies(task);
+  const blocked = isBlocked(task, allTasks);
   return (
     <Dialog open={true} onOpenChange={(v) => !v && onClose()}>
       <DialogContent className="!flex max-h-[85vh] max-w-lg !flex-col overflow-hidden">
@@ -530,6 +622,36 @@ function TaskDetailDialog({
               </Badge>
             )}
           </div>
+
+          {/* Dependencies */}
+          {deps.length > 0 && (
+            <div>
+              <label className="mb-1 block text-xs text-ink-dull">
+                Dependencies {blocked && <span className="text-red-400">(blocked)</span>}
+              </label>
+              <div className="flex flex-wrap gap-1.5">
+                {deps.map((depNum) => {
+                  const depTask = allTasks.find((t) => t.task_number === depNum);
+                  const depDone = depTask?.status === "done";
+                  return (
+                    <span
+                      key={depNum}
+                      className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs ${
+                        depDone
+                          ? "bg-emerald-500/10 text-emerald-400"
+                          : "bg-amber-500/10 text-amber-400"
+                      }`}
+                    >
+                      {depDone ? "\u2713" : "\u23F3"} #{depNum}
+                      {depTask && (
+                        <span className="text-ink-faint"> {depTask.title.slice(0, 30)}{depTask.title.length > 30 ? "..." : ""}</span>
+                      )}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
 
           {/* Description */}
           {task.description && (

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -20,6 +20,7 @@ import {
 import { Markdown } from "@/components/Markdown";
 import { TaskDependencyGraph } from "@/components/TaskDependencyGraph";
 import { DiffViewer } from "@/components/DiffViewer";
+import { useSpacebotConfig } from "@/hooks/useSpacebotConfig";
 import { formatTimeAgo } from "@/lib/format";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -97,6 +98,7 @@ interface IssuesResponse {
 export function AgentTasks({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient();
   const { taskEventVersion } = useLiveContext();
+  const config = useSpacebotConfig(agentId);
 
   // Invalidate on SSE task events
   const prevVersion = useRef(taskEventVersion);
@@ -142,7 +144,15 @@ export function AgentTasks({ agentId }: { agentId: string }) {
     ? githubIssues
     : githubIssues.filter((i) => i.repository === projectFilter);
 
-  // Group tasks by status
+  // Filter tasks by project (if a project filter is active)
+  const filteredTasks = projectFilter === "all"
+    ? tasks
+    : tasks.filter((t) => {
+        const repo = t.metadata?.github_repository as string | undefined;
+        return repo === projectFilter;
+      });
+
+  // Group filtered tasks by status
   const tasksByStatus: Record<TaskStatus, TaskItem[]> = {
     pending_approval: [],
     backlog: [],
@@ -150,7 +160,7 @@ export function AgentTasks({ agentId }: { agentId: string }) {
     in_progress: [],
     done: [],
   };
-  for (const task of tasks) {
+  for (const task of filteredTasks) {
     tasksByStatus[task.status]?.push(task);
   }
 
@@ -212,6 +222,31 @@ export function AgentTasks({ agentId }: { agentId: string }) {
       setSelectedTaskNumber(null);
     },
   });
+
+  const importIssueMutation = useMutation({
+    mutationFn: (issue: GitHubIssue) =>
+      api.createTask(agentId, {
+        title: `[${issue.repository.split("/").pop()}#${issue.number}] ${issue.title}`,
+        description: `GitHub: ${issue.url}`,
+        status: "backlog",
+        priority: "medium",
+        metadata: {
+          github_issue_url: issue.url,
+          github_issue_number: issue.number,
+          github_repository: issue.repository,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tasks", agentId] });
+    },
+  });
+
+  // Track which issues are already imported as tasks
+  const importedIssueUrls = new Set(
+    tasks
+      .map((t) => t.metadata?.github_issue_url as string | undefined)
+      .filter(Boolean)
+  );
 
   if (isLoading) {
     return (
@@ -310,6 +345,49 @@ export function AgentTasks({ agentId }: { agentId: string }) {
         </div>
       </div>
 
+      {/* Config Status Bar */}
+      {config.isReady && (
+        <div className="flex items-center gap-2 border-b border-app-line/50 bg-app-darkBox/20 px-4 py-1.5">
+          {/* Worker Model */}
+          <span className="rounded bg-app-line/30 px-1.5 py-0.5 text-tiny text-ink-faint" title="Worker model">
+            {config.workerModel.split("/").pop() ?? "no model"}
+          </span>
+          {/* Concurrency */}
+          <span
+            className={`rounded px-1.5 py-0.5 text-tiny ${
+              tasksByStatus.in_progress.length >= config.maxConcurrentWorkers
+                ? "bg-amber-500/10 text-amber-400"
+                : "bg-app-line/30 text-ink-faint"
+            }`}
+            title="Active / max concurrent workers"
+          >
+            {tasksByStatus.in_progress.length}/{config.maxConcurrentWorkers} workers
+          </span>
+          {/* Worktrees */}
+          <span
+            className={`rounded px-1.5 py-0.5 text-tiny ${
+              config.useWorktrees
+                ? "bg-emerald-500/10 text-emerald-400"
+                : "bg-app-line/30 text-ink-faint"
+            }`}
+          >
+            Worktrees {config.useWorktrees ? "ON" : "OFF"}
+          </span>
+          {/* Platforms */}
+          {config.enabledPlatforms.map((p) => (
+            <span key={p} className="rounded bg-app-line/30 px-1.5 py-0.5 text-tiny text-ink-faint capitalize">
+              {p}
+            </span>
+          ))}
+          {/* Auth */}
+          {config.isAnthropic && (
+            <span className="rounded bg-accent/10 px-1.5 py-0.5 text-tiny text-accent">
+              Claude Max
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Dependency Graph View */}
       {viewMode === "graph" && (
         <div className="flex-1 overflow-hidden">
@@ -351,42 +429,63 @@ export function AgentTasks({ agentId }: { agentId: string }) {
               <span className="text-tiny text-ink-faint">{filteredIssues.length}</span>
             </div>
             <div className="flex-1 space-y-2 overflow-y-auto p-2">
-              {filteredIssues.map((issue) => (
-                <a
-                  key={`${issue.repository}-${issue.number}`}
-                  href={issue.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block cursor-pointer rounded-md border border-app-line/30 bg-app p-3 transition-colors hover:border-accent/50"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="text-sm font-medium text-ink leading-tight">
-                      #{issue.number} {issue.title}
-                    </span>
-                  </div>
-                  <div className="mt-1.5 flex flex-wrap items-center gap-1">
-                    <span className="rounded bg-accent/10 px-1 py-0.5 text-tiny text-accent">
-                      {issue.repository.split("/").pop()}
-                    </span>
-                    {issue.labels.slice(0, 3).map((label) => (
-                      <span
-                        key={label}
-                        className="rounded bg-app-line/50 px-1 py-0.5 text-tiny text-ink-faint"
-                      >
-                        {label}
+              {filteredIssues.map((issue) => {
+                const isImported = importedIssueUrls.has(issue.url);
+                return (
+                  <div
+                    key={`${issue.repository}-${issue.number}`}
+                    className="rounded-md border border-app-line/30 bg-app p-3 transition-colors hover:border-accent/50"
+                  >
+                    <a
+                      href={issue.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="text-sm font-medium text-ink leading-tight">
+                          #{issue.number} {issue.title}
+                        </span>
+                      </div>
+                      <div className="mt-1.5 flex flex-wrap items-center gap-1">
+                        <span className="rounded bg-accent/10 px-1 py-0.5 text-tiny text-accent">
+                          {issue.repository.split("/").pop()}
+                        </span>
+                        {issue.labels.slice(0, 3).map((label) => (
+                          <span
+                            key={label}
+                            className="rounded bg-app-line/50 px-1 py-0.5 text-tiny text-ink-faint"
+                          >
+                            {label}
+                          </span>
+                        ))}
+                      </div>
+                      {issue.assignees.length > 0 && (
+                        <div className="mt-1 text-tiny text-ink-faint">
+                          {issue.assignees.join(", ")}
+                        </div>
+                      )}
+                    </a>
+                    <div className="mt-1.5 flex items-center justify-between">
+                      <span className="text-tiny text-ink-faint">
+                        {formatTimeAgo(issue.updated_at)}
                       </span>
-                    ))}
-                  </div>
-                  {issue.assignees.length > 0 && (
-                    <div className="mt-1 text-tiny text-ink-faint">
-                      {issue.assignees.join(", ")}
+                      {isImported ? (
+                        <span className="rounded bg-emerald-500/10 px-1.5 py-0.5 text-tiny text-emerald-400">
+                          Imported
+                        </span>
+                      ) : (
+                        <button
+                          className="rounded bg-accent/10 px-1.5 py-0.5 text-tiny text-accent hover:bg-accent/20"
+                          onClick={() => importIssueMutation.mutate(issue)}
+                        >
+                          Import
+                        </button>
+                      )}
                     </div>
-                  )}
-                  <div className="mt-1 text-tiny text-ink-faint">
-                    {formatTimeAgo(issue.updated_at)}
                   </div>
-                </a>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -76,6 +76,24 @@ function isBlocked(task: TaskItem, allTasks: TaskItem[]): boolean {
   });
 }
 
+// -- GitHub Issue type (from registry API) --
+interface GitHubIssue {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  repository: string;
+  labels: string[];
+  assignees: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+interface IssuesResponse {
+  issues: GitHubIssue[];
+  repos: string[];
+}
+
 export function AgentTasks({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient();
   const { taskEventVersion } = useLiveContext();
@@ -95,7 +113,34 @@ export function AgentTasks({ agentId }: { agentId: string }) {
     refetchInterval: 15_000,
   });
 
+  // Fetch GitHub issues from registry
+  const { data: issuesData } = useQuery({
+    queryKey: ["registry-issues", agentId],
+    queryFn: async () => {
+      const resp = await fetch(
+        `/api/registry/issues?agent_id=${agentId}&limit=100`
+      );
+      if (!resp.ok) return { issues: [], repos: [] } as IssuesResponse;
+      return resp.json() as Promise<IssuesResponse>;
+    },
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const githubIssues = issuesData?.issues ?? [];
+  const availableRepos = issuesData?.repos ?? [];
+
   const tasks = data?.tasks ?? [];
+
+  // Project filter
+  const [projectFilter, setProjectFilter] = useState<string>("all");
+  // Show/hide GitHub issues
+  const [showIssues, setShowIssues] = useState(true);
+
+  // Filter GitHub issues by project
+  const filteredIssues = projectFilter === "all"
+    ? githubIssues
+    : githubIssues.filter((i) => i.repository === projectFilter);
 
   // Group tasks by status
   const tasksByStatus: Record<TaskStatus, TaskItem[]> = {
@@ -232,6 +277,33 @@ export function AgentTasks({ agentId }: { agentId: string }) {
               Graph
             </button>
           </div>
+          {/* Project Filter */}
+          {availableRepos.length > 0 && (
+            <select
+              className="rounded-md border border-app-line bg-app-darkBox px-2 py-1 text-xs text-ink focus:border-accent focus:outline-none"
+              value={projectFilter}
+              onChange={(e) => setProjectFilter(e.target.value)}
+            >
+              <option value="all">All Projects</option>
+              {availableRepos.map((repo) => (
+                <option key={repo} value={repo}>
+                  {repo.split("/").pop()}
+                </option>
+              ))}
+            </select>
+          )}
+          {/* Issues Toggle */}
+          <button
+            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
+              showIssues
+                ? "border-accent/50 bg-accent/10 text-accent"
+                : "border-app-line text-ink-faint hover:text-ink"
+            }`}
+            onClick={() => setShowIssues(!showIssues)}
+            title="Show/hide GitHub issues"
+          >
+            Issues {showIssues && filteredIssues.length > 0 ? `(${filteredIssues.length})` : ""}
+          </button>
           <Button size="sm" onClick={() => setCreateOpen(true)}>
             Create Task
           </Button>
@@ -268,6 +340,56 @@ export function AgentTasks({ agentId }: { agentId: string }) {
             }
           />
         ))}
+
+        {/* GitHub Issues Column */}
+        {showIssues && filteredIssues.length > 0 && (
+          <div className="flex min-h-0 min-w-[14rem] flex-1 basis-[14rem] flex-col rounded-lg border border-accent/20 bg-accent/5">
+            <div className="flex items-center gap-2 border-b border-accent/10 px-3 py-2">
+              <Badge variant="accent" size="sm">
+                GitHub Issues
+              </Badge>
+              <span className="text-tiny text-ink-faint">{filteredIssues.length}</span>
+            </div>
+            <div className="flex-1 space-y-2 overflow-y-auto p-2">
+              {filteredIssues.map((issue) => (
+                <a
+                  key={`${issue.repository}-${issue.number}`}
+                  href={issue.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block cursor-pointer rounded-md border border-app-line/30 bg-app p-3 transition-colors hover:border-accent/50"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="text-sm font-medium text-ink leading-tight">
+                      #{issue.number} {issue.title}
+                    </span>
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-1">
+                    <span className="rounded bg-accent/10 px-1 py-0.5 text-tiny text-accent">
+                      {issue.repository.split("/").pop()}
+                    </span>
+                    {issue.labels.slice(0, 3).map((label) => (
+                      <span
+                        key={label}
+                        className="rounded bg-app-line/50 px-1 py-0.5 text-tiny text-ink-faint"
+                      >
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                  {issue.assignees.length > 0 && (
+                    <div className="mt-1 text-tiny text-ink-faint">
+                      {issue.assignees.join(", ")}
+                    </div>
+                  )}
+                  <div className="mt-1 text-tiny text-ink-faint">
+                    {formatTimeAgo(issue.updated_at)}
+                  </div>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Create Dialog */}

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -397,8 +397,18 @@ function TaskCard({
           </span>
         )}
         {task.worker_id && (
-          <Badge variant="violet" size="sm">
-            Worker
+          <Badge variant="violet" size="sm" title={task.worker_id}>
+            {"\u2699"} {task.worker_id.slice(0, 8)}
+          </Badge>
+        )}
+        {task.metadata?.worktree && (
+          <Badge variant="outline" size="sm" title={String(task.metadata.worktree)}>
+            {"\uD83C\uDF33"} worktree
+          </Badge>
+        )}
+        {task.metadata?.assigned_agent && (
+          <Badge variant="accent" size="sm">
+            {String(task.metadata.assigned_agent)}
           </Badge>
         )}
       </div>
@@ -467,6 +477,7 @@ function CreateTaskDialog({
   const [priority, setPriority] = useState<TaskPriority>("medium");
   const [status, setStatus] = useState<TaskStatus>("backlog");
   const [dependsOn, setDependsOn] = useState("");
+  const [assignedAgent, setAssignedAgent] = useState("");
 
   const handleSubmit = useCallback(() => {
     if (!title.trim()) return;
@@ -474,19 +485,23 @@ function CreateTaskDialog({
       .split(",")
       .map((s) => parseInt(s.trim().replace("#", ""), 10))
       .filter((n) => !isNaN(n));
+    const metadata: Record<string, unknown> = {};
+    if (deps.length > 0) metadata.depends_on = deps;
+    if (assignedAgent.trim()) metadata.assigned_agent = assignedAgent.trim();
     onCreate({
       title: title.trim(),
       description: description.trim() || undefined,
       priority,
       status,
-      metadata: deps.length > 0 ? { depends_on: deps } : undefined,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     });
     setTitle("");
     setDescription("");
     setPriority("medium");
     setStatus("backlog");
     setDependsOn("");
-  }, [title, description, priority, status, dependsOn, onCreate]);
+    setAssignedAgent("");
+  }, [title, description, priority, status, dependsOn, assignedAgent, onCreate]);
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
@@ -518,16 +533,29 @@ function CreateTaskDialog({
               rows={3}
             />
           </div>
-          <div>
-            <label className="mb-1 block text-xs text-ink-dull">
-              Depends On
-            </label>
-            <input
-              className="w-full rounded-md border border-app-line bg-app-darkBox px-3 py-2 text-sm text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
-              placeholder="Task numbers, e.g. #1, #3"
-              value={dependsOn}
-              onChange={(e) => setDependsOn(e.target.value)}
-            />
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className="mb-1 block text-xs text-ink-dull">
+                Depends On
+              </label>
+              <input
+                className="w-full rounded-md border border-app-line bg-app-darkBox px-3 py-2 text-sm text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
+                placeholder="#1, #3"
+                value={dependsOn}
+                onChange={(e) => setDependsOn(e.target.value)}
+              />
+            </div>
+            <div className="flex-1">
+              <label className="mb-1 block text-xs text-ink-dull">
+                Assign Agent
+              </label>
+              <input
+                className="w-full rounded-md border border-app-line bg-app-darkBox px-3 py-2 text-sm text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
+                placeholder="e.g. claude-code, codex"
+                value={assignedAgent}
+                onChange={(e) => setAssignedAgent(e.target.value)}
+              />
+            </div>
           </div>
           <div className="flex gap-4">
             <div className="flex-1">
@@ -619,6 +647,16 @@ function TaskDetailDialog({
             {task.worker_id && (
               <Badge variant="violet" size="md">
                 Worker: {task.worker_id.slice(0, 8)}
+              </Badge>
+            )}
+            {task.metadata?.assigned_agent && (
+              <Badge variant="accent" size="md">
+                Agent: {String(task.metadata.assigned_agent)}
+              </Badge>
+            )}
+            {task.metadata?.worktree && (
+              <Badge variant="default" size="md">
+                Worktree: {String(task.metadata.worktree)}
               </Badge>
             )}
           </div>

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -799,6 +799,29 @@ function TaskDetailDialog({
             </div>
           )}
 
+          {/* Worktree Actions */}
+          {!task.metadata?.worktree && task.status !== "done" && (
+            <button
+              className="w-full rounded-md border border-dashed border-app-line px-3 py-2 text-xs text-ink-faint hover:border-accent hover:text-accent transition-colors"
+              onClick={async () => {
+                const resp = await fetch(
+                  `/api/agents/tasks/${task.task_number}/worktree`,
+                  {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ agent_id: agentId }),
+                  }
+                );
+                if (resp.ok) {
+                  // Invalidate to refresh task with new metadata
+                  window.location.reload();
+                }
+              }}
+            >
+              Create Worktree for Task #{task.task_number}
+            </button>
+          )}
+
           {/* Inline Diff Review */}
           {diffData?.diff && (
             <div>

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -18,6 +18,7 @@ import {
   DialogFooter,
 } from "@/ui/Dialog";
 import { Markdown } from "@/components/Markdown";
+import { TaskDependencyGraph } from "@/components/TaskDependencyGraph";
 import { formatTimeAgo } from "@/lib/format";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -107,6 +108,8 @@ export function AgentTasks({ agentId }: { agentId: string }) {
     tasksByStatus[task.status]?.push(task);
   }
 
+  // View mode: "board" (kanban) or "graph" (dependency graph)
+  const [viewMode, setViewMode] = useState<"board" | "graph">("board");
   // Create task dialog
   const [createOpen, setCreateOpen] = useState(false);
   // Detail dialog — store task number and derive from live list to stay current.
@@ -204,13 +207,48 @@ export function AgentTasks({ agentId }: { agentId: string }) {
             </Badge>
           )}
         </div>
-        <Button size="sm" onClick={() => setCreateOpen(true)}>
-          Create Task
-        </Button>
+        <div className="flex items-center gap-2">
+          {/* View Toggle */}
+          <div className="flex rounded-md border border-app-line">
+            <button
+              className={`px-2.5 py-1 text-xs font-medium transition-colors ${
+                viewMode === "board"
+                  ? "bg-app-selected text-ink"
+                  : "text-ink-faint hover:text-ink"
+              }`}
+              onClick={() => setViewMode("board")}
+            >
+              Board
+            </button>
+            <button
+              className={`px-2.5 py-1 text-xs font-medium transition-colors ${
+                viewMode === "graph"
+                  ? "bg-app-selected text-ink"
+                  : "text-ink-faint hover:text-ink"
+              }`}
+              onClick={() => setViewMode("graph")}
+            >
+              Graph
+            </button>
+          </div>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            Create Task
+          </Button>
+        </div>
       </div>
 
+      {/* Dependency Graph View */}
+      {viewMode === "graph" && (
+        <div className="flex-1 overflow-hidden">
+          <TaskDependencyGraph
+            tasks={tasks}
+            onSelectTask={(num) => setSelectedTaskNumber(num)}
+          />
+        </div>
+      )}
+
       {/* Kanban Board */}
-      <div className="flex flex-1 flex-wrap content-start gap-3 overflow-y-auto p-4">
+      <div className={`flex flex-1 flex-wrap content-start gap-3 overflow-y-auto p-4 ${viewMode === "graph" ? "hidden" : ""}`}
         {COLUMNS.map(({ status, label }) => (
           <KanbanColumn
             key={status}

--- a/interface/src/routes/Pricing.tsx
+++ b/interface/src/routes/Pricing.tsx
@@ -1,0 +1,162 @@
+import { useSetTopBar } from "@/components/TopBar";
+
+const TIERS = [
+	{
+		name: "Open Source",
+		price: "Free",
+		subtitle: "For individual developers",
+		note: null,
+		cta: { label: "Get Started", href: "https://github.com/spacedriveapp/spacebot" },
+		highlight: false,
+		features: [
+			"Full Agent Orchestration",
+			"CLI + Web Dashboard",
+			"BYOK — Bring Your Own API Key",
+			"All Messaging Adapters",
+			"MCP Marketplace",
+			"Multi-Agent Kanban Board",
+			"Community Support",
+		],
+	},
+	{
+		name: "Teams",
+		price: "\u20AC0/mo*",
+		subtitle: "*through 2026",
+		note: "then \u20AC20/mo/user",
+		cta: { label: "Get Started", href: "#" },
+		highlight: true,
+		features: [
+			"All Features of OSS +",
+			"Centralized Billing",
+			"Team Management Dashboard",
+			"Role-Based Access Control",
+			"Limit Inference Providers",
+			"Priority Support",
+		],
+	},
+	{
+		name: "Enterprise",
+		price: "Custom",
+		subtitle: "SSO, SLA & Dedicated Support",
+		note: null,
+		cta: { label: "Contact Sales", href: "mailto:mail@marcmantei.com" },
+		highlight: false,
+		features: [
+			"All Features in Teams +",
+			"SSO / OIDC",
+			"SLA",
+			"Dedicated Support",
+			"Audit Logs",
+			"Advanced Config Management",
+			"Fine-Grained Permissioning",
+		],
+	},
+] as const;
+
+export function Pricing() {
+	useSetTopBar(
+		<div className="flex h-full items-center px-6">
+			<h1 className="font-plex text-sm font-medium text-ink">Pricing</h1>
+		</div>,
+	);
+
+	return (
+		<div className="flex flex-1 flex-col overflow-y-auto">
+			<div className="mx-auto w-full max-w-5xl px-6 py-12">
+				{/* Header */}
+				<div className="mb-12 text-center">
+					<h1 className="font-plex text-4xl font-bold text-ink">
+						Simple, transparent pricing
+					</h1>
+					<p className="mx-auto mt-4 max-w-xl text-base text-ink-dull">
+						Spacebot is free for individual developers. Pay only for AI
+						inference on a usage basis — no subscriptions, no vendor lock-in.
+					</p>
+				</div>
+
+				{/* Tier Cards */}
+				<div className="grid gap-6 md:grid-cols-3">
+					{TIERS.map((tier) => (
+						<div
+							key={tier.name}
+							className={`flex flex-col rounded-lg border p-6 ${
+								tier.highlight
+									? "border-accent bg-accent/5"
+									: "border-app-line bg-app-box"
+							}`}
+						>
+							{/* Tier Header */}
+							<div className="mb-6 text-center">
+								<p className="text-xs font-semibold uppercase tracking-wider text-ink-faint">
+									{tier.name}
+								</p>
+								<p className="mt-3 font-plex text-4xl font-bold text-ink">
+									{tier.price}
+								</p>
+								<p className="mt-1 text-sm text-ink-dull">
+									{tier.subtitle}
+								</p>
+								{tier.note && (
+									<p className="mt-0.5 text-xs text-ink-faint">
+										{tier.note}
+									</p>
+								)}
+							</div>
+
+							{/* CTA */}
+							<a
+								href={tier.cta.href}
+								target="_blank"
+								rel="noopener noreferrer"
+								className={`mb-6 block rounded-md px-4 py-2.5 text-center text-sm font-medium transition-colors ${
+									tier.highlight
+										? "bg-accent text-white hover:bg-accent-deep"
+										: "bg-app-button text-ink hover:bg-app-hover"
+								}`}
+							>
+								{tier.cta.label}
+							</a>
+
+							{/* Feature Divider Label */}
+							<p className="mb-3 text-center text-xs font-medium text-ink-faint">
+								Features
+							</p>
+							<div className="mb-4 h-px bg-app-line" />
+
+							{/* Feature List */}
+							<ul className="flex-1 space-y-3">
+								{tier.features.map((feature) => (
+									<li
+										key={feature}
+										className="flex items-start gap-2 text-sm text-ink-dull"
+									>
+										<svg
+											className="mt-0.5 h-4 w-4 shrink-0 text-accent"
+											viewBox="0 0 20 20"
+											fill="currentColor"
+										>
+											<path
+												fillRule="evenodd"
+												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+												clipRule="evenodd"
+											/>
+										</svg>
+										{feature}
+									</li>
+								))}
+							</ul>
+						</div>
+					))}
+				</div>
+
+				{/* Footer Note */}
+				<div className="mt-10 text-center">
+					<p className="text-sm text-ink-faint">
+						Inference costs are paid directly to your LLM provider.
+						No markup, no hidden fees.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/interface/src/routes/Settings.tsx
+++ b/interface/src/routes/Settings.tsx
@@ -861,11 +861,12 @@ function AppearanceSection() {
 }
 
 function ThemePreview({ themeId }: { themeId: ThemeId }) {
-	const colors = {
+	const colors: Record<ThemeId, { bg: string; sidebar: string; accent: string }> = {
 		default: { bg: "#0d0d0f", sidebar: "#0a0a0b", accent: "#a855f7" },
 		vanilla: { bg: "#ffffff", sidebar: "#f5f5f6", accent: "#3b82f6" },
 		midnight: { bg: "#14162b", sidebar: "#0c0e1a", accent: "#3b82f6" },
 		noir: { bg: "#080808", sidebar: "#000000", accent: "#3b82f6" },
+		ember: { bg: "#140e0c", sidebar: "#0d0806", accent: "#b52a1a" },
 	};
 	const c = colors[themeId];
 

--- a/interface/src/routes/Welcome.tsx
+++ b/interface/src/routes/Welcome.tsx
@@ -1,0 +1,125 @@
+import { useSetTopBar } from "@/components/TopBar";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { useNavigate } from "@tanstack/react-router";
+
+export function Welcome() {
+	const navigate = useNavigate();
+
+	useSetTopBar(
+		<div className="flex h-full items-center px-6">
+			<h1 className="font-plex text-sm font-medium text-ink">Welcome</h1>
+		</div>,
+	);
+
+	const { data: providersData } = useQuery({
+		queryKey: ["providers"],
+		queryFn: api.providers,
+		staleTime: 5_000,
+	});
+
+	const hasProvider = providersData?.has_any ?? false;
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center overflow-y-auto">
+			<div className="mx-auto w-full max-w-lg px-6 text-center">
+				{/* Logo/Title */}
+				<h1 className="font-plex text-5xl font-bold text-ink">
+					Spacebot
+				</h1>
+				<p className="mt-3 text-lg text-ink-dull">
+					Autonomous agent network for teams and communities
+				</p>
+
+				{/* Status Card */}
+				<div className="mt-10 rounded-lg border border-app-line bg-app-box p-6 text-left">
+					<h2 className="font-plex text-sm font-semibold text-ink">
+						Getting Started
+					</h2>
+
+					<div className="mt-4 space-y-3">
+						{/* Step 1: Provider */}
+						<div className="flex items-center gap-3">
+							<span
+								className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${
+									hasProvider
+										? "bg-emerald-500/20 text-emerald-400"
+										: "bg-accent/20 text-accent"
+								}`}
+							>
+								{hasProvider ? "\u2713" : "1"}
+							</span>
+							<div className="flex-1">
+								<p className="text-sm text-ink">
+									{hasProvider
+										? "LLM provider configured"
+										: "Add an LLM provider (API key)"}
+								</p>
+							</div>
+							{!hasProvider && (
+								<button
+									className="rounded-md bg-accent px-3 py-1 text-xs font-medium text-white hover:bg-accent-deep"
+									onClick={() =>
+										navigate({ to: "/settings", search: { tab: "providers" } })
+									}
+								>
+									Configure
+								</button>
+							)}
+						</div>
+
+						{/* Step 2: Agent */}
+						<div className="flex items-center gap-3">
+							<span className="flex h-6 w-6 items-center justify-center rounded-full bg-app-line/50 text-xs font-bold text-ink-faint">
+								2
+							</span>
+							<p className="flex-1 text-sm text-ink-dull">
+								Create your first agent
+							</p>
+						</div>
+
+						{/* Step 3: Connect */}
+						<div className="flex items-center gap-3">
+							<span className="flex h-6 w-6 items-center justify-center rounded-full bg-app-line/50 text-xs font-bold text-ink-faint">
+								3
+							</span>
+							<p className="flex-1 text-sm text-ink-dull">
+								Connect a messaging platform or use the web chat
+							</p>
+						</div>
+					</div>
+				</div>
+
+				{/* Quick Links */}
+				<div className="mt-6 flex items-center justify-center gap-4">
+					<button
+						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"
+						onClick={() => navigate({ to: "/settings" })}
+					>
+						Settings
+					</button>
+					<button
+						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"
+						onClick={() => navigate({ to: "/pricing" })}
+					>
+						Pricing
+					</button>
+					<a
+						href="https://github.com/spacedriveapp/spacebot"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"
+					>
+						GitHub
+					</a>
+				</div>
+
+				{/* Tagline */}
+				<p className="mt-8 text-xs text-ink-faint">
+					Works with Claude Code, Codex, VS Code, and more.
+					Open source. BYOK.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/interface/src/routes/Welcome.tsx
+++ b/interface/src/routes/Welcome.tsx
@@ -26,7 +26,9 @@ export function Welcome() {
 
 	const hasProvider = providersData?.has_any ?? false;
 	const isAnthropic = providersData?.providers?.anthropic ?? false;
-	const hasAgent = (agentsData?.agents?.length ?? 0) > 0;
+	const agents = agentsData?.agents ?? [];
+	const hasAgent = agents.length > 0;
+	const firstAgentId = hasAgent ? agents[0].id : "";
 
 	// Detect auth method
 	const providerLabel = isAnthropic
@@ -102,22 +104,17 @@ export function Welcome() {
 							<div className="flex-1">
 								<p className={`text-sm ${hasAgent ? "text-ink" : "text-ink-dull"}`}>
 									{hasAgent
-										? `Agent active (${agentsData!.agents[0].id})`
+										? `Agent active (${firstAgentId})`
 										: "Create your first agent"}
 								</p>
 							</div>
 							{hasProvider && hasAgent && (
-								<button
+								<a
+									href={`/agents/${firstAgentId}`}
 									className="rounded-md bg-app-button px-3 py-1 text-xs text-ink hover:bg-app-hover"
-									onClick={() =>
-										navigate({
-											to: "/agents/$agentId",
-											params: { agentId: agentsData!.agents[0].id },
-										})
-									}
 								>
 									View
-								</button>
+								</a>
 							)}
 						</div>
 
@@ -136,17 +133,12 @@ export function Welcome() {
 				{/* Quick Links */}
 				<div className="mt-6 flex items-center justify-center gap-4">
 					{hasAgent && (
-						<button
+						<a
+							href={`/agents/${firstAgentId}/tasks`}
 							className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-deep"
-							onClick={() =>
-								navigate({
-									to: "/agents/$agentId/tasks",
-									params: { agentId: agentsData!.agents[0].id },
-								})
-							}
 						>
 							Kanban Board
-						</button>
+						</a>
 					)}
 					<button
 						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"

--- a/interface/src/routes/Welcome.tsx
+++ b/interface/src/routes/Welcome.tsx
@@ -18,7 +18,22 @@ export function Welcome() {
 		staleTime: 5_000,
 	});
 
+	const { data: agentsData } = useQuery({
+		queryKey: ["agents"],
+		queryFn: api.agents,
+		staleTime: 10_000,
+	});
+
 	const hasProvider = providersData?.has_any ?? false;
+	const isAnthropic = providersData?.providers?.anthropic ?? false;
+	const hasAgent = (agentsData?.agents?.length ?? 0) > 0;
+
+	// Detect auth method
+	const providerLabel = isAnthropic
+		? "Anthropic (Claude Max / OAuth)"
+		: hasProvider
+			? "LLM provider configured"
+			: null;
 
 	return (
 		<div className="flex flex-1 flex-col items-center justify-center overflow-y-auto">
@@ -51,10 +66,13 @@ export function Welcome() {
 							</span>
 							<div className="flex-1">
 								<p className="text-sm text-ink">
-									{hasProvider
-										? "LLM provider configured"
-										: "Add an LLM provider (API key)"}
+									{providerLabel ?? "Add an LLM provider"}
 								</p>
+								{!hasProvider && (
+									<p className="mt-0.5 text-xs text-ink-faint">
+										API key, Claude Max OAuth, or another provider
+									</p>
+								)}
 							</div>
 							{!hasProvider && (
 								<button
@@ -70,12 +88,37 @@ export function Welcome() {
 
 						{/* Step 2: Agent */}
 						<div className="flex items-center gap-3">
-							<span className="flex h-6 w-6 items-center justify-center rounded-full bg-app-line/50 text-xs font-bold text-ink-faint">
-								2
+							<span
+								className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold ${
+									hasAgent
+										? "bg-emerald-500/20 text-emerald-400"
+										: hasProvider
+											? "bg-accent/20 text-accent"
+											: "bg-app-line/50 text-ink-faint"
+								}`}
+							>
+								{hasAgent ? "\u2713" : "2"}
 							</span>
-							<p className="flex-1 text-sm text-ink-dull">
-								Create your first agent
-							</p>
+							<div className="flex-1">
+								<p className={`text-sm ${hasAgent ? "text-ink" : "text-ink-dull"}`}>
+									{hasAgent
+										? `Agent active (${agentsData!.agents[0].id})`
+										: "Create your first agent"}
+								</p>
+							</div>
+							{hasProvider && hasAgent && (
+								<button
+									className="rounded-md bg-app-button px-3 py-1 text-xs text-ink hover:bg-app-hover"
+									onClick={() =>
+										navigate({
+											to: "/agents/$agentId",
+											params: { agentId: agentsData!.agents[0].id },
+										})
+									}
+								>
+									View
+								</button>
+							)}
 						</div>
 
 						{/* Step 3: Connect */}
@@ -92,6 +135,19 @@ export function Welcome() {
 
 				{/* Quick Links */}
 				<div className="mt-6 flex items-center justify-center gap-4">
+					{hasAgent && (
+						<button
+							className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-deep"
+							onClick={() =>
+								navigate({
+									to: "/agents/$agentId/tasks",
+									params: { agentId: agentsData!.agents[0].id },
+								})
+							}
+						>
+							Kanban Board
+						</button>
+					)}
 					<button
 						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"
 						onClick={() => navigate({ to: "/settings" })}
@@ -104,14 +160,6 @@ export function Welcome() {
 					>
 						Pricing
 					</button>
-					<a
-						href="https://github.com/spacedriveapp/spacebot"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="rounded-md bg-app-button px-4 py-2 text-sm text-ink hover:bg-app-hover"
-					>
-						GitHub
-					</a>
 				</div>
 
 				{/* Tagline */}

--- a/interface/src/ui/style/colors.scss
+++ b/interface/src/ui/style/colors.scss
@@ -196,3 +196,56 @@
 	--color-menu-selected: 0, 0%, 18%;
 	--color-menu-shade: 0, 0%, 0%;
 }
+
+.ember-theme {
+	--dark-hue: 8;
+	--color-black: 0, 0%, 0%;
+	--color-white: 0, 0%, 100%;
+	// dark red primary, warm orange secondary
+	--color-accent: 4, 72%, 40%;
+	--color-accent-faint: 14, 75%, 50%;
+	--color-accent-deep: 0, 78%, 30%;
+	// warm-tinted text
+	--color-ink: 15, 12%, 92%;
+	--color-ink-dull: 10, 8%, 62%;
+	--color-ink-faint: 8, 5%, 44%;
+	// sidebar — deep warm black
+	--color-sidebar: 8, 15%, 3%;
+	--color-sidebar-box: 8, 12%, 7%;
+	--color-sidebar-line: 8, 10%, 14%;
+	--color-sidebar-ink: 15, 12%, 92%;
+	--color-sidebar-ink-dull: 10, 8%, 62%;
+	--color-sidebar-ink-faint: 8, 5%, 44%;
+	--color-sidebar-divider: 8, 12%, 6%;
+	--color-sidebar-button: 8, 12%, 11%;
+	--color-sidebar-selected: 4, 18%, 16%;
+	--color-sidebar-shade: 8, 15%, 10%;
+	// main — warm dark surfaces
+	--color-app: 8, 12%, 5%;
+	--color-app-box: 8, 10%, 9%;
+	--color-app-dark-box: 8, 12%, 7%;
+	--color-app-darker-box: 8, 14%, 4%;
+	--color-app-light-box: 8, 10%, 14%;
+	--color-app-overlay: 8, 12%, 8%;
+	--color-app-input: 8, 10%, 11%;
+	--color-app-focus: 8, 14%, 4%;
+	--color-app-line: 8, 10%, 15%;
+	--color-app-divider: 8, 15%, 3%;
+	--color-app-button: 4, 14%, 13%;
+	--color-app-hover: 4, 12%, 17%;
+	--color-app-selected: 4, 16%, 19%;
+	--color-app-selected-item: 4, 12%, 10%;
+	--color-app-active: 4, 18%, 22%;
+	--color-app-shade: 8, 15%, 0%;
+	--color-app-frame: 8, 10%, 16%;
+	--color-app-slider: 8, 10%, 11%;
+	--color-app-explorer-scrollbar: 4, 14%, 20%;
+	// menu
+	--color-menu: 8, 14%, 4%;
+	--color-menu-line: 8, 10%, 9%;
+	--color-menu-ink: 15, 12%, 92%;
+	--color-menu-faint: 10, 5%, 68%;
+	--color-menu-hover: 4, 14%, 18%;
+	--color-menu-selected: 4, 12%, 20%;
+	--color-menu-shade: 8, 10%, 0%;
+}

--- a/mcp-bridge/README.md
+++ b/mcp-bridge/README.md
@@ -1,0 +1,52 @@
+# Spacebot MCP Bridge
+
+Connect CLI agents like **Claude Code**, **Codex**, and **VS Code** to your Spacebot instance via MCP (Model Context Protocol).
+
+## Quick Start
+
+```bash
+# 1. Start Spacebot
+spacebot local
+
+# 2. Add to Claude Code settings (~/.claude/settings.json)
+```
+
+```json
+{
+  "mcpServers": {
+    "spacebot": {
+      "command": "python3",
+      "args": ["/path/to/spacebot/mcp-bridge/spacebot_mcp_server.py"],
+      "env": {
+        "SPACEBOT_URL": "http://127.0.0.1:19898"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `spacebot_list_agents` | List all agents |
+| `spacebot_list_tasks` | List Kanban board tasks |
+| `spacebot_create_task` | Create a task (with dependencies) |
+| `spacebot_update_task` | Update task status/priority |
+| `spacebot_execute_task` | Execute task (spawns a worker) |
+| `spacebot_list_workers` | List active workers |
+| `spacebot_send_message` | Send message to a channel |
+| `spacebot_list_channels` | List agent channels |
+| `spacebot_status` | System status |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPACEBOT_URL` | `http://127.0.0.1:19898` | Spacebot API URL |
+| `SPACEBOT_TOKEN` | _(empty)_ | API auth token (if configured) |
+
+## Requirements
+
+- Python 3.8+ (no external dependencies)
+- Running Spacebot instance

--- a/mcp-bridge/spacebot_mcp_server.py
+++ b/mcp-bridge/spacebot_mcp_server.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Spacebot MCP Server Bridge
+
+Exposes Spacebot's HTTP API as MCP tools for CLI agents like Claude Code, Codex, etc.
+
+Usage:
+    python spacebot_mcp_server.py [--url http://127.0.0.1:19898] [--token YOUR_TOKEN]
+
+Add to Claude Code's .claude/settings.json:
+    {
+        "mcpServers": {
+            "spacebot": {
+                "command": "python3",
+                "args": ["/path/to/spacebot_mcp_server.py"],
+                "env": {
+                    "SPACEBOT_URL": "http://127.0.0.1:19898"
+                }
+            }
+        }
+    }
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Any
+
+SPACEBOT_URL = os.environ.get("SPACEBOT_URL", "http://127.0.0.1:19898")
+SPACEBOT_TOKEN = os.environ.get("SPACEBOT_TOKEN", "")
+
+
+def api_request(method: str, path: str, body: dict | None = None) -> dict:
+    """Make an HTTP request to the Spacebot API."""
+    url = f"{SPACEBOT_URL}/api{path}"
+    data = json.dumps(body).encode() if body else None
+    headers = {"Content-Type": "application/json"}
+    if SPACEBOT_TOKEN:
+        headers["Authorization"] = f"Bearer {SPACEBOT_TOKEN}"
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else str(e)
+        return {"error": f"HTTP {e.code}: {error_body}"}
+    except urllib.error.URLError as e:
+        return {"error": f"Connection failed: {e.reason}. Is Spacebot running at {SPACEBOT_URL}?"}
+
+
+# -- MCP Tool Definitions --
+
+TOOLS = [
+    {
+        "name": "spacebot_list_agents",
+        "description": "List all Spacebot agents and their status",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "spacebot_list_tasks",
+        "description": "List tasks for a Spacebot agent (Kanban board)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Filter by status: pending_approval, backlog, ready, in_progress, done",
+                    "enum": ["pending_approval", "backlog", "ready", "in_progress", "done"],
+                },
+            },
+        },
+    },
+    {
+        "name": "spacebot_create_task",
+        "description": "Create a new task on the Spacebot Kanban board",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "title": {"type": "string", "description": "Task title"},
+                "description": {
+                    "type": "string",
+                    "description": "Task description (markdown supported)",
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["critical", "high", "medium", "low"],
+                    "default": "medium",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pending_approval", "backlog", "ready"],
+                    "default": "backlog",
+                },
+                "depends_on": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "Task numbers this task depends on",
+                },
+            },
+            "required": ["title"],
+        },
+    },
+    {
+        "name": "spacebot_update_task",
+        "description": "Update a task's status or priority",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "task_number": {
+                    "type": "integer",
+                    "description": "Task number to update",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pending_approval", "backlog", "ready", "in_progress", "done"],
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["critical", "high", "medium", "low"],
+                },
+            },
+            "required": ["task_number"],
+        },
+    },
+    {
+        "name": "spacebot_execute_task",
+        "description": "Execute a task (spawns a Spacebot worker to work on it)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "task_number": {
+                    "type": "integer",
+                    "description": "Task number to execute",
+                },
+            },
+            "required": ["task_number"],
+        },
+    },
+    {
+        "name": "spacebot_list_workers",
+        "description": "List active workers and their status",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+            },
+        },
+    },
+    {
+        "name": "spacebot_send_message",
+        "description": "Send a message to a Spacebot channel (triggers agent response)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "channel_id": {
+                    "type": "string",
+                    "description": "Channel ID to send to (use spacebot_list_channels to find)",
+                },
+                "message": {"type": "string", "description": "Message content"},
+            },
+            "required": ["channel_id", "message"],
+        },
+    },
+    {
+        "name": "spacebot_list_channels",
+        "description": "List all channels for an agent",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+            },
+        },
+    },
+    {
+        "name": "spacebot_status",
+        "description": "Get Spacebot system status and version info",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+]
+
+
+def handle_tool_call(name: str, arguments: dict) -> Any:
+    """Route MCP tool calls to Spacebot API."""
+    agent_id = arguments.get("agent_id", "main")
+
+    if name == "spacebot_list_agents":
+        return api_request("GET", "/agents")
+
+    elif name == "spacebot_list_tasks":
+        params = f"?limit=100"
+        if "status" in arguments:
+            params += f"&status={arguments['status']}"
+        return api_request("GET", f"/agents/{agent_id}/tasks{params}")
+
+    elif name == "spacebot_create_task":
+        body: dict[str, Any] = {
+            "title": arguments["title"],
+            "priority": arguments.get("priority", "medium"),
+            "status": arguments.get("status", "backlog"),
+        }
+        if "description" in arguments:
+            body["description"] = arguments["description"]
+        if "depends_on" in arguments:
+            body["metadata"] = {"depends_on": arguments["depends_on"]}
+        return api_request("POST", f"/agents/{agent_id}/tasks", body)
+
+    elif name == "spacebot_update_task":
+        task_number = arguments["task_number"]
+        body = {}
+        if "status" in arguments:
+            body["status"] = arguments["status"]
+        if "priority" in arguments:
+            body["priority"] = arguments["priority"]
+        return api_request("PATCH", f"/agents/{agent_id}/tasks/{task_number}", body)
+
+    elif name == "spacebot_execute_task":
+        task_number = arguments["task_number"]
+        return api_request("POST", f"/agents/{agent_id}/tasks/{task_number}/execute")
+
+    elif name == "spacebot_list_workers":
+        return api_request("GET", f"/agents/{agent_id}/workers")
+
+    elif name == "spacebot_send_message":
+        body = {
+            "content": arguments["message"],
+            "author": "mcp-bridge",
+        }
+        return api_request(
+            "POST", f"/agents/{agent_id}/channels/{arguments['channel_id']}/messages", body
+        )
+
+    elif name == "spacebot_list_channels":
+        return api_request("GET", f"/agents/{agent_id}/channels")
+
+    elif name == "spacebot_status":
+        return api_request("GET", "/system/status")
+
+    return {"error": f"Unknown tool: {name}"}
+
+
+# -- MCP Protocol (JSON-RPC over stdio) --
+
+
+def write_message(msg: dict):
+    """Write a JSON-RPC message to stdout."""
+    content = json.dumps(msg)
+    header = f"Content-Length: {len(content)}\r\n\r\n"
+    sys.stdout.write(header)
+    sys.stdout.write(content)
+    sys.stdout.flush()
+
+
+def read_message() -> dict | None:
+    """Read a JSON-RPC message from stdin."""
+    # Read headers
+    content_length = 0
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            return None
+        line = line.strip()
+        if not line:
+            break
+        if line.startswith("Content-Length:"):
+            content_length = int(line.split(":")[1].strip())
+
+    if content_length == 0:
+        return None
+
+    content = sys.stdin.read(content_length)
+    return json.loads(content)
+
+
+def main():
+    """Run the MCP server loop."""
+    while True:
+        msg = read_message()
+        if msg is None:
+            break
+
+        method = msg.get("method", "")
+        msg_id = msg.get("id")
+
+        if method == "initialize":
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {"listChanged": False}},
+                        "serverInfo": {
+                            "name": "spacebot-mcp-bridge",
+                            "version": "0.1.0",
+                        },
+                    },
+                }
+            )
+
+        elif method == "notifications/initialized":
+            pass  # No response needed
+
+        elif method == "tools/list":
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"tools": TOOLS},
+                }
+            )
+
+        elif method == "tools/call":
+            params = msg.get("params", {})
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+
+            result = handle_tool_call(tool_name, arguments)
+            is_error = "error" in result if isinstance(result, dict) else False
+
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(result, indent=2, default=str),
+                            }
+                        ],
+                        "isError": is_error,
+                    },
+                }
+            )
+
+        elif msg_id is not None:
+            write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {
+                        "code": -32601,
+                        "message": f"Method not found: {method}",
+                    },
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-bridge/spacebot_mcp_server.py
+++ b/mcp-bridge/spacebot_mcp_server.py
@@ -211,6 +211,49 @@ TOOLS = [
         },
     },
     {
+        "name": "spacebot_create_worktree",
+        "description": "Create a git worktree for a task (isolated workspace)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "task_number": {
+                    "type": "integer",
+                    "description": "Task number to create worktree for",
+                },
+                "base_branch": {
+                    "type": "string",
+                    "description": "Base branch (default: 'main')",
+                    "default": "main",
+                },
+            },
+            "required": ["task_number"],
+        },
+    },
+    {
+        "name": "spacebot_task_diff",
+        "description": "Get the git diff for a task's worktree or branch",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID (default: 'main')",
+                    "default": "main",
+                },
+                "task_number": {
+                    "type": "integer",
+                    "description": "Task number",
+                },
+            },
+            "required": ["task_number"],
+        },
+    },
+    {
         "name": "spacebot_status",
         "description": "Get Spacebot system status and version info",
         "inputSchema": {
@@ -273,6 +316,17 @@ def handle_tool_call(name: str, arguments: dict) -> Any:
 
     elif name == "spacebot_list_channels":
         return api_request("GET", f"/agents/{agent_id}/channels")
+
+    elif name == "spacebot_create_worktree":
+        task_number = arguments["task_number"]
+        body = {"agent_id": agent_id}
+        if "base_branch" in arguments:
+            body["base_branch"] = arguments["base_branch"]
+        return api_request("POST", f"/agents/tasks/{task_number}/worktree", body)
+
+    elif name == "spacebot_task_diff":
+        task_number = arguments["task_number"]
+        return api_request("GET", f"/agents/tasks/{task_number}/diff?agent_id={agent_id}")
 
     elif name == "spacebot_status":
         return api_request("GET", "/system/status")

--- a/migrations/20260312000001_registry.sql
+++ b/migrations/20260312000001_registry.sql
@@ -1,0 +1,36 @@
+-- Dynamic project registry: auto-discovered GitHub repositories.
+-- Tracks repos from `gh repo list` with per-repo config overrides.
+
+CREATE TABLE IF NOT EXISTS registry_repos (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    default_branch TEXT NOT NULL DEFAULT 'main',
+    is_archived INTEGER NOT NULL DEFAULT 0,
+    is_fork INTEGER NOT NULL DEFAULT 0,
+    visibility TEXT NOT NULL DEFAULT 'private',
+    language TEXT,
+    local_path TEXT,
+    clone_url TEXT NOT NULL,
+    ssh_url TEXT NOT NULL DEFAULT '',
+    -- Per-repo overrides (NULL = inherit from agent defaults)
+    worker_model TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    -- Linkage to existing projects table
+    project_id TEXT,
+    -- Sync metadata
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_registry_repos_full_name
+    ON registry_repos(agent_id, full_name);
+CREATE INDEX IF NOT EXISTS idx_registry_repos_agent
+    ON registry_repos(agent_id);
+CREATE INDEX IF NOT EXISTS idx_registry_repos_enabled
+    ON registry_repos(agent_id, enabled);

--- a/prompts/en/worker.md.j2
+++ b/prompts/en/worker.md.j2
@@ -45,6 +45,42 @@ Execute the task you were given. Use your tools. Report your status as you make 
 
 **When the task is fully complete** (or you've reached a definitive result for every part of the task), call `set_status` with `kind: "outcome"` and a summary of what happened. Only then provide your final text response. If you try to finish without signaling an outcome, the system will send you back to keep working. Do not signal an outcome prematurely — completing part of a multi-step task is not completion.
 
+## Coding Principles — CUPID
+
+All code you write must follow the CUPID principles (cupid.dev). These are non-negotiable defaults for every implementation task.
+
+### Composable — plays well with others
+
+- **Small surface area.** Expose a narrow, opinionated API. Less to learn, less to break, less to conflict with other code. Find the right granularity — not so fragmented that users must combine dozens of pieces, not so bloated that the component does too much.
+- **Intention-revealing.** Code should be easy to discover and quick to evaluate. A reader should be able to find a component and determine whether it's relevant within seconds. Names, structure, and signatures should communicate purpose.
+- **Minimal dependencies.** Every dependency is a liability — it brings transitive versions, compatibility risks, and upgrade burden. Only depend on what you truly need. If you can achieve the same thing with a few lines of code, don't add a library.
+
+### Unix philosophy — does one thing well
+
+- **Single purpose.** Each component, function, or module should have a specific, well-defined, and comprehensive purpose. Like Unix tools (`ls` lists files, `grep` matches patterns, `sed` transforms text), your code should do one thing and do it thoroughly.
+- **Compose, don't complect.** Build capability by combining focused components, not by making individual components do more. Prefer pipelines and composition over monolithic functions.
+- **Don't split what changes together.** Avoid artificial separation of concerns that forces you to change multiple files for a single logical change. If content and format always change together, keep them together. Let real usage patterns — not theoretical purity — guide structure.
+
+### Predictable — does what you expect
+
+- **Behaves as expected.** Code should do what it looks like it does. The intended behaviour should be obvious from structure and naming. Even without tests, a reader should be able to predict what the code does.
+- **Deterministic.** Same inputs → same outputs, every time. For code with inherent non-determinism (randomness, timing, external calls), define and document the operational bounds. Be robust (cover edge cases obviously), reliable (consistent results), and resilient (handle unexpected perturbations gracefully).
+- **Observable.** Design code so internal state can be inferred from outputs. Instrument deliberately — log what the code is doing at meaningful checkpoints, surface errors clearly, make debugging straightforward. Don't swallow errors silently.
+
+### Idiomatic — feels natural
+
+- **Follow language conventions.** Write code the way the language community writes it. Use the standard formatter, follow naming conventions, use idiomatic patterns. In Python, write pythonic code. In Rust, use the type system and ownership idioms. In TypeScript, leverage the type system properly.
+- **Respect local idioms.** When the project has established patterns (architecture, naming, error handling, test style), follow them — even if you'd personally choose differently. Consistency within a codebase matters more than individual preference.
+- **Write for the next developer.** Your code will be read by someone unfamiliar with it. Your learning curve is shorter-lived than the code you write. Don't write code that only makes sense to you right now.
+
+### Domain-based — the solution models the problem
+
+- **Use domain language.** Name variables, functions, types, and modules using the language of the problem domain, not implementation details. A `Surname` type reveals more than `string[30]`. A `Money` type with `Currency` and `Amount` prevents the floating-point bugs that plague financial software. The benchmark: an observer can't tell whether people are discussing the code or the domain.
+- **Domain-based structure.** Organize code around use cases and domain concepts, not framework conventions. Prefer `patient_history/`, `appointments/`, `billing/` over `models/`, `views/`, `controllers/`. When you need to change a feature, all related code should be nearby.
+- **Align boundaries with the domain.** Module boundaries should mirror domain boundaries. This makes deployment, refactoring, and reasoning about the system natural — components map to business concepts, not technical layers.
+
+These five properties are mutually reinforcing. Composable code tends to be predictable. Domain-based code tends to be idiomatic within its context. Code that follows the Unix philosophy is naturally composable. Apply all five together.
+
 ## Task
 
 Your task is provided in the first message. It contains everything you need to know. If it doesn't, work with what you have — you can't ask the channel for clarification unless you're an interactive worker that receives follow-up messages.

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -104,6 +104,9 @@ pub struct ChannelState {
     /// claimed under a write lock before any async spawn work and released
     /// when the worker is registered in the status block or the spawn fails.
     pub reserved_tasks: Arc<RwLock<HashSet<String>>>,
+    /// Spawn requests queued because the worker limit was reached. Drained
+    /// automatically when a worker completes and a slot opens.
+    pub worker_queue: Arc<RwLock<std::collections::VecDeque<crate::agent::channel_dispatch::QueuedWorkerSpawn>>>,
     pub status_block: Arc<RwLock<StatusBlock>>,
     pub deps: AgentDeps,
     pub conversation_logger: ConversationLogger,
@@ -521,6 +524,7 @@ impl Channel {
             worker_inputs: Arc::new(RwLock::new(HashMap::new())),
             worker_injections: Arc::new(RwLock::new(HashMap::new())),
             reserved_tasks: Arc::new(RwLock::new(HashSet::new())),
+            worker_queue: Arc::new(RwLock::new(std::collections::VecDeque::new())),
             status_block: status_block.clone(),
             deps: deps.clone(),
             conversation_logger,
@@ -2874,6 +2878,17 @@ impl Channel {
                 }
 
                 tracing::info!(worker_id = %worker_id, "worker completed, result queued for retrigger");
+
+                // Drain the worker queue now that a slot opened.
+                if let Some((queued_worker_id, queued_task)) =
+                    crate::agent::channel_dispatch::drain_worker_queue(&self.state).await
+                {
+                    tracing::info!(
+                        worker_id = %queued_worker_id,
+                        task = %queued_task,
+                        "auto-spawned queued worker after slot opened"
+                    );
+                }
             }
             ProcessEvent::OpenCodeSessionCreated {
                 worker_id,

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -106,7 +106,8 @@ pub struct ChannelState {
     pub reserved_tasks: Arc<RwLock<HashSet<String>>>,
     /// Spawn requests queued because the worker limit was reached. Drained
     /// automatically when a worker completes and a slot opens.
-    pub worker_queue: Arc<RwLock<std::collections::VecDeque<crate::agent::channel_dispatch::QueuedWorkerSpawn>>>,
+    pub worker_queue:
+        Arc<RwLock<std::collections::VecDeque<crate::agent::channel_dispatch::QueuedWorkerSpawn>>>,
     pub status_block: Arc<RwLock<StatusBlock>>,
     pub deps: AgentDeps,
     pub conversation_logger: ConversationLogger,

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -2051,11 +2051,12 @@ impl Channel {
             }
         };
 
-        if projects.is_empty() {
-            return None;
-        }
+        let mut contexts = Vec::new();
 
-        let mut contexts = Vec::with_capacity(projects.len());
+        // Collect project_ids that are linked to registry repos so we can
+        // avoid duplicating them when we append unlinked registry repos below.
+        let mut linked_project_ids = std::collections::HashSet::new();
+
         for project in &projects {
             let repos = match store.list_repos(&project.id).await {
                 Ok(repos) => repos,
@@ -2105,6 +2106,65 @@ impl Channel {
                     })
                     .collect(),
             });
+            linked_project_ids.insert(project.id.clone());
+        }
+
+        // Append enabled registry repos that are NOT already linked to a project,
+        // so the agent knows about all dynamically discovered repos.
+        if let Ok(registry_repos) = self
+            .deps
+            .registry_store
+            .list_repos(&self.deps.agent_id, true)
+            .await
+        {
+            for reg_repo in registry_repos {
+                // Skip repos already represented via a linked project.
+                if reg_repo
+                    .project_id
+                    .as_ref()
+                    .is_some_and(|pid| linked_project_ids.contains(pid))
+                {
+                    continue;
+                }
+                // Skip archived repos.
+                if reg_repo.is_archived {
+                    continue;
+                }
+                let root_path = reg_repo
+                    .local_path
+                    .clone()
+                    .unwrap_or_else(|| format!("(not cloned) {}", reg_repo.clone_url));
+                let mut desc_parts = Vec::new();
+                if let Some(ref lang) = reg_repo.language {
+                    desc_parts.push(lang.clone());
+                }
+                if let Some(ref model) = reg_repo.worker_model {
+                    desc_parts.push(format!("model: {model}"));
+                }
+                contexts.push(ProjectContext {
+                    name: reg_repo.full_name.clone(),
+                    root_path,
+                    description: if desc_parts.is_empty() {
+                        None
+                    } else {
+                        Some(desc_parts.join(", "))
+                    },
+                    tags: Vec::new(),
+                    repos: vec![ProjectRepoContext {
+                        name: reg_repo.name.clone(),
+                        path: reg_repo
+                            .local_path
+                            .unwrap_or_else(|| reg_repo.clone_url.clone()),
+                        default_branch: reg_repo.default_branch.clone(),
+                        remote_url: Some(reg_repo.clone_url),
+                    }],
+                    worktrees: Vec::new(),
+                });
+            }
+        }
+
+        if contexts.is_empty() {
+            return None;
         }
 
         match prompt_engine.render_projects_context(contexts) {

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -687,10 +687,7 @@ pub async fn spawn_or_queue_worker(
     {
         let queue = state.worker_queue.read().await;
         if queue.iter().any(|q| {
-            let q_norm = q
-                .task
-                .strip_prefix("[opencode] ")
-                .unwrap_or(&q.task);
+            let q_norm = q.task.strip_prefix("[opencode] ").unwrap_or(&q.task);
             q_norm == normalized
         }) {
             return Err(AgentError::DuplicateWorkerTask {
@@ -706,7 +703,12 @@ pub async fn spawn_or_queue_worker(
         queued_at: request.queued_at,
     };
     state.worker_queue.write().await.push_back(request);
-    state.status_block.write().await.queued_workers.push(queued_info);
+    state
+        .status_block
+        .write()
+        .await
+        .queued_workers
+        .push(queued_info);
     Ok(None)
 }
 
@@ -729,22 +731,17 @@ async fn do_spawn(
     match request.worker_type {
         QueuedWorkerType::OpenCode => {
             let dir = request.directory.as_deref().ok_or_else(|| {
-                AgentError::Other(anyhow::anyhow!(
-                    "directory required for opencode workers"
-                ))
+                AgentError::Other(anyhow::anyhow!("directory required for opencode workers"))
             })?;
             spawn_opencode_worker_from_state(state, &request.task, dir, true).await
         }
         QueuedWorkerType::Builtin => {
-            let skills: Vec<&str> =
-                request.suggested_skills.iter().map(|s| s.as_str()).collect();
-            spawn_worker_from_state(
-                state,
-                &request.task,
-                request.interactive,
-                &skills,
-            )
-            .await
+            let skills: Vec<&str> = request
+                .suggested_skills
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            spawn_worker_from_state(state, &request.task, request.interactive, &skills).await
         }
     }
 }
@@ -778,8 +775,11 @@ pub async fn drain_worker_queue(state: &ChannelState) -> Option<(WorkerId, Strin
             spawn_opencode_worker_from_state(state, &request.task, dir, true).await
         }
         QueuedWorkerType::Builtin => {
-            let skills: Vec<&str> =
-                request.suggested_skills.iter().map(|s| s.as_str()).collect();
+            let skills: Vec<&str> = request
+                .suggested_skills
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
             spawn_worker_from_state(state, &request.task, request.interactive, &skills).await
         }
     };

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -16,6 +16,26 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::Instrument as _;
 
+/// Worker type for queued spawns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueuedWorkerType {
+    Builtin,
+    OpenCode,
+}
+
+/// A spawn request queued because the worker limit was reached.
+#[derive(Debug, Clone)]
+pub struct QueuedWorkerSpawn {
+    pub task: String,
+    pub interactive: bool,
+    pub suggested_skills: Vec<String>,
+    pub worker_type: QueuedWorkerType,
+    pub directory: Option<String>,
+    pub project_id: Option<String>,
+    pub worktree_id: Option<String>,
+    pub queued_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// Validate worker capacity for a channel based on current active worker count.
 pub(crate) fn reserve_worker_slot_local(
     active_worker_count: usize,
@@ -613,6 +633,168 @@ pub async fn spawn_opencode_worker_from_state(
     release_task_reservation(state, &task).await;
 
     result
+}
+
+/// Try to spawn a worker. If the limit is reached, evict an idle worker to
+/// make room. If no idle workers can be evicted, queue the request instead
+/// of returning an error. Returns `Ok(Some(worker_id))` on immediate spawn,
+/// `Ok(None)` when queued, or an error for non-limit failures.
+pub async fn spawn_or_queue_worker(
+    state: &ChannelState,
+    request: QueuedWorkerSpawn,
+) -> std::result::Result<Option<WorkerId>, AgentError> {
+    // If limit not reached, try the normal spawn path.
+    if check_worker_limit(state).await.is_ok() {
+        return do_spawn(state, &request).await.map(Some);
+    }
+
+    // Limit reached — try to evict an idle worker to free a slot.
+    if let Some(evicted_id) = find_oldest_idle_worker(state).await {
+        tracing::info!(
+            evicted_worker_id = %evicted_id,
+            new_task = %request.task,
+            "evicting idle worker to make room for new task"
+        );
+        if state
+            .cancel_worker_with_reason(evicted_id, "evicted: idle worker displaced by new task")
+            .await
+            .is_ok()
+        {
+            // Slot freed — try spawning now.
+            if check_worker_limit(state).await.is_ok() {
+                return do_spawn(state, &request).await.map(Some);
+            }
+        }
+    }
+
+    // No idle workers to evict (or eviction didn't free a slot) — queue.
+    // Check for duplicates before queuing.
+    let normalized = request
+        .task
+        .strip_prefix("[opencode] ")
+        .unwrap_or(&request.task)
+        .to_string();
+
+    {
+        let status = state.status_block.read().await;
+        if let Some(existing_id) = status.find_duplicate_worker_task(&request.task) {
+            return Err(AgentError::DuplicateWorkerTask {
+                channel_id: state.channel_id.to_string(),
+                existing_worker_id: existing_id.to_string(),
+            });
+        }
+    }
+    {
+        let queue = state.worker_queue.read().await;
+        if queue.iter().any(|q| {
+            let q_norm = q
+                .task
+                .strip_prefix("[opencode] ")
+                .unwrap_or(&q.task);
+            q_norm == normalized
+        }) {
+            return Err(AgentError::DuplicateWorkerTask {
+                channel_id: state.channel_id.to_string(),
+                existing_worker_id: "queued".to_string(),
+            });
+        }
+    }
+
+    // Add to queue and update StatusBlock for visibility.
+    let queued_info = crate::agent::status::QueuedWorkerInfo {
+        task: request.task.clone(),
+        queued_at: request.queued_at,
+    };
+    state.worker_queue.write().await.push_back(request);
+    state.status_block.write().await.queued_workers.push(queued_info);
+    Ok(None)
+}
+
+/// Find the oldest idle worker in the channel's StatusBlock.
+async fn find_oldest_idle_worker(state: &ChannelState) -> Option<WorkerId> {
+    let status = state.status_block.read().await;
+    status
+        .active_workers
+        .iter()
+        .filter(|w| w.status == "idle")
+        .min_by_key(|w| w.started_at)
+        .map(|w| w.id)
+}
+
+/// Execute the actual spawn for a `QueuedWorkerSpawn` request.
+async fn do_spawn(
+    state: &ChannelState,
+    request: &QueuedWorkerSpawn,
+) -> std::result::Result<WorkerId, AgentError> {
+    match request.worker_type {
+        QueuedWorkerType::OpenCode => {
+            let dir = request.directory.as_deref().ok_or_else(|| {
+                AgentError::Other(anyhow::anyhow!(
+                    "directory required for opencode workers"
+                ))
+            })?;
+            spawn_opencode_worker_from_state(state, &request.task, dir, true).await
+        }
+        QueuedWorkerType::Builtin => {
+            let skills: Vec<&str> =
+                request.suggested_skills.iter().map(|s| s.as_str()).collect();
+            spawn_worker_from_state(
+                state,
+                &request.task,
+                request.interactive,
+                &skills,
+            )
+            .await
+        }
+    }
+}
+
+/// Try to spawn the next queued worker after a slot opens.
+/// Returns `Some((worker_id, task))` if a queued task was spawned.
+pub async fn drain_worker_queue(state: &ChannelState) -> Option<(WorkerId, String)> {
+    // Check if there's capacity.
+    if check_worker_limit(state).await.is_err() {
+        return None;
+    }
+
+    let request = state.worker_queue.write().await.pop_front()?;
+    let task_description = request.task.clone();
+
+    // Remove from StatusBlock's queued list.
+    {
+        let mut status = state.status_block.write().await;
+        if let Some(pos) = status
+            .queued_workers
+            .iter()
+            .position(|q| q.task == task_description)
+        {
+            status.queued_workers.remove(pos);
+        }
+    }
+
+    let result = match request.worker_type {
+        QueuedWorkerType::OpenCode => {
+            let dir = request.directory.as_deref().unwrap_or(".");
+            spawn_opencode_worker_from_state(state, &request.task, dir, true).await
+        }
+        QueuedWorkerType::Builtin => {
+            let skills: Vec<&str> =
+                request.suggested_skills.iter().map(|s| s.as_str()).collect();
+            spawn_worker_from_state(state, &request.task, request.interactive, &skills).await
+        }
+    };
+
+    match result {
+        Ok(worker_id) => Some((worker_id, task_description)),
+        Err(e) => {
+            tracing::warn!(
+                task = %task_description,
+                error = %e,
+                "queued worker spawn failed, dropping"
+            );
+            None
+        }
+    }
 }
 
 /// Inner implementation of OpenCode worker spawning, separated so the

--- a/src/agent/status.rs
+++ b/src/agent/status.rs
@@ -134,10 +134,19 @@ pub struct StatusBlock {
     pub active_branches: Vec<BranchStatus>,
     /// Currently running workers.
     pub active_workers: Vec<WorkerStatus>,
+    /// Workers queued because the worker limit was reached.
+    pub queued_workers: Vec<QueuedWorkerInfo>,
     /// Recently completed work.
     pub completed_items: Vec<CompletedItem>,
     /// Active link conversations with other agents.
     pub active_link_conversations: Vec<LinkConversationStatus>,
+}
+
+/// Info about a queued worker spawn.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct QueuedWorkerInfo {
+    pub task: String,
+    pub queued_at: DateTime<Utc>,
 }
 
 /// Status of an active branch.
@@ -392,6 +401,20 @@ impl StatusBlock {
                     worker.started_at.format("%H:%M"),
                     tool_calls_str,
                     worker.status
+                ));
+            }
+            output.push('\n');
+        }
+
+        // Queued workers (waiting for a slot)
+        if !self.queued_workers.is_empty() {
+            output.push_str("## Queued Workers\n");
+            for (i, queued) in self.queued_workers.iter().enumerate() {
+                output.push_str(&format!(
+                    "- [{}] {} (queued {})\n",
+                    i + 1,
+                    queued.task,
+                    queued.queued_at.format("%H:%M"),
                 ));
             }
             output.push('\n');

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -522,7 +522,20 @@ impl Worker {
             }
         }
 
-        // For interactive workers, enter a follow-up loop
+        // For interactive workers, enter a follow-up loop -- but only if the
+        // worker has not already signaled a terminal outcome. Workers that called
+        // set_status(kind="outcome") are done; entering the idle loop would block
+        // forever and prevent WorkerComplete from firing (circular dependency).
+        if !resuming && self.hook.outcome_signaled() {
+            tracing::info!(
+                worker_id = %self.id,
+                "worker signaled outcome, skipping idle follow-up loop"
+            );
+            // Drop the input receiver so the channel cleans up and
+            // WorkerComplete fires normally.
+            self.input_rx.take();
+        }
+
         let mut follow_up_failure: Option<String> = None;
         if let Some(mut input_rx) = self.input_rx.take() {
             if !resuming {

--- a/src/api.rs
+++ b/src/api.rs
@@ -20,6 +20,7 @@ mod models;
 mod opencode_proxy;
 mod projects;
 mod providers;
+mod registry;
 mod secrets;
 mod server;
 mod settings;

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -417,6 +417,8 @@ pub(super) async fn trigger_warmup(
             let (event_tx, memory_event_tx) = crate::create_process_event_buses();
             let project_store =
                 std::sync::Arc::new(crate::projects::ProjectStore::new(sqlite_pool.clone()));
+            let registry_store =
+                std::sync::Arc::new(crate::registry::RegistryStore::new(sqlite_pool.clone()));
             let deps = crate::AgentDeps {
                 agent_id: Arc::from(agent_id.as_str()),
                 memory_search,
@@ -431,6 +433,7 @@ pub(super) async fn trigger_warmup(
                 sandbox,
                 task_store,
                 project_store,
+                registry_store,
                 links: Arc::new(arc_swap::ArcSwap::from_pointee(Vec::new())),
                 agent_names: Arc::new(std::collections::HashMap::new()),
                 humans: Arc::new(arc_swap::ArcSwap::from_pointee(humans)),
@@ -760,6 +763,8 @@ pub async fn create_agent_internal(
     );
 
     let project_store = std::sync::Arc::new(crate::projects::ProjectStore::new(db.sqlite.clone()));
+    let registry_store =
+        std::sync::Arc::new(crate::registry::RegistryStore::new(db.sqlite.clone()));
 
     // Inject active project root paths into the sandbox allowlist.
     crate::projects::refresh_sandbox_project_paths(&project_store, &arc_agent_id, &sandbox).await;
@@ -771,6 +776,7 @@ pub async fn create_agent_internal(
         mcp_manager: mcp_manager.clone(),
         task_store: task_store.clone(),
         project_store: project_store.clone(),
+        registry_store: registry_store.clone(),
         cron_tool: None,
         runtime_config: runtime_config.clone(),
         event_tx: event_tx.clone(),

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -349,6 +349,7 @@ pub(super) async fn get_providers(
     let config_path = state.config_path.read().await.clone();
     let instance_dir = (**state.instance_dir.load()).clone();
     let openai_oauth_configured = crate::openai_auth::credentials_path(&instance_dir).exists();
+    let anthropic_oauth_configured = crate::auth::credentials_path(&instance_dir).exists();
 
     let (
         anthropic,
@@ -395,7 +396,7 @@ pub(super) async fn get_providers(
         };
 
         (
-            has_value("anthropic_key", "ANTHROPIC_API_KEY"),
+            has_value("anthropic_key", "ANTHROPIC_API_KEY") || anthropic_oauth_configured,
             has_value("openai_key", "OPENAI_API_KEY"),
             openai_oauth_configured,
             has_value("openrouter_key", "OPENROUTER_API_KEY"),
@@ -421,7 +422,7 @@ pub(super) async fn get_providers(
         )
     } else {
         (
-            std::env::var("ANTHROPIC_API_KEY").is_ok(),
+            std::env::var("ANTHROPIC_API_KEY").is_ok() || anthropic_oauth_configured,
             std::env::var("OPENAI_API_KEY").is_ok(),
             openai_oauth_configured,
             std::env::var("OPENROUTER_API_KEY").is_ok(),

--- a/src/api/registry.rs
+++ b/src/api/registry.rs
@@ -7,6 +7,7 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tokio::process::Command as TokioCommand;
 
 use crate::registry::store::RegistryRepo;
 use crate::registry::sync::{SyncResult, SyncStatus, sync_registry};
@@ -172,4 +173,137 @@ pub(super) async fn registry_status(
 
     let current = status.load().as_ref().clone();
     Ok(Json(StatusResponse { status: current }))
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Issues integration
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub(super) struct IssuesQuery {
+    agent_id: String,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default = "default_issues_limit")]
+    limit: usize,
+    #[serde(default = "default_issues_state")]
+    state: String,
+}
+
+fn default_issues_limit() -> usize { 50 }
+fn default_issues_state() -> String { "open".to_string() }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(super) struct GitHubIssue {
+    pub number: i64,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+    pub repository: String,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    #[serde(default)]
+    pub assignees: Vec<String>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+pub(super) struct IssuesResponse {
+    issues: Vec<GitHubIssue>,
+    repos: Vec<String>,
+}
+
+/// GET /api/registry/issues — fetch GitHub issues from all registry repos.
+/// Uses the `gh` CLI to query GitHub.
+pub(super) async fn list_registry_issues(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<IssuesQuery>,
+) -> Result<Json<IssuesResponse>, StatusCode> {
+    let stores = state.registry_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let repos = store
+        .list_repos(&query.agent_id, true)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let repo_names: Vec<String> = repos.iter().map(|r| r.full_name.clone()).collect();
+
+    // Filter to specific repo if requested
+    let target_repos: Vec<&str> = if let Some(ref repo_filter) = query.repo {
+        repo_names
+            .iter()
+            .filter(|r| r.as_str() == repo_filter.as_str())
+            .map(|r| r.as_str())
+            .collect()
+    } else {
+        repo_names.iter().map(|r| r.as_str()).collect()
+    };
+
+    let mut all_issues = Vec::new();
+
+    for repo_name in &target_repos {
+        let output = TokioCommand::new("gh")
+            .args([
+                "issue", "list",
+                "--repo", repo_name,
+                "--state", &query.state,
+                "--limit", &query.limit.to_string(),
+                "--json", "number,title,state,url,labels,assignees,createdAt,updatedAt",
+            ])
+            .output()
+            .await;
+
+        match output {
+            Ok(out) if out.status.success() => {
+                if let Ok(issues) = serde_json::from_slice::<Vec<serde_json::Value>>(&out.stdout) {
+                    for issue in issues {
+                        all_issues.push(GitHubIssue {
+                            number: issue["number"].as_i64().unwrap_or(0),
+                            title: issue["title"].as_str().unwrap_or("").to_string(),
+                            state: issue["state"].as_str().unwrap_or("OPEN").to_string(),
+                            url: issue["url"].as_str().unwrap_or("").to_string(),
+                            repository: repo_name.to_string(),
+                            labels: issue["labels"]
+                                .as_array()
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|l| l["name"].as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            assignees: issue["assignees"]
+                                .as_array()
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|a| a["login"].as_str().map(String::from))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            created_at: issue["createdAt"].as_str().unwrap_or("").to_string(),
+                            updated_at: issue["updatedAt"].as_str().unwrap_or("").to_string(),
+                        });
+                    }
+                }
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                tracing::warn!(%repo_name, %stderr, "gh issue list failed");
+            }
+            Err(e) => {
+                tracing::warn!(%repo_name, %e, "failed to run gh CLI");
+            }
+        }
+    }
+
+    // Sort by updated_at descending
+    all_issues.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
+    Ok(Json(IssuesResponse {
+        issues: all_issues,
+        repos: repo_names,
+    }))
 }

--- a/src/api/registry.rs
+++ b/src/api/registry.rs
@@ -1,0 +1,185 @@
+//! REST API handlers for the dynamic project registry.
+
+use super::state::ApiState;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::registry::store::RegistryRepo;
+use crate::registry::sync::{SyncResult, SyncStatus, sync_registry};
+
+// ---------------------------------------------------------------------------
+// Query / request types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub(super) struct AgentQuery {
+    agent_id: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct RepoListQuery {
+    agent_id: String,
+    #[serde(default)]
+    enabled_only: bool,
+}
+
+#[derive(Deserialize)]
+pub(super) struct RepoQuery {
+    agent_id: String,
+    full_name: String,
+}
+
+#[derive(Deserialize)]
+pub(super) struct UpdateRepoOverridesBody {
+    agent_id: String,
+    full_name: String,
+    /// Set to `Some(Some("model"))` to set, `Some(None)` to clear, `None` to leave unchanged.
+    worker_model: Option<Option<String>>,
+    enabled: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub(super) struct RepoListResponse {
+    repos: Vec<RegistryRepo>,
+    total: usize,
+}
+
+#[derive(Serialize)]
+pub(super) struct SyncResponse {
+    result: SyncResult,
+}
+
+#[derive(Serialize)]
+pub(super) struct StatusResponse {
+    status: SyncStatus,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/registry/repos — list all registry repos for an agent.
+pub(super) async fn list_registry_repos(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<RepoListQuery>,
+) -> Result<Json<RepoListResponse>, StatusCode> {
+    let stores = state.registry_stores.load();
+    let store = stores
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let repos = store
+        .list_repos(&query.agent_id, query.enabled_only)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let total = repos.len();
+    Ok(Json(RepoListResponse { repos, total }))
+}
+
+/// GET /api/registry/repos/detail — get a single repo by full_name.
+pub(super) async fn get_registry_repo(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<RepoQuery>,
+) -> Result<Json<RegistryRepo>, StatusCode> {
+    let stores = state.registry_stores.load();
+    let store = stores
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let repo = store
+        .get_by_full_name(&query.agent_id, &query.full_name)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(repo))
+}
+
+/// PUT /api/registry/repos/overrides — update per-repo overrides.
+pub(super) async fn update_repo_overrides(
+    State(state): State<Arc<ApiState>>,
+    Json(body): Json<UpdateRepoOverridesBody>,
+) -> Result<Json<RegistryRepo>, StatusCode> {
+    let stores = state.registry_stores.load();
+    let store = stores
+        .get(&body.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let repo = store
+        .set_overrides(
+            &body.agent_id,
+            &body.full_name,
+            body.worker_model,
+            body.enabled,
+        )
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(repo))
+}
+
+/// POST /api/registry/sync — trigger a manual sync.
+pub(super) async fn trigger_sync(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<AgentQuery>,
+) -> Result<Json<SyncResponse>, StatusCode> {
+    let stores = state.registry_stores.load();
+    let store = stores
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let configs = state.runtime_configs.load();
+    let runtime_config = configs
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let registry_config = runtime_config.registry.load();
+
+    if !registry_config.enabled {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Update sync status
+    let status_map = state.registry_sync_status.load();
+    if let Some(status) = status_map.get(&query.agent_id) {
+        status.store(Arc::new(SyncStatus::Syncing));
+    }
+
+    let result = sync_registry(store, &query.agent_id, &registry_config)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Update sync status
+    if let Some(status) = status_map.get(&query.agent_id) {
+        status.store(Arc::new(SyncStatus::Completed {
+            at: chrono::Utc::now().to_rfc3339(),
+            result: result.clone(),
+        }));
+    }
+
+    Ok(Json(SyncResponse { result }))
+}
+
+/// GET /api/registry/status — get current sync status.
+pub(super) async fn registry_status(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<AgentQuery>,
+) -> Result<Json<StatusResponse>, StatusCode> {
+    let status_map = state.registry_sync_status.load();
+    let status = status_map
+        .get(&query.agent_id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let current = status.load().as_ref().clone();
+    Ok(Json(StatusResponse { status: current }))
+}

--- a/src/api/registry.rs
+++ b/src/api/registry.rs
@@ -72,9 +72,7 @@ pub(super) async fn list_registry_repos(
     Query(query): Query<RepoListQuery>,
 ) -> Result<Json<RepoListResponse>, StatusCode> {
     let stores = state.registry_stores.load();
-    let store = stores
-        .get(&query.agent_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
 
     let repos = store
         .list_repos(&query.agent_id, query.enabled_only)
@@ -91,9 +89,7 @@ pub(super) async fn get_registry_repo(
     Query(query): Query<RepoQuery>,
 ) -> Result<Json<RegistryRepo>, StatusCode> {
     let stores = state.registry_stores.load();
-    let store = stores
-        .get(&query.agent_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
 
     let repo = store
         .get_by_full_name(&query.agent_id, &query.full_name)
@@ -110,9 +106,7 @@ pub(super) async fn update_repo_overrides(
     Json(body): Json<UpdateRepoOverridesBody>,
 ) -> Result<Json<RegistryRepo>, StatusCode> {
     let stores = state.registry_stores.load();
-    let store = stores
-        .get(&body.agent_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let store = stores.get(&body.agent_id).ok_or(StatusCode::NOT_FOUND)?;
 
     let repo = store
         .set_overrides(
@@ -134,14 +128,10 @@ pub(super) async fn trigger_sync(
     Query(query): Query<AgentQuery>,
 ) -> Result<Json<SyncResponse>, StatusCode> {
     let stores = state.registry_stores.load();
-    let store = stores
-        .get(&query.agent_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
 
     let configs = state.runtime_configs.load();
-    let runtime_config = configs
-        .get(&query.agent_id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let runtime_config = configs.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
 
     let registry_config = runtime_config.registry.load();
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -164,6 +164,10 @@ pub async fn start_http_server(
         .route("/agents/tasks/{number}/execute", post(tasks::execute_task))
         .route("/agents/tasks/{number}/diff", get(tasks::task_diff))
         .route(
+            "/agents/tasks/{number}/worktree",
+            post(tasks::create_worktree).delete(tasks::delete_worktree),
+        )
+        .route(
             "/agents/projects",
             get(projects::list_projects).post(projects::create_project),
         )

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -3,8 +3,8 @@
 use super::state::ApiState;
 use super::{
     agents, bindings, channels, config, cortex, cron, factory, ingest, links, mcp, memories,
-    messaging, models, opencode_proxy, projects, providers, secrets, settings, skills, ssh, system,
-    tasks, tools, webchat, workers,
+    messaging, models, opencode_proxy, projects, providers, registry, secrets, settings, skills,
+    ssh, system, tasks, tools, webchat, workers,
 };
 
 use axum::Json;
@@ -202,6 +202,15 @@ pub async fn start_http_server(
         .route("/agents/skills/upload", post(skills::upload_skill))
         .route("/agents/skills/remove", delete(skills::remove_skill))
         .route("/agents/tools", get(tools::list_tools))
+        // Registry: dynamic project discovery
+        .route("/registry/repos", get(registry::list_registry_repos))
+        .route("/registry/repos/detail", get(registry::get_registry_repo))
+        .route(
+            "/registry/repos/overrides",
+            put(registry::update_repo_overrides),
+        )
+        .route("/registry/sync", post(registry::trigger_sync))
+        .route("/registry/status", get(registry::registry_status))
         // Secret store management
         .route("/secrets/status", get(secrets::secrets_status))
         .route("/secrets", get(secrets::list_secrets))

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -162,6 +162,7 @@ pub async fn start_http_server(
         )
         .route("/agents/tasks/{number}/approve", post(tasks::approve_task))
         .route("/agents/tasks/{number}/execute", post(tasks::execute_task))
+        .route("/agents/tasks/{number}/diff", get(tasks::task_diff))
         .route(
             "/agents/projects",
             get(projects::list_projects).post(projects::create_project),

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -209,6 +209,7 @@ pub async fn start_http_server(
         .route("/agents/tools", get(tools::list_tools))
         // Registry: dynamic project discovery
         .route("/registry/repos", get(registry::list_registry_repos))
+        .route("/registry/issues", get(registry::list_registry_issues))
         .route("/registry/repos/detail", get(registry::get_registry_repo))
         .route(
             "/registry/repos/overrides",

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -12,6 +12,7 @@ use crate::memory::{EmbeddingModel, MemorySearch};
 use crate::messaging::MessagingManager;
 use crate::messaging::webchat::WebChatAdapter;
 use crate::projects::ProjectStore;
+use crate::registry::{RegistryStore, SyncStatus};
 use crate::prompts::PromptEngine;
 use crate::tasks::TaskStore;
 use crate::update::SharedUpdateStatus;
@@ -84,6 +85,10 @@ pub struct ApiState {
     pub task_stores: arc_swap::ArcSwap<HashMap<String, Arc<TaskStore>>>,
     /// Per-agent project stores for project/repo/worktree CRUD operations.
     pub project_stores: arc_swap::ArcSwap<HashMap<String, Arc<ProjectStore>>>,
+    /// Per-agent registry stores for auto-discovered GitHub repos.
+    pub registry_stores: arc_swap::ArcSwap<HashMap<String, Arc<RegistryStore>>>,
+    /// Per-agent registry sync status.
+    pub registry_sync_status: arc_swap::ArcSwap<HashMap<String, Arc<ArcSwap<SyncStatus>>>>,
     /// Per-agent RuntimeConfig for reading live hot-reloaded configuration.
     pub runtime_configs: ArcSwap<HashMap<String, Arc<RuntimeConfig>>>,
     /// Per-agent MCP managers for status and reconnect APIs.
@@ -310,6 +315,8 @@ impl ApiState {
             cron_schedulers: arc_swap::ArcSwap::from_pointee(HashMap::new()),
             task_stores: arc_swap::ArcSwap::from_pointee(HashMap::new()),
             project_stores: arc_swap::ArcSwap::from_pointee(HashMap::new()),
+            registry_stores: arc_swap::ArcSwap::from_pointee(HashMap::new()),
+            registry_sync_status: arc_swap::ArcSwap::from_pointee(HashMap::new()),
             runtime_configs: ArcSwap::from_pointee(HashMap::new()),
             mcp_managers: ArcSwap::from_pointee(HashMap::new()),
             sandboxes: ArcSwap::from_pointee(HashMap::new()),
@@ -754,6 +761,19 @@ impl ApiState {
     /// Set the project stores for all agents.
     pub fn set_project_stores(&self, stores: HashMap<String, Arc<ProjectStore>>) {
         self.project_stores.store(Arc::new(stores));
+    }
+
+    /// Set the registry stores for all agents.
+    pub fn set_registry_stores(&self, stores: HashMap<String, Arc<RegistryStore>>) {
+        self.registry_stores.store(Arc::new(stores));
+    }
+
+    /// Set the registry sync status trackers for all agents.
+    pub fn set_registry_sync_status(
+        &self,
+        status: HashMap<String, Arc<ArcSwap<SyncStatus>>>,
+    ) {
+        self.registry_sync_status.store(Arc::new(status));
     }
 
     /// Set the runtime configs for all agents.

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -12,8 +12,8 @@ use crate::memory::{EmbeddingModel, MemorySearch};
 use crate::messaging::MessagingManager;
 use crate::messaging::webchat::WebChatAdapter;
 use crate::projects::ProjectStore;
-use crate::registry::{RegistryStore, SyncStatus};
 use crate::prompts::PromptEngine;
+use crate::registry::{RegistryStore, SyncStatus};
 use crate::tasks::TaskStore;
 use crate::update::SharedUpdateStatus;
 use crate::{ProcessEvent, ProcessId};
@@ -769,10 +769,7 @@ impl ApiState {
     }
 
     /// Set the registry sync status trackers for all agents.
-    pub fn set_registry_sync_status(
-        &self,
-        status: HashMap<String, Arc<ArcSwap<SyncStatus>>>,
-    ) {
+    pub fn set_registry_sync_status(&self, status: HashMap<String, Arc<ArcSwap<SyncStatus>>>) {
         self.registry_sync_status.store(Arc::new(status));
     }
 

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -510,7 +510,9 @@ pub(super) async fn create_worktree(
             tracing::warn!(%e, "failed to find git root");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-    let root = String::from_utf8_lossy(&repo_root.stdout).trim().to_string();
+    let root = String::from_utf8_lossy(&repo_root.stdout)
+        .trim()
+        .to_string();
     let worktree_dir = format!("{}/../.spacebot-worktrees/task-{number}", root);
 
     // Create branch from base

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -5,6 +5,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tokio::process::Command as TokioCommand;
 
 #[derive(Deserialize)]
 pub(super) struct TaskListQuery {
@@ -372,4 +373,74 @@ pub(super) async fn execute_task(
         .ok();
 
     Ok(Json(TaskResponse { task }))
+}
+
+#[derive(Serialize)]
+pub(super) struct TaskDiffResponse {
+    task_number: i64,
+    diff: String,
+    branch: Option<String>,
+    worktree: Option<String>,
+}
+
+/// Get the git diff for a task. Reads `worktree` and `branch` from task
+/// metadata to determine which diff to show.
+pub(super) async fn task_diff(
+    State(state): State<Arc<ApiState>>,
+    Path(number): Path<i64>,
+    Query(query): Query<TaskGetQuery>,
+) -> Result<Json<TaskDiffResponse>, StatusCode> {
+    let stores = state.task_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let task = store
+        .get_by_number(&query.agent_id, number)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, agent_id = %query.agent_id, task_number = number, "failed to get task for diff");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let metadata = task.metadata.as_ref();
+    let worktree_path = metadata
+        .and_then(|m| m.get("worktree"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let branch = metadata
+        .and_then(|m| m.get("branch"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let diff = if let Some(ref wt) = worktree_path {
+        let output = TokioCommand::new("git")
+            .args(["diff", "HEAD"])
+            .current_dir(wt)
+            .output()
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, worktree = %wt, "failed to run git diff in worktree");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        String::from_utf8_lossy(&output.stdout).to_string()
+    } else if let Some(ref br) = branch {
+        let output = TokioCommand::new("git")
+            .args(["diff", &format!("main...{br}")])
+            .output()
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, branch = %br, "failed to run git diff for branch");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        String::from_utf8_lossy(&output.stdout).to_string()
+    } else {
+        String::new()
+    };
+
+    Ok(Json(TaskDiffResponse {
+        task_number: number,
+        diff,
+        branch,
+        worktree: worktree_path,
+    }))
 }

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -444,3 +444,207 @@ pub(super) async fn task_diff(
         worktree: worktree_path,
     }))
 }
+
+#[derive(Deserialize)]
+pub(super) struct WorktreeRequest {
+    agent_id: String,
+    #[serde(default)]
+    base_branch: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(super) struct WorktreeResponse {
+    task_number: i64,
+    branch: String,
+    worktree_path: String,
+    created: bool,
+}
+
+/// Create a git worktree for a task. Creates a new branch `task/{number}` and
+/// a worktree directory. Stores the path and branch in task metadata.
+pub(super) async fn create_worktree(
+    State(state): State<Arc<ApiState>>,
+    Path(number): Path<i64>,
+    Json(request): Json<WorktreeRequest>,
+) -> Result<Json<WorktreeResponse>, StatusCode> {
+    let stores = state.task_stores.load();
+    let store = stores.get(&request.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let task = store
+        .get_by_number(&request.agent_id, number)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to get task for worktree creation");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // Check if worktree already exists
+    if let Some(existing) = task.metadata.as_ref().and_then(|m| m.get("worktree")) {
+        if let Some(path) = existing.as_str() {
+            let branch = task
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("branch"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+            return Ok(Json(WorktreeResponse {
+                task_number: number,
+                branch,
+                worktree_path: path.to_string(),
+                created: false,
+            }));
+        }
+    }
+
+    let branch_name = format!("task/{number}");
+    let base = request.base_branch.as_deref().unwrap_or("main");
+
+    // Determine worktree directory (next to the repo)
+    let repo_root = TokioCommand::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to find git root");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let root = String::from_utf8_lossy(&repo_root.stdout).trim().to_string();
+    let worktree_dir = format!("{}/../.spacebot-worktrees/task-{number}", root);
+
+    // Create branch from base
+    let branch_result = TokioCommand::new("git")
+        .args(["branch", &branch_name, base])
+        .output()
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to create branch");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if !branch_result.status.success() {
+        let stderr = String::from_utf8_lossy(&branch_result.stderr);
+        // Branch may already exist, which is fine
+        if !stderr.contains("already exists") {
+            tracing::warn!(%stderr, "git branch creation failed");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Create worktree
+    let wt_result = TokioCommand::new("git")
+        .args(["worktree", "add", &worktree_dir, &branch_name])
+        .output()
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to create worktree");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if !wt_result.status.success() {
+        let stderr = String::from_utf8_lossy(&wt_result.stderr);
+        tracing::warn!(%stderr, "git worktree add failed");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // Update task metadata with worktree info
+    let mut metadata = task.metadata.unwrap_or_else(|| serde_json::json!({}));
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert("worktree".to_string(), serde_json::json!(worktree_dir));
+        obj.insert("branch".to_string(), serde_json::json!(branch_name));
+    }
+
+    let updated_task = store
+        .update(
+            &request.agent_id,
+            number,
+            crate::tasks::UpdateTaskInput {
+                metadata: Some(metadata),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to update task metadata with worktree");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    state
+        .event_tx
+        .send(super::state::ApiEvent::TaskUpdated {
+            agent_id: updated_task.agent_id.clone(),
+            task_number: updated_task.task_number,
+            status: updated_task.status.to_string(),
+            action: "updated".to_string(),
+        })
+        .ok();
+
+    Ok(Json(WorktreeResponse {
+        task_number: number,
+        branch: branch_name,
+        worktree_path: worktree_dir,
+        created: true,
+    }))
+}
+
+/// Remove a task's git worktree and optionally delete the branch.
+pub(super) async fn delete_worktree(
+    State(state): State<Arc<ApiState>>,
+    Path(number): Path<i64>,
+    Query(query): Query<TaskGetQuery>,
+) -> Result<Json<TaskActionResponse>, StatusCode> {
+    let stores = state.task_stores.load();
+    let store = stores.get(&query.agent_id).ok_or(StatusCode::NOT_FOUND)?;
+
+    let task = store
+        .get_by_number(&query.agent_id, number)
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to get task for worktree deletion");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let worktree_path = task
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("worktree"))
+        .and_then(|v| v.as_str())
+        .ok_or(StatusCode::NOT_FOUND)?
+        .to_string();
+
+    // Remove worktree
+    let _ = TokioCommand::new("git")
+        .args(["worktree", "remove", &worktree_path, "--force"])
+        .output()
+        .await;
+
+    // Clean metadata
+    let mut metadata = task.metadata.unwrap_or_else(|| serde_json::json!({}));
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.remove("worktree");
+        // Keep branch reference for history
+    }
+
+    store
+        .update(
+            &query.agent_id,
+            number,
+            crate::tasks::UpdateTaskInput {
+                metadata: Some(metadata),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| {
+            tracing::warn!(%e, "failed to update task after worktree removal");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(TaskActionResponse {
+        success: true,
+        message: format!("Worktree removed for task #{number}"),
+    }))
+}

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -402,13 +402,14 @@ pub(super) async fn task_diff(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    let metadata = task.metadata.as_ref();
-    let worktree_path = metadata
-        .and_then(|m| m.get("worktree"))
+    let worktree_path = task
+        .metadata
+        .get("worktree")
         .and_then(|v| v.as_str())
         .map(String::from);
-    let branch = metadata
-        .and_then(|m| m.get("branch"))
+    let branch = task
+        .metadata
+        .get("branch")
         .and_then(|v| v.as_str())
         .map(String::from);
 
@@ -480,12 +481,11 @@ pub(super) async fn create_worktree(
         .ok_or(StatusCode::NOT_FOUND)?;
 
     // Check if worktree already exists
-    if let Some(existing) = task.metadata.as_ref().and_then(|m| m.get("worktree")) {
+    if let Some(existing) = task.metadata.get("worktree") {
         if let Some(path) = existing.as_str() {
             let branch = task
                 .metadata
-                .as_ref()
-                .and_then(|m| m.get("branch"))
+                .get("branch")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_string();
@@ -551,7 +551,7 @@ pub(super) async fn create_worktree(
     }
 
     // Update task metadata with worktree info
-    let mut metadata = task.metadata.unwrap_or_else(|| serde_json::json!({}));
+    let mut metadata = task.metadata;
     if let Some(obj) = metadata.as_object_mut() {
         obj.insert("worktree".to_string(), serde_json::json!(worktree_dir));
         obj.insert("branch".to_string(), serde_json::json!(branch_name));
@@ -611,8 +611,7 @@ pub(super) async fn delete_worktree(
 
     let worktree_path = task
         .metadata
-        .as_ref()
-        .and_then(|m| m.get("worktree"))
+        .get("worktree")
         .and_then(|v| v.as_str())
         .ok_or(StatusCode::NOT_FOUND)?
         .to_string();
@@ -624,7 +623,7 @@ pub(super) async fn delete_worktree(
         .await;
 
     // Clean metadata
-    let mut metadata = task.metadata.unwrap_or_else(|| serde_json::json!({}));
+    let mut metadata = task.metadata;
     if let Some(obj) = metadata.as_object_mut() {
         obj.remove("worktree");
         // Keep branch reference for history

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1629,6 +1629,9 @@ impl Config {
                         exclude_patterns: r
                             .exclude_patterns
                             .unwrap_or_else(|| base.exclude_patterns.clone()),
+                        notification_target: r
+                            .notification_target
+                            .or_else(|| base.notification_target.clone()),
                     }
                 })
                 .unwrap_or_else(|| base_defaults.registry.clone()),

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1632,6 +1632,9 @@ impl Config {
                         notification_target: r
                             .notification_target
                             .or_else(|| base.notification_target.clone()),
+                        pr_conflict_check_interval_secs: r
+                            .pr_conflict_check_interval_secs
+                            .or(base.pr_conflict_check_interval_secs),
                     }
                 })
                 .unwrap_or_else(|| base_defaults.registry.clone()),

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1617,14 +1617,14 @@ impl Config {
                     let base = &base_defaults.registry;
                     RegistryConfig {
                         enabled: r.enabled.unwrap_or(base.enabled),
-                        github_owners: r.github_owners.unwrap_or_else(|| base.github_owners.clone()),
+                        github_owners: r
+                            .github_owners
+                            .unwrap_or_else(|| base.github_owners.clone()),
                         clone_base_dir: r
                             .clone_base_dir
                             .map(std::path::PathBuf::from)
                             .unwrap_or_else(|| base.clone_base_dir.clone()),
-                        sync_interval_secs: r
-                            .sync_interval_secs
-                            .unwrap_or(base.sync_interval_secs),
+                        sync_interval_secs: r.sync_interval_secs.unwrap_or(base.sync_interval_secs),
                         auto_clone: r.auto_clone.unwrap_or(base.auto_clone),
                         exclude_patterns: r
                             .exclude_patterns

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -15,7 +15,7 @@ use super::{
     CoalesceConfig, CompactionConfig, Config, CortexConfig, CronDef, DefaultsConfig, DiscordConfig,
     DiscordInstanceConfig, EmailConfig, EmailInstanceConfig, GroupDef, HumanDef, IngestionConfig,
     LinkDef, LlmConfig, McpServerConfig, McpTransport, MemoryPersistenceConfig, MessagingConfig,
-    MetricsConfig, OpenCodeConfig, ProjectsConfig, ProviderConfig, SignalConfig,
+    MetricsConfig, OpenCodeConfig, ProjectsConfig, ProviderConfig, RegistryConfig, SignalConfig,
     SignalInstanceConfig, SlackCommandConfig, SlackConfig, SlackInstanceConfig, TelegramConfig,
     TelegramInstanceConfig, TelemetryConfig, TwitchConfig, TwitchInstanceConfig, WarmupConfig,
     WebhookConfig, normalize_adapter, validate_named_messaging_adapters,
@@ -1610,6 +1610,28 @@ impl Config {
                     }
                 })
                 .unwrap_or_else(|| base_defaults.projects.clone()),
+            registry: toml
+                .defaults
+                .registry
+                .map(|r| {
+                    let base = &base_defaults.registry;
+                    RegistryConfig {
+                        enabled: r.enabled.unwrap_or(base.enabled),
+                        github_owners: r.github_owners.unwrap_or_else(|| base.github_owners.clone()),
+                        clone_base_dir: r
+                            .clone_base_dir
+                            .map(std::path::PathBuf::from)
+                            .unwrap_or_else(|| base.clone_base_dir.clone()),
+                        sync_interval_secs: r
+                            .sync_interval_secs
+                            .unwrap_or(base.sync_interval_secs),
+                        auto_clone: r.auto_clone.unwrap_or(base.auto_clone),
+                        exclude_patterns: r
+                            .exclude_patterns
+                            .unwrap_or_else(|| base.exclude_patterns.clone()),
+                    }
+                })
+                .unwrap_or_else(|| base_defaults.registry.clone()),
         };
 
         let mut agents: Vec<AgentConfig> = toml

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -77,6 +77,8 @@ pub struct RuntimeConfig {
     pub sandbox: Arc<ArcSwap<crate::sandbox::SandboxConfig>>,
     /// Projects workspace management configuration.
     pub projects: ArcSwap<crate::config::ProjectsConfig>,
+    /// Registry configuration for auto-discovering GitHub repos.
+    pub registry: ArcSwap<crate::config::RegistryConfig>,
     /// Shared browser state for persistent sessions.
     ///
     /// When `browser.persist_session = true`, all workers share this handle so
@@ -141,6 +143,7 @@ impl RuntimeConfig {
             secrets: ArcSwap::from_pointee(None),
             sandbox: Arc::new(ArcSwap::from_pointee(agent_config.sandbox.clone())),
             projects: ArcSwap::from_pointee(agent_config.projects.clone()),
+            registry: ArcSwap::from_pointee(agent_config.registry.clone()),
             shared_browser: if agent_config.browser.persist_session {
                 Some(crate::tools::browser::new_shared_browser_handle())
             } else {
@@ -294,6 +297,8 @@ impl RuntimeConfig {
         new_sandbox.project_paths = existing_project_paths;
         self.sandbox.store(Arc::new(new_sandbox));
         self.projects.store(Arc::new(resolved.projects.clone()));
+        self.registry
+            .store(Arc::new(config.defaults.registry.clone()));
 
         let old_opencode = self.opencode.load().as_ref().clone();
         let new_opencode = config.defaults.opencode.clone();

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -308,6 +308,7 @@ pub(super) struct TomlRegistryConfig {
     pub(super) auto_clone: Option<bool>,
     #[serde(default)]
     pub(super) exclude_patterns: Option<Vec<String>>,
+    pub(super) notification_target: Option<String>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -294,6 +294,20 @@ pub(super) struct TomlDefaultsConfig {
     pub(super) opencode: Option<TomlOpenCodeConfig>,
     pub(super) worker_log_mode: Option<String>,
     pub(super) projects: Option<TomlProjectsConfig>,
+    pub(super) registry: Option<TomlRegistryConfig>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct TomlRegistryConfig {
+    #[serde(default)]
+    pub(super) enabled: Option<bool>,
+    #[serde(default)]
+    pub(super) github_owners: Option<Vec<String>>,
+    pub(super) clone_base_dir: Option<String>,
+    pub(super) sync_interval_secs: Option<u64>,
+    pub(super) auto_clone: Option<bool>,
+    #[serde(default)]
+    pub(super) exclude_patterns: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -309,6 +309,7 @@ pub(super) struct TomlRegistryConfig {
     #[serde(default)]
     pub(super) exclude_patterns: Option<Vec<String>>,
     pub(super) notification_target: Option<String>,
+    pub(super) pr_conflict_check_interval_secs: Option<u64>,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1013,6 +1013,9 @@ pub struct RegistryConfig {
     pub auto_clone: bool,
     /// Repos to exclude from the registry (exact match or trailing `*` glob).
     pub exclude_patterns: Vec<String>,
+    /// Optional delivery target for notifications when repos are discovered/archived.
+    /// Format: "adapter:target" (e.g., "telegram:1285309093", "discord:123456789").
+    pub notification_target: Option<String>,
 }
 
 impl Default for RegistryConfig {
@@ -1024,6 +1027,7 @@ impl Default for RegistryConfig {
             sync_interval_secs: 3600,
             auto_clone: false,
             exclude_patterns: Vec::new(),
+            notification_target: None,
         }
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1016,6 +1016,11 @@ pub struct RegistryConfig {
     /// Optional delivery target for notifications when repos are discovered/archived.
     /// Format: "adapter:target" (e.g., "telegram:1285309093", "discord:123456789").
     pub notification_target: Option<String>,
+    /// Interval in seconds for PR conflict checking (default: 600 = 10 minutes).
+    /// Set to 0 to disable. When enabled, open PRs across registered repos are
+    /// polled for merge conflicts. Conflicting PRs trigger a message to the
+    /// channel agent which spawns a worker to resolve them.
+    pub pr_conflict_check_interval_secs: Option<u64>,
 }
 
 impl Default for RegistryConfig {
@@ -1028,6 +1033,7 @@ impl Default for RegistryConfig {
             auto_clone: false,
             exclude_patterns: Vec::new(),
             notification_target: None,
+            pr_conflict_check_interval_secs: None,
         }
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -550,6 +550,8 @@ pub struct DefaultsConfig {
     pub worker_log_mode: crate::settings::WorkerLogMode,
     /// Projects workspace management defaults.
     pub projects: ProjectsConfig,
+    /// Registry configuration for auto-discovering GitHub repos.
+    pub registry: RegistryConfig,
 }
 
 impl std::fmt::Debug for DefaultsConfig {
@@ -581,6 +583,7 @@ impl std::fmt::Debug for DefaultsConfig {
             .field("opencode", &self.opencode)
             .field("worker_log_mode", &self.worker_log_mode)
             .field("projects", &self.projects)
+            .field("registry", &self.registry)
             .finish()
     }
 }
@@ -995,6 +998,36 @@ impl Default for ProjectsConfig {
     }
 }
 
+/// Registry configuration for auto-discovering GitHub repositories.
+#[derive(Debug, Clone)]
+pub struct RegistryConfig {
+    /// Whether the registry sync is enabled.
+    pub enabled: bool,
+    /// GitHub user/org names to discover repos from.
+    pub github_owners: Vec<String>,
+    /// Base directory for auto-cloning repos.
+    pub clone_base_dir: std::path::PathBuf,
+    /// Sync interval in seconds (default: 3600 = 1 hour).
+    pub sync_interval_secs: u64,
+    /// Whether to auto-clone newly discovered repos.
+    pub auto_clone: bool,
+    /// Repos to exclude from the registry (exact match or trailing `*` glob).
+    pub exclude_patterns: Vec<String>,
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            github_owners: Vec::new(),
+            clone_base_dir: std::path::PathBuf::from("/tmp/spacebot-repos"),
+            sync_interval_secs: 3600,
+            auto_clone: false,
+            exclude_patterns: Vec::new(),
+        }
+    }
+}
+
 /// Current warmup lifecycle state.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1198,6 +1231,8 @@ pub struct ResolvedAgentConfig {
     pub sandbox: crate::sandbox::SandboxConfig,
     /// Projects workspace management settings.
     pub projects: ProjectsConfig,
+    /// Registry configuration for auto-discovering GitHub repos.
+    pub registry: RegistryConfig,
     /// Number of messages to fetch from the platform when a new channel is created.
     pub history_backfill_count: usize,
     pub cron: Vec<CronDef>,
@@ -1229,6 +1264,7 @@ impl Default for DefaultsConfig {
             opencode: OpenCodeConfig::default(),
             worker_log_mode: crate::settings::WorkerLogMode::default(),
             projects: ProjectsConfig::default(),
+            registry: RegistryConfig::default(),
         }
     }
 }
@@ -1300,6 +1336,7 @@ impl AgentConfig {
                 .projects
                 .clone()
                 .unwrap_or_else(|| defaults.projects.clone()),
+            registry: defaults.registry.clone(),
             history_backfill_count: defaults.history_backfill_count,
             cron: self.cron.clone(),
         }

--- a/src/conversation/history.rs
+++ b/src/conversation/history.rs
@@ -446,7 +446,10 @@ impl ProcessRunLogger {
         let id = worker_id.to_string();
 
         tokio::spawn(async move {
-            if let Err(error) = sqlx::query("UPDATE worker_runs SET status = 'idle' WHERE id = ?")
+            // Only transition to idle if the worker is not already in a terminal
+            // state (done/failed/completed/cancelled). This prevents a race where
+            // a fire-and-forget idle update overwrites a completed status.
+            if let Err(error) = sqlx::query("UPDATE worker_runs SET status = 'idle' WHERE id = ? AND status NOT IN ('done', 'failed', 'completed', 'cancelled')")
                 .bind(&id)
                 .execute(&pool)
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod telemetry;
 pub mod tools;
 pub mod update;
 pub mod upgrade;
+pub mod watchdog;
 
 pub use error::{Error, Result};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod openai_auth;
 pub mod opencode;
 pub mod projects;
 pub mod prompts;
+pub mod registry;
 pub mod sandbox;
 pub mod secrets;
 pub mod self_awareness;
@@ -386,6 +387,7 @@ pub struct AgentDeps {
     pub mcp_manager: Arc<mcp::McpManager>,
     pub task_store: Arc<tasks::TaskStore>,
     pub project_store: Arc<projects::ProjectStore>,
+    pub registry_store: Arc<registry::RegistryStore>,
     pub cron_tool: Option<tools::CronTool>,
     pub runtime_config: Arc<config::RuntimeConfig>,
     pub event_tx: tokio::sync::broadcast::Sender<ProcessEvent>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod tasks;
 pub mod telemetry;
 pub mod tools;
 pub mod update;
+pub mod upgrade;
 
 pub use error::{Error, Result};
 

--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -36,7 +36,7 @@ pub struct RoutingConfig {
 
 impl Default for RoutingConfig {
     fn default() -> Self {
-        Self::for_model("anthropic/claude-sonnet-4".into())
+        Self::for_model("anthropic/claude-sonnet-4-20250514".into())
     }
 }
 
@@ -163,7 +163,7 @@ pub fn is_context_overflow_error(error_message: &str) -> bool {
 /// each provider sane defaults so things work out of the box.
 pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
     match provider {
-        "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4".into()),
+        "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4-20250514".into()),
         "openrouter" => {
             let channel: String = "openrouter/anthropic/claude-sonnet-4-20250514".into();
             let worker: String = "openrouter/anthropic/claude-haiku-4.5-20250514".into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,7 +644,11 @@ fn cmd_upgrade(
     }
 
     eprintln!();
-    eprintln!("upgrade complete: {} → {}", &check.local_head[..8], &check.remote_head[..8]);
+    eprintln!(
+        "upgrade complete: {} → {}",
+        &check.local_head[..8],
+        &check.remote_head[..8]
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2097,6 +2097,37 @@ async fn run(
         }
     }
 
+    // Startup catch-up: scan for issues missed during downtime.
+    // Runs as a background task so it doesn't block the main event loop.
+    if agents_initialized {
+        let catchup_injection_tx = injection_tx.clone();
+        let catchup_agents: Vec<_> = agents
+            .iter()
+            .map(|(id, a)| (id.to_string(), a.deps.registry_store.clone()))
+            .collect();
+        tokio::spawn(async move {
+            // Small delay to let the main loop start accepting messages first
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            for (agent_id, registry_store) in &catchup_agents {
+                spacebot::watchdog::run_startup_catchup(
+                    agent_id,
+                    registry_store,
+                    &catchup_injection_tx,
+                )
+                .await;
+            }
+        });
+    }
+
+    // Health watchdog: exit if no messages are processed for 10 minutes.
+    // systemd will restart the service automatically.
+    let watchdog = spacebot::watchdog::spawn_watchdog(
+        std::time::Duration::from_secs(600),  // 10 minute timeout
+        std::time::Duration::from_secs(60),    // check every minute
+    );
+    // Ping immediately so the watchdog doesn't trigger during initial quiet period
+    watchdog.ping();
+
     // Main event loop: route inbound messages to agent channels
     loop {
         // Poll the inbound stream if it exists, otherwise yield a never-resolving future
@@ -2319,6 +2350,8 @@ async fn run(
                             "failed to forward message to channel"
                         );
                         active_channels.remove(&conversation_id);
+                    } else {
+                        watchdog.ping();
                     }
                 }
             }
@@ -2347,6 +2380,7 @@ async fn run(
                             "failed to forward injected message to channel"
                         );
                     } else {
+                        watchdog.ping();
                         tracing::info!(
                             conversation_id = %injection.conversation_id,
                             agent_id = %injection.agent_id,
@@ -2354,6 +2388,10 @@ async fn run(
                         );
                     }
                 } else {
+                    // No active channel — the catch-up message will be routed
+                    // when the next inbound message creates the channel.
+                    // Still ping watchdog since we're processing events.
+                    watchdog.ping();
                     tracing::info!(
                         conversation_id = %injection.conversation_id,
                         agent_id = %injection.agent_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ enum Command {
     },
     /// Show status of the running daemon
     Status,
+    /// Start in local mode (foreground + auto-open browser)
+    Local {
+        /// Port to serve on (default: 19898)
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
     /// Manage skills
     #[command(subcommand)]
     Skill(SkillCommand),
@@ -363,13 +369,14 @@ fn main() -> anyhow::Result<()> {
     let command = cli.command.unwrap_or(Command::Start { foreground: false });
 
     match command {
-        Command::Start { foreground } => cmd_start(cli.config, cli.debug, foreground),
+        Command::Start { foreground } => cmd_start(cli.config, cli.debug, foreground, None),
         Command::Stop => cmd_stop(),
         Command::Restart { foreground } => {
             cmd_stop_if_running();
-            cmd_start(cli.config, cli.debug, foreground)
+            cmd_start(cli.config, cli.debug, foreground, None)
         }
         Command::Status => cmd_status(),
+        Command::Local { port } => cmd_start(cli.config, cli.debug, true, port),
         Command::Skill(skill_cmd) => cmd_skill(cli.config, skill_cmd),
         Command::Auth(auth_cmd) => cmd_auth(cli.config, auth_cmd),
         Command::Secrets(secrets_cmd) => cmd_secrets(cli.config, secrets_cmd),
@@ -395,6 +402,7 @@ fn cmd_start(
     config_path: Option<std::path::PathBuf>,
     debug: bool,
     foreground: bool,
+    port_override: Option<u16>,
 ) -> anyhow::Result<()> {
     // Use the config path (if provided) to derive the correct instance dir
     // for the PID check, so it matches the PID file written during daemonize.
@@ -438,7 +446,12 @@ fn cmd_start(
     // we are either in foreground mode (no fork) or in the daemon child process.
     let bootstrapped_store = bootstrap_secrets_store(&resolved_config_path);
 
-    let config = load_config(&resolved_config_path)?;
+    let mut config = load_config(&resolved_config_path)?;
+
+    // Apply port override for `spacebot local --port`
+    if let Some(port) = port_override {
+        config.api.port = port;
+    }
 
     // Build a fresh Tokio runtime in this process (the child after daemonize,
     // or the foreground process). Tracing init — including the OTLP batch
@@ -450,6 +463,10 @@ fn cmd_start(
         .build()
         .context("failed to build Tokio runtime")?;
 
+    // Auto-open browser for `spacebot local` (foreground + port_override set)
+    let open_browser = foreground && port_override.is_some();
+    let browser_url = format!("http://{}:{}", config.api.bind, config.api.port);
+
     runtime.block_on(async {
         let otel_provider = if foreground {
             spacebot::daemon::init_foreground_tracing(debug, &config.telemetry)
@@ -457,6 +474,19 @@ fn cmd_start(
             let paths = spacebot::daemon::DaemonPaths::new(&config.instance_dir);
             spacebot::daemon::init_background_tracing(&paths, debug, &config.telemetry)
         };
+
+        if open_browser {
+            // Delay slightly so the server binds before the browser opens
+            let url = browser_url.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                eprintln!("\n  Opening {} in your browser...\n", url);
+                if let Err(e) = open::that(&url) {
+                    eprintln!("  Could not open browser: {e}");
+                    eprintln!("  Open manually: {url}");
+                }
+            });
+        }
 
         run(config, foreground, otel_provider, bootstrapped_store).await
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -2735,11 +2735,13 @@ async fn initialize_agents(
                 let reg_store = agent.deps.registry_store.as_ref().clone();
                 let reg_agent_id = agent_id.to_string();
                 let reg_runtime_config = agent.deps.runtime_config.clone();
+                let reg_messaging = agent.deps.messaging_manager.clone();
                 tokio::spawn(spacebot::registry::sync::registry_sync_loop(
                     reg_store,
                     reg_agent_id,
                     reg_runtime_config,
                     sync_status,
+                    reg_messaging,
                 ));
             }
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2528,6 +2528,7 @@ async fn initialize_agents(
             spacebot::memory::MemoryStore::with_agent_id(db.sqlite.clone(), &agent_config.id);
         let task_store = Arc::new(spacebot::tasks::TaskStore::new(db.sqlite.clone()));
         let project_store = Arc::new(spacebot::projects::ProjectStore::new(db.sqlite.clone()));
+        let registry_store = Arc::new(spacebot::registry::RegistryStore::new(db.sqlite.clone()));
         let embedding_table = spacebot::memory::EmbeddingTable::open_or_create(&db.lance)
             .await
             .with_context(|| {
@@ -2635,6 +2636,7 @@ async fn initialize_agents(
             mcp_manager,
             task_store: task_store.clone(),
             project_store: project_store.clone(),
+            registry_store: registry_store.clone(),
             cron_tool: None,
             runtime_config,
             event_tx,
@@ -2707,6 +2709,8 @@ async fn initialize_agents(
         let mut mcp_managers = std::collections::HashMap::new();
         let mut task_stores = std::collections::HashMap::new();
         let mut project_stores = std::collections::HashMap::new();
+        let mut registry_stores = std::collections::HashMap::new();
+        let mut registry_sync_statuses = std::collections::HashMap::new();
         let mut agent_workspaces = std::collections::HashMap::new();
         let mut agent_identity_dirs = std::collections::HashMap::new();
         let mut agent_data_dirs = std::collections::HashMap::new();
@@ -2720,6 +2724,24 @@ async fn initialize_agents(
             mcp_managers.insert(agent_id.to_string(), agent.deps.mcp_manager.clone());
             task_stores.insert(agent_id.to_string(), agent.deps.task_store.clone());
             project_stores.insert(agent_id.to_string(), agent.deps.project_store.clone());
+            registry_stores.insert(agent_id.to_string(), agent.deps.registry_store.clone());
+            // Registry sync: start background loop for each agent
+            {
+                let sync_status = std::sync::Arc::new(
+                    arc_swap::ArcSwap::from_pointee(spacebot::registry::SyncStatus::default()),
+                );
+                registry_sync_statuses
+                    .insert(agent_id.to_string(), sync_status.clone());
+                let reg_store = agent.deps.registry_store.as_ref().clone();
+                let reg_agent_id = agent_id.to_string();
+                let reg_runtime_config = agent.deps.runtime_config.clone();
+                tokio::spawn(spacebot::registry::sync::registry_sync_loop(
+                    reg_store,
+                    reg_agent_id,
+                    reg_runtime_config,
+                    sync_status,
+                ));
+            }
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
             agent_identity_dirs.insert(agent_id.to_string(), agent.config.identity_dir.clone());
             agent_data_dirs.insert(agent_id.to_string(), agent.config.data_dir.clone());
@@ -2744,6 +2766,8 @@ async fn initialize_agents(
         api_state.set_mcp_managers(mcp_managers);
         api_state.set_task_stores(task_stores);
         api_state.set_project_stores(project_stores);
+        api_state.set_registry_stores(registry_stores);
+        api_state.set_registry_sync_status(registry_sync_statuses);
         api_state.set_runtime_configs(runtime_configs);
         api_state.set_agent_workspaces(agent_workspaces);
         api_state.set_agent_identity_dirs(agent_identity_dirs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2007,34 +2007,33 @@ async fn run(
                 // conversation_id format: "webhook:github:{owner/repo}"
                 if let Some(repo_full_name) = conversation_id
                     .strip_prefix("webhook:github:")
+                    && let Some(agent) = agents.get(&agent_id)
                 {
-                    if let Some(agent) = agents.get(&agent_id) {
-                        let registry = &agent.deps.registry_store;
-                        match registry.get_by_full_name(&agent_id, repo_full_name).await {
-                            Ok(Some(reg_repo)) if !reg_repo.enabled => {
-                                tracing::debug!(
-                                    repo = %repo_full_name,
-                                    "webhook event dropped: repo disabled in registry"
-                                );
-                                continue;
-                            }
-                            Ok(None) => {
-                                tracing::debug!(
-                                    repo = %repo_full_name,
-                                    "webhook event dropped: repo not in registry"
-                                );
-                                continue;
-                            }
-                            Err(error) => {
-                                tracing::warn!(
-                                    repo = %repo_full_name,
-                                    %error,
-                                    "registry lookup failed, allowing webhook event"
-                                );
-                            }
-                            Ok(Some(_)) => {
-                                // Repo is enabled, proceed.
-                            }
+                    let registry = &agent.deps.registry_store;
+                    match registry.get_by_full_name(&agent_id, repo_full_name).await {
+                        Ok(Some(reg_repo)) if !reg_repo.enabled => {
+                            tracing::debug!(
+                                repo = %repo_full_name,
+                                "webhook event dropped: repo disabled in registry"
+                            );
+                            continue;
+                        }
+                        Ok(None) => {
+                            tracing::debug!(
+                                repo = %repo_full_name,
+                                "webhook event dropped: repo not in registry"
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                repo = %repo_full_name,
+                                %error,
+                                "registry lookup failed, allowing webhook event"
+                            );
+                        }
+                        Ok(Some(_)) => {
+                            // Repo is enabled, proceed.
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,32 @@ enum Command {
     /// Manage secrets stored in the running instance
     #[command(subcommand)]
     Secrets(SecretsCommand),
+    /// Pull latest source, rebuild, and restart the service
+    Upgrade {
+        /// Source directory (default: ~/.spacebot-src or SPACEBOT_SRC_DIR)
+        #[arg(long)]
+        source_dir: Option<std::path::PathBuf>,
+
+        /// Git remote to fetch from
+        #[arg(long, default_value = "origin")]
+        remote: String,
+
+        /// Git branch to pull (default: current branch)
+        #[arg(long)]
+        branch: Option<String>,
+
+        /// Binary install path (default: path of current executable)
+        #[arg(long)]
+        install_path: Option<std::path::PathBuf>,
+
+        /// Skip the service restart step
+        #[arg(long)]
+        no_restart: bool,
+
+        /// Only check for updates, don't apply
+        #[arg(long)]
+        check_only: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -347,6 +373,21 @@ fn main() -> anyhow::Result<()> {
         Command::Skill(skill_cmd) => cmd_skill(cli.config, skill_cmd),
         Command::Auth(auth_cmd) => cmd_auth(cli.config, auth_cmd),
         Command::Secrets(secrets_cmd) => cmd_secrets(cli.config, secrets_cmd),
+        Command::Upgrade {
+            source_dir,
+            remote,
+            branch,
+            install_path,
+            no_restart,
+            check_only,
+        } => cmd_upgrade(
+            source_dir,
+            remote,
+            branch,
+            install_path,
+            no_restart,
+            check_only,
+        ),
     }
 }
 
@@ -494,6 +535,88 @@ fn cmd_stop_if_running() {
             spacebot::daemon::wait_for_exit(pid);
         }
     });
+}
+
+fn cmd_upgrade(
+    source_dir: Option<std::path::PathBuf>,
+    remote: String,
+    branch: Option<String>,
+    install_path: Option<std::path::PathBuf>,
+    no_restart: bool,
+    check_only: bool,
+) -> anyhow::Result<()> {
+    use spacebot::upgrade;
+
+    let source_dir = upgrade::resolve_source_dir(source_dir.as_deref())?;
+    let install_path = upgrade::resolve_install_path(install_path.as_deref())?;
+
+    let branch = match branch {
+        Some(b) => b,
+        None => upgrade::current_branch(&source_dir)?,
+    };
+
+    eprintln!("source:  {}", source_dir.display());
+    eprintln!("remote:  {remote}/{branch}");
+    eprintln!("binary:  {}", install_path.display());
+    eprintln!();
+
+    // Check for updates
+    eprint!("checking for updates... ");
+    let check = upgrade::check_for_updates(&source_dir, &remote, &branch)?;
+
+    if !check.has_updates {
+        eprintln!("already up to date ({}).", &check.local_head[..8]);
+        return Ok(());
+    }
+
+    eprintln!(
+        "{} new commit{}:",
+        check.commit_count,
+        if check.commit_count == 1 { "" } else { "s" }
+    );
+    for summary in &check.commit_summaries {
+        eprintln!("  {summary}");
+    }
+    eprintln!();
+
+    if check_only {
+        return Ok(());
+    }
+
+    // Pull
+    eprint!("pulling... ");
+    upgrade::pull(&source_dir)?;
+    eprintln!("done.");
+
+    // Build
+    eprintln!("building release binary...");
+    let built_binary = upgrade::build_release(&source_dir, |line| {
+        eprintln!("  {line}");
+    })?;
+    eprintln!("build complete.");
+    eprintln!();
+
+    // Stop the running daemon before swapping the binary
+    cmd_stop_if_running();
+
+    // Install
+    eprint!("installing binary... ");
+    upgrade::install_binary(&built_binary, &install_path)?;
+    eprintln!("done.");
+
+    // Restart
+    if no_restart {
+        eprintln!("skipping restart (--no-restart).");
+    } else {
+        eprint!("restarting service... ");
+        upgrade::restart_service()?;
+        eprintln!("done.");
+    }
+
+    eprintln!();
+    eprintln!("upgrade complete: {} → {}", &check.local_head[..8], &check.remote_head[..8]);
+
+    Ok(())
 }
 
 fn cmd_status() -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2725,24 +2725,13 @@ async fn initialize_agents(
             task_stores.insert(agent_id.to_string(), agent.deps.task_store.clone());
             project_stores.insert(agent_id.to_string(), agent.deps.project_store.clone());
             registry_stores.insert(agent_id.to_string(), agent.deps.registry_store.clone());
-            // Registry sync: start background loop for each agent
+            // Registry sync: prepare status (spawn deferred until messaging_manager is set)
             {
                 let sync_status = std::sync::Arc::new(
                     arc_swap::ArcSwap::from_pointee(spacebot::registry::SyncStatus::default()),
                 );
                 registry_sync_statuses
                     .insert(agent_id.to_string(), sync_status.clone());
-                let reg_store = agent.deps.registry_store.as_ref().clone();
-                let reg_agent_id = agent_id.to_string();
-                let reg_runtime_config = agent.deps.runtime_config.clone();
-                let reg_messaging = agent.deps.messaging_manager.clone();
-                tokio::spawn(spacebot::registry::sync::registry_sync_loop(
-                    reg_store,
-                    reg_agent_id,
-                    reg_runtime_config,
-                    sync_status,
-                    reg_messaging,
-                ));
             }
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
             agent_identity_dirs.insert(agent_id.to_string(), agent.config.identity_dir.clone());
@@ -3214,6 +3203,24 @@ async fn initialize_agents(
     for (agent_id, agent) in agents.iter_mut() {
         let store = Arc::new(spacebot::cron::CronStore::new(agent.db.sqlite.clone()));
         agent.deps.messaging_manager = Some(messaging_manager.clone());
+
+        // Registry sync: spawn background loop now that messaging_manager is available
+        {
+            let statuses = api_state.registry_sync_status.load();
+            if let Some(sync_status) = statuses.get(&agent_id.to_string()) {
+                let reg_store = agent.deps.registry_store.as_ref().clone();
+                let reg_agent_id = agent_id.to_string();
+                let reg_runtime_config = agent.deps.runtime_config.clone();
+                let reg_messaging = agent.deps.messaging_manager.clone();
+                tokio::spawn(spacebot::registry::sync::registry_sync_loop(
+                    reg_store,
+                    reg_agent_id,
+                    reg_runtime_config,
+                    sync_status.clone(),
+                    reg_messaging,
+                ));
+            }
+        }
 
         // Seed cron jobs from config into the database
         for cron_def in &agent.config.cron {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2003,6 +2003,42 @@ async fn run(
 
                 let conversation_id = message.conversation_id.clone();
 
+                // Filter webhook events against the dynamic registry.
+                // conversation_id format: "webhook:github:{owner/repo}"
+                if let Some(repo_full_name) = conversation_id
+                    .strip_prefix("webhook:github:")
+                {
+                    if let Some(agent) = agents.get(&agent_id) {
+                        let registry = &agent.deps.registry_store;
+                        match registry.get_by_full_name(&agent_id, repo_full_name).await {
+                            Ok(Some(reg_repo)) if !reg_repo.enabled => {
+                                tracing::debug!(
+                                    repo = %repo_full_name,
+                                    "webhook event dropped: repo disabled in registry"
+                                );
+                                continue;
+                            }
+                            Ok(None) => {
+                                tracing::debug!(
+                                    repo = %repo_full_name,
+                                    "webhook event dropped: repo not in registry"
+                                );
+                                continue;
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    repo = %repo_full_name,
+                                    %error,
+                                    "registry lookup failed, allowing webhook event"
+                                );
+                            }
+                            Ok(Some(_)) => {
+                                // Repo is enabled, proceed.
+                            }
+                        }
+                    }
+                }
+
                 // Find or create a channel for this conversation
                 if !active_channels.contains_key(&conversation_id) {
                     let Some(agent) = agents.get(&agent_id) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3379,6 +3379,22 @@ async fn initialize_agents(
             }
         }
 
+        // PR conflict checker: spawn background loop to detect conflicting PRs.
+        if let Some(webhook_config) = &config.messaging.webhook
+            && webhook_config.enabled
+        {
+            let conflict_store = agent.deps.registry_store.as_ref().clone();
+            let conflict_agent_id = agent_id.to_string();
+            let conflict_runtime_config = agent.deps.runtime_config.clone();
+            let webhook_port = webhook_config.port;
+            tokio::spawn(spacebot::registry::pr_conflicts::pr_conflict_check_loop(
+                conflict_store,
+                conflict_agent_id,
+                conflict_runtime_config,
+                webhook_port,
+            ));
+        }
+
         // Seed cron jobs from config into the database
         for cron_def in &agent.config.cron {
             let cron_config = spacebot::cron::CronConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2727,11 +2727,10 @@ async fn initialize_agents(
             registry_stores.insert(agent_id.to_string(), agent.deps.registry_store.clone());
             // Registry sync: prepare status (spawn deferred until messaging_manager is set)
             {
-                let sync_status = std::sync::Arc::new(
-                    arc_swap::ArcSwap::from_pointee(spacebot::registry::SyncStatus::default()),
-                );
-                registry_sync_statuses
-                    .insert(agent_id.to_string(), sync_status.clone());
+                let sync_status = std::sync::Arc::new(arc_swap::ArcSwap::from_pointee(
+                    spacebot::registry::SyncStatus::default(),
+                ));
+                registry_sync_statuses.insert(agent_id.to_string(), sync_status.clone());
             }
             agent_workspaces.insert(agent_id.to_string(), agent.config.workspace.clone());
             agent_identity_dirs.insert(agent_id.to_string(), agent.config.identity_dir.clone());

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,6 +1,7 @@
 //! Dynamic project registry: auto-discovers GitHub repositories and keeps
 //! a persistent index of repos with per-repo config overrides.
 
+pub mod pr_conflicts;
 pub mod store;
 pub mod sync;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,8 @@
+//! Dynamic project registry: auto-discovers GitHub repositories and keeps
+//! a persistent index of repos with per-repo config overrides.
+
+pub mod store;
+pub mod sync;
+
+pub use store::{RegistryRepo, RegistryStore};
+pub use sync::{SyncResult, SyncStatus};

--- a/src/registry/pr_conflicts.rs
+++ b/src/registry/pr_conflicts.rs
@@ -150,8 +150,7 @@ pub async fn pr_conflict_check_loop(
 
     // Track which PRs we've already sent a conflict message for,
     // so we don't spam the channel on every check pass.
-    let mut notified: std::collections::HashSet<(String, u64)> =
-        std::collections::HashSet::new();
+    let mut notified: std::collections::HashSet<(String, u64)> = std::collections::HashSet::new();
 
     loop {
         let current_config = runtime_config.registry.load();

--- a/src/registry/pr_conflicts.rs
+++ b/src/registry/pr_conflicts.rs
@@ -1,0 +1,211 @@
+//! PR conflict checker: periodically scans open PRs across registered repos
+//! for merge conflicts and injects a message into the webhook channel so the
+//! agent can spawn a worker to resolve them.
+
+use crate::registry::store::RegistryStore;
+
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::time::Duration;
+
+/// Default interval between conflict check passes (10 minutes).
+const DEFAULT_CHECK_INTERVAL_SECS: u64 = 600;
+
+/// JSON shape returned by `gh pr list --json`.
+#[derive(Debug, Deserialize)]
+struct GhPr {
+    number: u64,
+    title: String,
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: String,
+    url: String,
+    mergeable: String,
+}
+
+/// Query open PRs for a single repo using `gh pr list`.
+async fn list_open_prs(repo: &str) -> Result<Vec<GhPr>, String> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,baseRefName,url,mergeable",
+            "--limit",
+            "50",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("failed to run `gh pr list`: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "`gh pr list --repo {repo}` failed: {}",
+            stderr.trim()
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("failed to parse gh pr list output for {repo}: {e}"))
+}
+
+/// Build a message that instructs the agent to fix a conflicting PR.
+fn build_conflict_message(repo: &str, pr: &GhPr) -> String {
+    format!(
+        "PR conflict detected — automatic resolution requested.\n\
+         Repo: {repo}\n\
+         PR #{}: {}\n\
+         Branch: {} -> {}\n\
+         URL: {}\n\
+         Status: CONFLICTING\n\n\
+         Resolve the merge conflicts on this PR. Check out the branch, \
+         rebase or merge the base branch, fix any conflicts, and push.",
+        pr.number, pr.title, pr.head_ref_name, pr.base_ref_name, pr.url,
+    )
+}
+
+/// Run a single conflict check pass across all registered repos.
+async fn check_all_repos(store: &RegistryStore, agent_id: &str) -> Vec<(String, GhPr)> {
+    let repos = match store.list_repos(agent_id, true).await {
+        Ok(repos) => repos,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to list repos for PR conflict check");
+            return Vec::new();
+        }
+    };
+
+    let mut conflicting = Vec::new();
+
+    for repo in &repos {
+        match list_open_prs(&repo.full_name).await {
+            Ok(prs) => {
+                for pr in prs {
+                    if pr.mergeable == "CONFLICTING" {
+                        tracing::info!(
+                            repo = %repo.full_name,
+                            pr_number = pr.number,
+                            pr_title = %pr.title,
+                            "PR has merge conflicts"
+                        );
+                        conflicting.push((repo.full_name.clone(), pr));
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    repo = %repo.full_name,
+                    error = %e,
+                    "skipping repo for conflict check"
+                );
+            }
+        }
+    }
+
+    conflicting
+}
+
+/// Forward a conflict message to the Spacebot webhook adapter so it enters
+/// the normal message routing pipeline.
+async fn forward_to_webhook(webhook_url: &str, repo: &str, message: &str) -> Result<(), String> {
+    let conversation_id = format!("github:{repo}");
+    let payload = serde_json::json!({
+        "conversation_id": conversation_id,
+        "sender_id": "pr-conflict-checker",
+        "content": message,
+    });
+
+    let client = reqwest::Client::new();
+    client
+        .post(webhook_url)
+        .json(&payload)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| format!("failed to forward conflict message: {e}"))?;
+
+    Ok(())
+}
+
+/// Background loop that checks for PR conflicts at a regular interval.
+///
+/// When a conflicting PR is found, a message is forwarded to the
+/// webhook adapter at `webhook_url`, creating a conversation in the
+/// `github:{repo}` channel so the agent can spawn a worker to fix it.
+pub async fn pr_conflict_check_loop(
+    store: RegistryStore,
+    agent_id: String,
+    runtime_config: Arc<crate::config::RuntimeConfig>,
+    webhook_port: u16,
+) {
+    // Initial delay to let the agent fully start up and registry sync to run first.
+    tokio::time::sleep(Duration::from_secs(90)).await;
+
+    let webhook_url = format!("http://127.0.0.1:{webhook_port}/send");
+
+    // Track which PRs we've already sent a conflict message for,
+    // so we don't spam the channel on every check pass.
+    let mut notified: std::collections::HashSet<(String, u64)> =
+        std::collections::HashSet::new();
+
+    loop {
+        let current_config = runtime_config.registry.load();
+        if !current_config.enabled {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            continue;
+        }
+
+        let check_interval = current_config
+            .pr_conflict_check_interval_secs
+            .unwrap_or(DEFAULT_CHECK_INTERVAL_SECS);
+
+        if check_interval == 0 {
+            // Disabled via config.
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            continue;
+        }
+
+        let conflicting = check_all_repos(&store, &agent_id).await;
+
+        for (repo, pr) in &conflicting {
+            let key = (repo.clone(), pr.number);
+            if notified.contains(&key) {
+                continue;
+            }
+
+            let message = build_conflict_message(repo, pr);
+            match forward_to_webhook(&webhook_url, repo, &message).await {
+                Ok(()) => {
+                    tracing::info!(
+                        repo = %repo,
+                        pr_number = pr.number,
+                        "sent conflict resolution request to channel"
+                    );
+                    notified.insert(key);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        repo = %repo,
+                        pr_number = pr.number,
+                        error = %e,
+                        "failed to send conflict resolution request"
+                    );
+                }
+            }
+        }
+
+        // Clean up notified set: remove entries for PRs that are no longer conflicting.
+        let current_conflicts: std::collections::HashSet<(String, u64)> = conflicting
+            .iter()
+            .map(|(repo, pr)| (repo.clone(), pr.number))
+            .collect();
+        notified.retain(|key| current_conflicts.contains(key));
+
+        tokio::time::sleep(Duration::from_secs(check_interval)).await;
+    }
+}

--- a/src/registry/store.rs
+++ b/src/registry/store.rs
@@ -272,6 +272,22 @@ impl RegistryStore {
         Ok(result.rows_affected())
     }
 
+    /// Get the full names of all non-archived repos for an agent.
+    pub async fn get_non_archived_names(&self, agent_id: &str) -> Result<Vec<String>> {
+        let rows = sqlx::query(
+            "SELECT full_name FROM registry_repos WHERE agent_id = ? AND is_archived = 0",
+        )
+        .bind(agent_id)
+        .fetch_all(&self.pool)
+        .await
+        .context("failed to fetch non-archived repo names")?;
+
+        rows.iter()
+            .map(|r| r.try_get("full_name").context("missing full_name"))
+            .collect::<std::result::Result<Vec<String>, _>>()
+            .map_err(Into::into)
+    }
+
     /// Delete a repo from the registry.
     pub async fn delete_repo(&self, agent_id: &str, full_name: &str) -> Result<bool> {
         let result = sqlx::query(

--- a/src/registry/store.rs
+++ b/src/registry/store.rs
@@ -115,14 +115,12 @@ impl RegistryStore {
         agent_id: &str,
         full_name: &str,
     ) -> Result<Option<RegistryRepo>> {
-        let row = sqlx::query(
-            "SELECT * FROM registry_repos WHERE agent_id = ? AND full_name = ?",
-        )
-        .bind(agent_id)
-        .bind(full_name)
-        .fetch_optional(&self.pool)
-        .await
-        .context("failed to fetch registry repo by full_name")?;
+        let row = sqlx::query("SELECT * FROM registry_repos WHERE agent_id = ? AND full_name = ?")
+            .bind(agent_id)
+            .bind(full_name)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed to fetch registry repo by full_name")?;
 
         row.map(|r| row_to_registry_repo(&r)).transpose()
     }
@@ -153,13 +151,11 @@ impl RegistryStore {
             .await
             .context("failed to list enabled registry repos")?
         } else {
-            sqlx::query(
-                "SELECT * FROM registry_repos WHERE agent_id = ? ORDER BY full_name ASC",
-            )
-            .bind(agent_id)
-            .fetch_all(&self.pool)
-            .await
-            .context("failed to list registry repos")?
+            sqlx::query("SELECT * FROM registry_repos WHERE agent_id = ? ORDER BY full_name ASC")
+                .bind(agent_id)
+                .fetch_all(&self.pool)
+                .await
+                .context("failed to list registry repos")?
         };
 
         rows.iter().map(row_to_registry_repo).collect()
@@ -290,14 +286,12 @@ impl RegistryStore {
 
     /// Delete a repo from the registry.
     pub async fn delete_repo(&self, agent_id: &str, full_name: &str) -> Result<bool> {
-        let result = sqlx::query(
-            "DELETE FROM registry_repos WHERE agent_id = ? AND full_name = ?",
-        )
-        .bind(agent_id)
-        .bind(full_name)
-        .execute(&self.pool)
-        .await
-        .context("failed to delete registry repo")?;
+        let result = sqlx::query("DELETE FROM registry_repos WHERE agent_id = ? AND full_name = ?")
+            .bind(agent_id)
+            .bind(full_name)
+            .execute(&self.pool)
+            .await
+            .context("failed to delete registry repo")?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -322,9 +316,7 @@ fn row_to_registry_repo(row: &sqlx::sqlite::SqliteRow) -> Result<RegistryRepo> {
         is_fork: row
             .try_get::<bool, _>("is_fork")
             .context("missing is_fork")?,
-        visibility: row
-            .try_get("visibility")
-            .context("missing visibility")?,
+        visibility: row.try_get("visibility").context("missing visibility")?,
         language: row.try_get("language").unwrap_or(None),
         local_path: row.try_get("local_path").unwrap_or(None),
         clone_url: row.try_get("clone_url").context("missing clone_url")?,
@@ -471,10 +463,7 @@ mod tests {
 
         // Only ChargePilot-Launch was seen in this sync
         let archived = store
-            .mark_absent_as_archived(
-                "main",
-                &["marcmantei/ChargePilot-Launch".into()],
-            )
+            .mark_absent_as_archived("main", &["marcmantei/ChargePilot-Launch".into()])
             .await
             .unwrap();
         assert_eq!(archived, 1);

--- a/src/registry/store.rs
+++ b/src/registry/store.rs
@@ -1,0 +1,539 @@
+//! SQLite-backed registry store for auto-discovered GitHub repositories.
+
+use crate::error::Result;
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use sqlx::{Row as _, SqlitePool};
+
+/// A GitHub repository tracked in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryRepo {
+    pub id: String,
+    pub agent_id: String,
+    pub owner: String,
+    pub name: String,
+    pub full_name: String,
+    pub description: String,
+    pub default_branch: String,
+    pub is_archived: bool,
+    pub is_fork: bool,
+    pub visibility: String,
+    pub language: Option<String>,
+    pub local_path: Option<String>,
+    pub clone_url: String,
+    pub ssh_url: String,
+    /// Per-repo model override (e.g., "anthropic/claude-sonnet-4").
+    pub worker_model: Option<String>,
+    /// Whether the agent should process events for this repo.
+    pub enabled: bool,
+    /// Link to the existing projects table.
+    pub project_id: Option<String>,
+    pub last_synced_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Input for upserting a repo discovered from `gh repo list`.
+#[derive(Debug, Clone)]
+pub struct UpsertRepoInput {
+    pub agent_id: String,
+    pub owner: String,
+    pub name: String,
+    pub full_name: String,
+    pub description: String,
+    pub default_branch: String,
+    pub is_archived: bool,
+    pub is_fork: bool,
+    pub visibility: String,
+    pub language: Option<String>,
+    pub clone_url: String,
+    pub ssh_url: String,
+}
+
+/// SQLite-backed registry store.
+#[derive(Debug, Clone)]
+pub struct RegistryStore {
+    pool: SqlitePool,
+}
+
+impl RegistryStore {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert or update a discovered repo. Preserves user-set overrides
+    /// (worker_model, enabled) on conflict.
+    pub async fn upsert_repo(&self, input: UpsertRepoInput) -> Result<RegistryRepo> {
+        let id = uuid::Uuid::new_v4().to_string();
+
+        sqlx::query(
+            r#"
+            INSERT INTO registry_repos (id, agent_id, owner, name, full_name, description,
+                default_branch, is_archived, is_fork, visibility, language, clone_url, ssh_url,
+                last_synced_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT (agent_id, full_name) DO UPDATE SET
+                description = excluded.description,
+                default_branch = excluded.default_branch,
+                is_archived = excluded.is_archived,
+                is_fork = excluded.is_fork,
+                visibility = excluded.visibility,
+                language = excluded.language,
+                clone_url = excluded.clone_url,
+                ssh_url = excluded.ssh_url,
+                last_synced_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            "#,
+        )
+        .bind(&id)
+        .bind(&input.agent_id)
+        .bind(&input.owner)
+        .bind(&input.name)
+        .bind(&input.full_name)
+        .bind(&input.description)
+        .bind(&input.default_branch)
+        .bind(input.is_archived)
+        .bind(input.is_fork)
+        .bind(&input.visibility)
+        .bind(&input.language)
+        .bind(&input.clone_url)
+        .bind(&input.ssh_url)
+        .execute(&self.pool)
+        .await
+        .context("failed to upsert registry repo")?;
+
+        Ok(self
+            .get_by_full_name(&input.agent_id, &input.full_name)
+            .await?
+            .context("repo not found after upsert")?)
+    }
+
+    /// Get a repo by its full name (e.g., "marcmantei/ChargePilot-Launch").
+    pub async fn get_by_full_name(
+        &self,
+        agent_id: &str,
+        full_name: &str,
+    ) -> Result<Option<RegistryRepo>> {
+        let row = sqlx::query(
+            "SELECT * FROM registry_repos WHERE agent_id = ? AND full_name = ?",
+        )
+        .bind(agent_id)
+        .bind(full_name)
+        .fetch_optional(&self.pool)
+        .await
+        .context("failed to fetch registry repo by full_name")?;
+
+        row.map(|r| row_to_registry_repo(&r)).transpose()
+    }
+
+    /// Get a repo by its ID.
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<RegistryRepo>> {
+        let row = sqlx::query("SELECT * FROM registry_repos WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .context("failed to fetch registry repo by id")?;
+
+        row.map(|r| row_to_registry_repo(&r)).transpose()
+    }
+
+    /// List all repos for an agent, optionally filtering by enabled status.
+    pub async fn list_repos(
+        &self,
+        agent_id: &str,
+        enabled_only: bool,
+    ) -> Result<Vec<RegistryRepo>> {
+        let rows = if enabled_only {
+            sqlx::query(
+                "SELECT * FROM registry_repos WHERE agent_id = ? AND enabled = 1 ORDER BY full_name ASC",
+            )
+            .bind(agent_id)
+            .fetch_all(&self.pool)
+            .await
+            .context("failed to list enabled registry repos")?
+        } else {
+            sqlx::query(
+                "SELECT * FROM registry_repos WHERE agent_id = ? ORDER BY full_name ASC",
+            )
+            .bind(agent_id)
+            .fetch_all(&self.pool)
+            .await
+            .context("failed to list registry repos")?
+        };
+
+        rows.iter().map(row_to_registry_repo).collect()
+    }
+
+    /// Update per-repo overrides.
+    pub async fn set_overrides(
+        &self,
+        agent_id: &str,
+        full_name: &str,
+        worker_model: Option<Option<String>>,
+        enabled: Option<bool>,
+    ) -> Result<Option<RegistryRepo>> {
+        let existing = self.get_by_full_name(agent_id, full_name).await?;
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
+
+        let worker_model = match worker_model {
+            Some(v) => v,
+            None => existing.worker_model,
+        };
+        let enabled = enabled.unwrap_or(existing.enabled);
+
+        sqlx::query(
+            r#"
+            UPDATE registry_repos
+            SET worker_model = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE agent_id = ? AND full_name = ?
+            "#,
+        )
+        .bind(&worker_model)
+        .bind(enabled)
+        .bind(agent_id)
+        .bind(full_name)
+        .execute(&self.pool)
+        .await
+        .context("failed to update registry repo overrides")?;
+
+        self.get_by_full_name(agent_id, full_name).await
+    }
+
+    /// Link a registry repo to an existing project.
+    pub async fn link_project(
+        &self,
+        agent_id: &str,
+        full_name: &str,
+        project_id: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE registry_repos SET project_id = ?, updated_at = CURRENT_TIMESTAMP WHERE agent_id = ? AND full_name = ?",
+        )
+        .bind(project_id)
+        .bind(agent_id)
+        .bind(full_name)
+        .execute(&self.pool)
+        .await
+        .context("failed to link registry repo to project")?;
+        Ok(())
+    }
+
+    /// Set the local_path for a repo (after cloning).
+    pub async fn set_local_path(
+        &self,
+        agent_id: &str,
+        full_name: &str,
+        local_path: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE registry_repos SET local_path = ?, updated_at = CURRENT_TIMESTAMP WHERE agent_id = ? AND full_name = ?",
+        )
+        .bind(local_path)
+        .bind(agent_id)
+        .bind(full_name)
+        .execute(&self.pool)
+        .await
+        .context("failed to set registry repo local_path")?;
+        Ok(())
+    }
+
+    /// Mark repos not seen in the latest sync as archived.
+    pub async fn mark_absent_as_archived(
+        &self,
+        agent_id: &str,
+        seen_full_names: &[String],
+    ) -> Result<u64> {
+        if seen_full_names.is_empty() {
+            return Ok(0);
+        }
+
+        // Build a parameterized IN clause
+        let placeholders: Vec<&str> = seen_full_names.iter().map(|_| "?").collect();
+        let in_clause = placeholders.join(", ");
+        let query = format!(
+            "UPDATE registry_repos SET is_archived = 1, updated_at = CURRENT_TIMESTAMP \
+             WHERE agent_id = ? AND full_name NOT IN ({}) AND is_archived = 0",
+            in_clause
+        );
+
+        let mut q = sqlx::query(&query).bind(agent_id);
+        for name in seen_full_names {
+            q = q.bind(name);
+        }
+
+        let result = q
+            .execute(&self.pool)
+            .await
+            .context("failed to mark absent repos as archived")?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Delete a repo from the registry.
+    pub async fn delete_repo(&self, agent_id: &str, full_name: &str) -> Result<bool> {
+        let result = sqlx::query(
+            "DELETE FROM registry_repos WHERE agent_id = ? AND full_name = ?",
+        )
+        .bind(agent_id)
+        .bind(full_name)
+        .execute(&self.pool)
+        .await
+        .context("failed to delete registry repo")?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+// Row mapping
+
+fn row_to_registry_repo(row: &sqlx::sqlite::SqliteRow) -> Result<RegistryRepo> {
+    Ok(RegistryRepo {
+        id: row.try_get("id").context("missing id")?,
+        agent_id: row.try_get("agent_id").context("missing agent_id")?,
+        owner: row.try_get("owner").context("missing owner")?,
+        name: row.try_get("name").context("missing name")?,
+        full_name: row.try_get("full_name").context("missing full_name")?,
+        description: row.try_get("description").context("missing description")?,
+        default_branch: row
+            .try_get("default_branch")
+            .context("missing default_branch")?,
+        is_archived: row
+            .try_get::<bool, _>("is_archived")
+            .context("missing is_archived")?,
+        is_fork: row
+            .try_get::<bool, _>("is_fork")
+            .context("missing is_fork")?,
+        visibility: row
+            .try_get("visibility")
+            .context("missing visibility")?,
+        language: row.try_get("language").unwrap_or(None),
+        local_path: row.try_get("local_path").unwrap_or(None),
+        clone_url: row.try_get("clone_url").context("missing clone_url")?,
+        ssh_url: row.try_get("ssh_url").context("missing ssh_url")?,
+        worker_model: row.try_get("worker_model").unwrap_or(None),
+        enabled: row
+            .try_get::<bool, _>("enabled")
+            .context("missing enabled")?,
+        project_id: row.try_get("project_id").unwrap_or(None),
+        last_synced_at: row.try_get("last_synced_at").unwrap_or(None),
+        created_at: row.try_get("created_at").context("missing created_at")?,
+        updated_at: row.try_get("updated_at").context("missing updated_at")?,
+    })
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("failed to create in-memory pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("failed to run migrations");
+        pool
+    }
+
+    fn sample_input() -> UpsertRepoInput {
+        UpsertRepoInput {
+            agent_id: "main".into(),
+            owner: "marcmantei".into(),
+            name: "ChargePilot-Launch".into(),
+            full_name: "marcmantei/ChargePilot-Launch".into(),
+            description: "ChargePilot launch site".into(),
+            default_branch: "main".into(),
+            is_archived: false,
+            is_fork: false,
+            visibility: "private".into(),
+            language: Some("TypeScript".into()),
+            clone_url: "https://github.com/marcmantei/ChargePilot-Launch.git".into(),
+            ssh_url: "git@github.com:marcmantei/ChargePilot-Launch.git".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_and_retrieve() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool);
+
+        let repo = store.upsert_repo(sample_input()).await.unwrap();
+        assert_eq!(repo.full_name, "marcmantei/ChargePilot-Launch");
+        assert_eq!(repo.language.as_deref(), Some("TypeScript"));
+        assert!(repo.enabled);
+        assert!(!repo.is_archived);
+
+        // Retrieve by full name
+        let found = store
+            .get_by_full_name("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap()
+            .expect("should find repo");
+        assert_eq!(found.id, repo.id);
+    }
+
+    #[tokio::test]
+    async fn upsert_preserves_overrides() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool);
+
+        store.upsert_repo(sample_input()).await.unwrap();
+
+        // Set a worker_model override
+        store
+            .set_overrides(
+                "main",
+                "marcmantei/ChargePilot-Launch",
+                Some(Some("anthropic/claude-sonnet-4".into())),
+                Some(false),
+            )
+            .await
+            .unwrap();
+
+        // Upsert again (simulating re-sync)
+        let mut input = sample_input();
+        input.description = "Updated description".into();
+        store.upsert_repo(input).await.unwrap();
+
+        // Overrides should be preserved
+        let repo = store
+            .get_by_full_name("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            repo.worker_model.as_deref(),
+            Some("anthropic/claude-sonnet-4")
+        );
+        assert!(!repo.enabled);
+        assert_eq!(repo.description, "Updated description");
+    }
+
+    #[tokio::test]
+    async fn list_repos_filter() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool);
+
+        store.upsert_repo(sample_input()).await.unwrap();
+
+        let mut input2 = sample_input();
+        input2.name = "other-repo".into();
+        input2.full_name = "marcmantei/other-repo".into();
+        store.upsert_repo(input2).await.unwrap();
+
+        // Disable one
+        store
+            .set_overrides("main", "marcmantei/other-repo", None, Some(false))
+            .await
+            .unwrap();
+
+        let all = store.list_repos("main", false).await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        let enabled = store.list_repos("main", true).await.unwrap();
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].full_name, "marcmantei/ChargePilot-Launch");
+    }
+
+    #[tokio::test]
+    async fn mark_absent_as_archived() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool);
+
+        store.upsert_repo(sample_input()).await.unwrap();
+
+        let mut input2 = sample_input();
+        input2.name = "removed-repo".into();
+        input2.full_name = "marcmantei/removed-repo".into();
+        store.upsert_repo(input2).await.unwrap();
+
+        // Only ChargePilot-Launch was seen in this sync
+        let archived = store
+            .mark_absent_as_archived(
+                "main",
+                &["marcmantei/ChargePilot-Launch".into()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(archived, 1);
+
+        let repo = store
+            .get_by_full_name("main", "marcmantei/removed-repo")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo.is_archived);
+    }
+
+    #[tokio::test]
+    async fn delete_repo() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool);
+
+        store.upsert_repo(sample_input()).await.unwrap();
+        let deleted = store
+            .delete_repo("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap();
+        assert!(deleted);
+
+        let found = store
+            .get_by_full_name("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn link_project() {
+        let pool = setup_pool().await;
+        let store = RegistryStore::new(pool.clone());
+
+        store.upsert_repo(sample_input()).await.unwrap();
+
+        // Create a real project to link to (satisfies FK constraint).
+        let project_store = crate::projects::ProjectStore::new(pool);
+        let project = project_store
+            .create_project(crate::projects::store::CreateProjectInput {
+                agent_id: "main".into(),
+                name: "ChargePilot".into(),
+                description: String::new(),
+                icon: String::new(),
+                tags: vec![],
+                root_path: "/home/sira/ChargePilot-Launch".into(),
+                settings: serde_json::Value::Object(Default::default()),
+            })
+            .await
+            .unwrap();
+
+        store
+            .link_project("main", "marcmantei/ChargePilot-Launch", Some(&project.id))
+            .await
+            .unwrap();
+
+        let repo = store
+            .get_by_full_name("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(repo.project_id.as_deref(), Some(project.id.as_str()));
+
+        // Unlinking should also work.
+        store
+            .link_project("main", "marcmantei/ChargePilot-Launch", None)
+            .await
+            .unwrap();
+        let repo = store
+            .get_by_full_name("main", "marcmantei/ChargePilot-Launch")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(repo.project_id.is_none());
+    }
+}

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -4,6 +4,9 @@
 use super::store::{RegistryStore, UpsertRepoInput};
 use crate::config::RegistryConfig;
 use crate::error::Result;
+use crate::messaging::MessagingManager;
+use crate::messaging::target::parse_delivery_target;
+use crate::OutboundResponse;
 
 use anyhow::Context as _;
 use arc_swap::ArcSwap;
@@ -21,6 +24,10 @@ pub struct SyncResult {
     pub archived: usize,
     pub cloned: usize,
     pub errors: Vec<String>,
+    /// Names of newly discovered repos (for notifications).
+    pub new_repos: Vec<String>,
+    /// Names of repos newly marked as archived (for notifications).
+    pub archived_repos: Vec<String>,
 }
 
 /// Current sync status.
@@ -171,6 +178,7 @@ pub async fn sync_registry(
                         result.updated += 1;
                     } else {
                         result.new += 1;
+                        result.new_repos.push(full_name.clone());
 
                         // Auto-clone if configured
                         if config.auto_clone && !gh_repo.is_archived {
@@ -223,9 +231,19 @@ pub async fn sync_registry(
 
     // Mark repos not seen in this sync as archived
     if !all_seen.is_empty() {
+        // Snapshot non-archived names before marking, so we can report which ones changed.
+        let before = store.get_non_archived_names(agent_id).await?;
         result.archived = store
             .mark_absent_as_archived(agent_id, &all_seen)
             .await? as usize;
+        if result.archived > 0 {
+            let seen_set: std::collections::HashSet<&str> =
+                all_seen.iter().map(|s| s.as_str()).collect();
+            result.archived_repos = before
+                .into_iter()
+                .filter(|name| !seen_set.contains(name.as_str()))
+                .collect();
+        }
     }
 
     Ok(result)
@@ -260,6 +278,7 @@ pub async fn registry_sync_loop(
     agent_id: String,
     runtime_config: Arc<crate::config::RuntimeConfig>,
     status: Arc<ArcSwap<SyncStatus>>,
+    messaging_manager: Option<Arc<MessagingManager>>,
 ) {
     // Initial delay to let the agent fully start up.
     tokio::time::sleep(Duration::from_secs(30)).await;
@@ -287,6 +306,17 @@ pub async fn registry_sync_loop(
                     errors = result.errors.len(),
                     "registry sync completed"
                 );
+
+                // Send notification if there are new or archived repos.
+                if !result.new_repos.is_empty() || !result.archived_repos.is_empty() {
+                    send_sync_notification(
+                        &current_config,
+                        &messaging_manager,
+                        &result,
+                    )
+                    .await;
+                }
+
                 status.store(Arc::new(SyncStatus::Completed {
                     at: chrono::Utc::now().to_rfc3339(),
                     result,
@@ -302,6 +332,55 @@ pub async fn registry_sync_loop(
         }
 
         tokio::time::sleep(Duration::from_secs(sync_interval)).await;
+    }
+}
+
+/// Build and send a notification about new/archived repos after a sync pass.
+async fn send_sync_notification(
+    config: &RegistryConfig,
+    messaging_manager: &Option<Arc<MessagingManager>>,
+    result: &SyncResult,
+) {
+    let target_str = match &config.notification_target {
+        Some(t) => t,
+        None => return,
+    };
+    let mm = match messaging_manager {
+        Some(m) => m,
+        None => return,
+    };
+    let target = match parse_delivery_target(target_str) {
+        Some(t) => t,
+        None => {
+            tracing::warn!(
+                target = %target_str,
+                "invalid notification_target for registry sync"
+            );
+            return;
+        }
+    };
+
+    let mut lines = Vec::new();
+    lines.push("📦 Registry sync update:".to_string());
+    if !result.new_repos.is_empty() {
+        lines.push(format!("\nNew repos ({}):", result.new_repos.len()));
+        for name in &result.new_repos {
+            lines.push(format!("  + {}", name));
+        }
+    }
+    if !result.archived_repos.is_empty() {
+        lines.push(format!("\nArchived repos ({}):", result.archived_repos.len()));
+        for name in &result.archived_repos {
+            lines.push(format!("  − {}", name));
+        }
+    }
+    let text = lines.join("\n");
+
+    if let Err(e) = mm
+        .broadcast(&target.adapter, &target.target, OutboundResponse::Text(text))
+        .await
+    {
+        tracing::warn!(error = %e, "failed to send registry sync notification");
     }
 }
 

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -2,11 +2,11 @@
 //! against the local registry store.
 
 use super::store::{RegistryStore, UpsertRepoInput};
+use crate::OutboundResponse;
 use crate::config::RegistryConfig;
 use crate::error::Result;
 use crate::messaging::MessagingManager;
 use crate::messaging::target::parse_delivery_target;
-use crate::OutboundResponse;
 
 use anyhow::Context as _;
 use arc_swap::ArcSwap;
@@ -36,14 +36,8 @@ pub struct SyncResult {
 pub enum SyncStatus {
     Idle,
     Syncing,
-    Failed {
-        error: String,
-        at: String,
-    },
-    Completed {
-        at: String,
-        result: SyncResult,
-    },
+    Failed { error: String, at: String },
+    Completed { at: String, result: SyncResult },
 }
 
 impl Default for SyncStatus {
@@ -201,8 +195,7 @@ pub async fn sync_registry(
                                         );
                                     }
                                     Err(e) => {
-                                        let msg =
-                                            format!("failed to clone {}: {}", full_name, e);
+                                        let msg = format!("failed to clone {}: {}", full_name, e);
                                         tracing::warn!("{}", msg);
                                         result.errors.push(msg);
                                     }
@@ -233,9 +226,7 @@ pub async fn sync_registry(
     if !all_seen.is_empty() {
         // Snapshot non-archived names before marking, so we can report which ones changed.
         let before = store.get_non_archived_names(agent_id).await?;
-        result.archived = store
-            .mark_absent_as_archived(agent_id, &all_seen)
-            .await? as usize;
+        result.archived = store.mark_absent_as_archived(agent_id, &all_seen).await? as usize;
         if result.archived > 0 {
             let seen_set: std::collections::HashSet<&str> =
                 all_seen.iter().map(|s| s.as_str()).collect();
@@ -252,12 +243,7 @@ pub async fn sync_registry(
 /// Clone a repo using `gh repo clone`.
 async fn auto_clone_repo(full_name: &str, target_dir: &Path) -> Result<()> {
     let output = tokio::process::Command::new("gh")
-        .args([
-            "repo",
-            "clone",
-            full_name,
-            &target_dir.to_string_lossy(),
-        ])
+        .args(["repo", "clone", full_name, &target_dir.to_string_lossy()])
         .output()
         .await
         .context("failed to run `gh repo clone`")?;
@@ -309,12 +295,7 @@ pub async fn registry_sync_loop(
 
                 // Send notification if there are new or archived repos.
                 if !result.new_repos.is_empty() || !result.archived_repos.is_empty() {
-                    send_sync_notification(
-                        &current_config,
-                        &messaging_manager,
-                        &result,
-                    )
-                    .await;
+                    send_sync_notification(&current_config, &messaging_manager, &result).await;
                 }
 
                 status.store(Arc::new(SyncStatus::Completed {
@@ -369,7 +350,10 @@ async fn send_sync_notification(
         }
     }
     if !result.archived_repos.is_empty() {
-        lines.push(format!("\nArchived repos ({}):", result.archived_repos.len()));
+        lines.push(format!(
+            "\nArchived repos ({}):",
+            result.archived_repos.len()
+        ));
         for name in &result.archived_repos {
             lines.push(format!("  − {}", name));
         }
@@ -377,7 +361,11 @@ async fn send_sync_notification(
     let text = lines.join("\n");
 
     if let Err(e) = mm
-        .broadcast(&target.adapter, &target.target, OutboundResponse::Text(text))
+        .broadcast(
+            &target.adapter,
+            &target.target,
+            OutboundResponse::Text(text),
+        )
         .await
     {
         tracing::warn!(error = %e, "failed to send registry sync notification");
@@ -390,9 +378,18 @@ mod tests {
 
     #[test]
     fn test_matches_exclude() {
-        assert!(matches_exclude("marcmantei/liralot-config", &["marcmantei/liralot-config".into()]));
-        assert!(matches_exclude("marcmantei/test-repo", &["marcmantei/test*".into()]));
-        assert!(!matches_exclude("marcmantei/ChargePilot", &["marcmantei/liralot-config".into()]));
+        assert!(matches_exclude(
+            "marcmantei/liralot-config",
+            &["marcmantei/liralot-config".into()]
+        ));
+        assert!(matches_exclude(
+            "marcmantei/test-repo",
+            &["marcmantei/test*".into()]
+        ));
+        assert!(!matches_exclude(
+            "marcmantei/ChargePilot",
+            &["marcmantei/liralot-config".into()]
+        ));
         assert!(!matches_exclude("other/repo", &["marcmantei/*".into()]));
     }
 

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -31,19 +31,20 @@ pub struct SyncResult {
 }
 
 /// Current sync status.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum SyncStatus {
+    #[default]
     Idle,
     Syncing,
-    Failed { error: String, at: String },
-    Completed { at: String, result: SyncResult },
-}
-
-impl Default for SyncStatus {
-    fn default() -> Self {
-        Self::Idle
-    }
+    Failed {
+        error: String,
+        at: String,
+    },
+    Completed {
+        at: String,
+        result: SyncResult,
+    },
 }
 
 /// JSON shape returned by `gh repo list --json`.
@@ -111,10 +112,10 @@ fn matches_exclude(full_name: &str, patterns: &[String]) -> bool {
             return true;
         }
         // Support trailing wildcard: "owner/*-test" not supported, but "owner/prefix*" is.
-        if let Some(prefix) = pattern.strip_suffix('*') {
-            if full_name.starts_with(prefix) {
-                return true;
-            }
+        if let Some(prefix) = pattern.strip_suffix('*')
+            && full_name.starts_with(prefix)
+        {
+            return true;
         }
     }
     false

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -1,0 +1,340 @@
+//! Registry sync: discovers GitHub repos via `gh repo list` and reconciles
+//! against the local registry store.
+
+use super::store::{RegistryStore, UpsertRepoInput};
+use crate::config::RegistryConfig;
+use crate::error::Result;
+
+use anyhow::Context as _;
+use arc_swap::ArcSwap;
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::time::Duration;
+
+/// Result of a single sync pass.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct SyncResult {
+    pub repos_found: usize,
+    pub new: usize,
+    pub updated: usize,
+    pub archived: usize,
+    pub cloned: usize,
+    pub errors: Vec<String>,
+}
+
+/// Current sync status.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SyncStatus {
+    Idle,
+    Syncing,
+    Failed {
+        error: String,
+        at: String,
+    },
+    Completed {
+        at: String,
+        result: SyncResult,
+    },
+}
+
+impl Default for SyncStatus {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+/// JSON shape returned by `gh repo list --json`.
+#[derive(Debug, Deserialize)]
+struct GhRepo {
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(rename = "defaultBranchRef")]
+    default_branch_ref: Option<GhBranchRef>,
+    #[serde(rename = "isArchived", default)]
+    is_archived: bool,
+    #[serde(rename = "isFork", default)]
+    is_fork: bool,
+    #[serde(default)]
+    visibility: String,
+    #[serde(rename = "primaryLanguage")]
+    primary_language: Option<GhLanguage>,
+    #[serde(default)]
+    url: String,
+    #[serde(rename = "sshUrl", default)]
+    ssh_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhBranchRef {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLanguage {
+    name: String,
+}
+
+/// Discover repos for a single GitHub owner using the `gh` CLI.
+async fn discover_github_repos(owner: &str) -> Result<Vec<GhRepo>> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "repo",
+            "list",
+            owner,
+            "--json",
+            "name,description,defaultBranchRef,isArchived,isFork,visibility,primaryLanguage,url,sshUrl",
+            "--limit",
+            "200",
+        ])
+        .output()
+        .await
+        .context("failed to run `gh repo list`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!("`gh repo list {}` failed: {}", owner, stderr.trim()).into());
+    }
+
+    let repos: Vec<GhRepo> =
+        serde_json::from_slice(&output.stdout).context("failed to parse gh repo list output")?;
+    Ok(repos)
+}
+
+/// Check if a repo matches any exclude pattern (simple glob with `*` support).
+fn matches_exclude(full_name: &str, patterns: &[String]) -> bool {
+    for pattern in patterns {
+        if pattern == full_name {
+            return true;
+        }
+        // Support trailing wildcard: "owner/*-test" not supported, but "owner/prefix*" is.
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            if full_name.starts_with(prefix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Run a single sync pass: discover repos, upsert into store, mark absent repos.
+pub async fn sync_registry(
+    store: &RegistryStore,
+    agent_id: &str,
+    config: &RegistryConfig,
+) -> Result<SyncResult> {
+    let mut result = SyncResult::default();
+    let mut all_seen: Vec<String> = Vec::new();
+
+    for owner in &config.github_owners {
+        match discover_github_repos(owner).await {
+            Ok(repos) => {
+                for gh_repo in repos {
+                    let full_name = format!("{}/{}", owner, gh_repo.name);
+
+                    // Apply exclude patterns
+                    if matches_exclude(&full_name, &config.exclude_patterns) {
+                        continue;
+                    }
+
+                    all_seen.push(full_name.clone());
+                    result.repos_found += 1;
+
+                    let was_known = store
+                        .get_by_full_name(agent_id, &full_name)
+                        .await?
+                        .is_some();
+
+                    let input = UpsertRepoInput {
+                        agent_id: agent_id.to_string(),
+                        owner: owner.clone(),
+                        name: gh_repo.name.clone(),
+                        full_name: full_name.clone(),
+                        description: gh_repo.description,
+                        default_branch: gh_repo
+                            .default_branch_ref
+                            .map(|b| b.name)
+                            .unwrap_or_else(|| "main".into()),
+                        is_archived: gh_repo.is_archived,
+                        is_fork: gh_repo.is_fork,
+                        visibility: gh_repo.visibility.to_lowercase(),
+                        language: gh_repo.primary_language.map(|l| l.name),
+                        clone_url: gh_repo.url.clone(),
+                        ssh_url: gh_repo.ssh_url,
+                    };
+
+                    store.upsert_repo(input).await?;
+
+                    if was_known {
+                        result.updated += 1;
+                    } else {
+                        result.new += 1;
+
+                        // Auto-clone if configured
+                        if config.auto_clone && !gh_repo.is_archived {
+                            let clone_dir = config.clone_base_dir.join(&gh_repo.name);
+                            if !clone_dir.exists() {
+                                match auto_clone_repo(&full_name, &clone_dir).await {
+                                    Ok(()) => {
+                                        store
+                                            .set_local_path(
+                                                agent_id,
+                                                &full_name,
+                                                &clone_dir.to_string_lossy(),
+                                            )
+                                            .await?;
+                                        result.cloned += 1;
+                                        tracing::info!(
+                                            repo = %full_name,
+                                            path = %clone_dir.display(),
+                                            "auto-cloned new repo"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        let msg =
+                                            format!("failed to clone {}: {}", full_name, e);
+                                        tracing::warn!("{}", msg);
+                                        result.errors.push(msg);
+                                    }
+                                }
+                            } else {
+                                // Directory exists, just record the path
+                                store
+                                    .set_local_path(
+                                        agent_id,
+                                        &full_name,
+                                        &clone_dir.to_string_lossy(),
+                                    )
+                                    .await?;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let msg = format!("failed to discover repos for {}: {}", owner, e);
+                tracing::warn!("{}", msg);
+                result.errors.push(msg);
+            }
+        }
+    }
+
+    // Mark repos not seen in this sync as archived
+    if !all_seen.is_empty() {
+        result.archived = store
+            .mark_absent_as_archived(agent_id, &all_seen)
+            .await? as usize;
+    }
+
+    Ok(result)
+}
+
+/// Clone a repo using `gh repo clone`.
+async fn auto_clone_repo(full_name: &str, target_dir: &Path) -> Result<()> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "repo",
+            "clone",
+            full_name,
+            &target_dir.to_string_lossy(),
+        ])
+        .output()
+        .await
+        .context("failed to run `gh repo clone`")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!("gh repo clone failed: {}", stderr.trim()).into());
+    }
+    Ok(())
+}
+
+/// Background loop that periodically syncs the registry.
+///
+/// Reads the current `RegistryConfig` from `runtime_config` on each iteration
+/// so hot-reloads take effect without restarting.
+pub async fn registry_sync_loop(
+    store: RegistryStore,
+    agent_id: String,
+    runtime_config: Arc<crate::config::RuntimeConfig>,
+    status: Arc<ArcSwap<SyncStatus>>,
+) {
+    // Initial delay to let the agent fully start up.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    loop {
+        let current_config = runtime_config.registry.load();
+        if !current_config.enabled {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            continue;
+        }
+
+        let sync_interval = current_config.sync_interval_secs;
+
+        status.store(Arc::new(SyncStatus::Syncing));
+        tracing::info!(agent_id = %agent_id, "starting registry sync");
+
+        match sync_registry(&store, &agent_id, &current_config).await {
+            Ok(result) => {
+                tracing::info!(
+                    agent_id = %agent_id,
+                    found = result.repos_found,
+                    new = result.new,
+                    archived = result.archived,
+                    cloned = result.cloned,
+                    errors = result.errors.len(),
+                    "registry sync completed"
+                );
+                status.store(Arc::new(SyncStatus::Completed {
+                    at: chrono::Utc::now().to_rfc3339(),
+                    result,
+                }));
+            }
+            Err(e) => {
+                tracing::error!(agent_id = %agent_id, error = %e, "registry sync failed");
+                status.store(Arc::new(SyncStatus::Failed {
+                    error: e.to_string(),
+                    at: chrono::Utc::now().to_rfc3339(),
+                }));
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(sync_interval)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_exclude() {
+        assert!(matches_exclude("marcmantei/liralot-config", &["marcmantei/liralot-config".into()]));
+        assert!(matches_exclude("marcmantei/test-repo", &["marcmantei/test*".into()]));
+        assert!(!matches_exclude("marcmantei/ChargePilot", &["marcmantei/liralot-config".into()]));
+        assert!(!matches_exclude("other/repo", &["marcmantei/*".into()]));
+    }
+
+    #[test]
+    fn test_gh_repo_deserialization() {
+        let json = r#"[
+            {
+                "name": "test-repo",
+                "description": "A test",
+                "defaultBranchRef": {"name": "main"},
+                "isArchived": false,
+                "isFork": false,
+                "visibility": "PRIVATE",
+                "primaryLanguage": {"name": "Rust"},
+                "url": "https://github.com/owner/test-repo",
+                "sshUrl": "git@github.com:owner/test-repo.git"
+            }
+        ]"#;
+        let repos: Vec<GhRepo> = serde_json::from_str(json).unwrap();
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].name, "test-repo");
+        assert_eq!(repos[0].primary_language.as_ref().unwrap().name, "Rust");
+    }
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -389,13 +389,16 @@ pub async fn add_channel_tools(
             .cloned()
             .unwrap_or_else(|| state.deps.agent_id.to_string());
         handle
-            .add_tool(SendMessageTool::new(
-                messaging_manager.clone(),
-                state.channel_store.clone(),
-                state.conversation_logger.clone(),
-                send_message_display_name,
-                current_adapter.clone(),
-            ))
+            .add_tool(
+                SendMessageTool::new(
+                    messaging_manager.clone(),
+                    state.channel_store.clone(),
+                    state.conversation_logger.clone(),
+                    send_message_display_name,
+                    current_adapter.clone(),
+                )
+                .with_replied_flag(replied_flag.clone()),
+            )
             .await?;
     }
     handle

--- a/src/tools/send_message_to_another_channel.rs
+++ b/src/tools/send_message_to_another_channel.rs
@@ -4,12 +4,14 @@ use crate::ChannelId;
 use crate::conversation::ChannelStore;
 use crate::conversation::history::ConversationLogger;
 use crate::messaging::MessagingManager;
+use crate::tools::reply::RepliedFlag;
 
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 /// Check if a string is a valid UUID format.
 /// Accepts standard UUID format: 8-4-4-4-12 hexadecimal digits.
@@ -30,6 +32,7 @@ pub struct SendMessageTool {
     conversation_logger: ConversationLogger,
     agent_display_name: String,
     current_adapter: Option<String>,
+    replied_flag: Option<RepliedFlag>,
 }
 
 impl std::fmt::Debug for SendMessageTool {
@@ -52,6 +55,20 @@ impl SendMessageTool {
             conversation_logger,
             agent_display_name,
             current_adapter,
+            replied_flag: None,
+        }
+    }
+
+    /// Attach a replied flag so successful sends mark the retrigger as relayed.
+    pub fn with_replied_flag(mut self, flag: RepliedFlag) -> Self {
+        self.replied_flag = Some(flag);
+        self
+    }
+
+    /// Mark the replied flag (if present) to indicate a message was delivered.
+    fn mark_replied(&self) {
+        if let Some(flag) = &self.replied_flag {
+            flag.store(true, Ordering::Relaxed);
         }
     }
 }
@@ -174,6 +191,7 @@ impl Tool for SendMessageTool {
                 "message sent via explicit signal: prefix"
             );
 
+            self.mark_replied();
             return Ok(SendMessageOutput {
                 success: true,
                 target: target.target,
@@ -208,6 +226,7 @@ impl Tool for SendMessageTool {
                         "message sent via implicit Signal shorthand"
                     );
 
+                    self.mark_replied();
                     return Ok(SendMessageOutput {
                         success: true,
                         target: target.target,
@@ -241,6 +260,7 @@ impl Tool for SendMessageTool {
             );
 
             // Email targets don't have a channel to log to.
+            self.mark_replied();
             return Ok(SendMessageOutput {
                 success: true,
                 target: explicit_target.target,
@@ -303,6 +323,7 @@ impl Tool for SendMessageTool {
             "message sent to channel and logged to destination history"
         );
 
+        self.mark_replied();
         Ok(SendMessageOutput {
             success: true,
             target: channel.display_name.unwrap_or_else(|| channel.id.clone()),

--- a/src/tools/spawn_worker.rs
+++ b/src/tools/spawn_worker.rs
@@ -234,12 +234,10 @@ impl Tool for SpawnWorkerTool {
             queued_at: chrono::Utc::now(),
         };
 
-        let spawn_result = crate::agent::channel_dispatch::spawn_or_queue_worker(
-            &self.state,
-            request,
-        )
-        .await
-        .map_err(|e| SpawnWorkerError(format!("{e}")))?;
+        let spawn_result =
+            crate::agent::channel_dispatch::spawn_or_queue_worker(&self.state, request)
+                .await
+                .map_err(|e| SpawnWorkerError(format!("{e}")))?;
 
         match spawn_result {
             Some(worker_id) => {

--- a/src/tools/spawn_worker.rs
+++ b/src/tools/spawn_worker.rs
@@ -7,7 +7,6 @@
 
 use crate::WorkerId;
 use crate::agent::channel::ChannelState;
-use crate::agent::channel_dispatch::{spawn_opencode_worker_from_state, spawn_worker_from_state};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use schemars::JsonSchema;
@@ -78,6 +77,8 @@ pub struct SpawnWorkerOutput {
     pub spawned: bool,
     /// Whether this is an interactive worker.
     pub interactive: bool,
+    /// Whether the spawn was queued (limit reached, will auto-spawn when a slot opens).
+    pub queued: bool,
     /// Status message.
     pub message: String,
 }
@@ -192,6 +193,7 @@ impl Tool for SpawnWorkerTool {
                     worker_id: existing_id,
                     spawned: false,
                     interactive: args.interactive,
+                    queued: false,
                     message: format!(
                         "A worker is already running this task (worker {existing_id}). \
                          Use route to send additional context to the running worker instead."
@@ -209,74 +211,99 @@ impl Tool for SpawnWorkerTool {
         )
         .await;
 
-        let worker_id = if is_opencode {
-            let directory = resolved_directory.as_deref().ok_or_else(|| {
-                SpawnWorkerError(
-                    "directory is required for opencode workers (set directory, project_id, or worktree_id)".into(),
-                )
-            })?;
-
-            // OpenCode workers are always interactive — ignore args.interactive.
-            spawn_opencode_worker_from_state(&self.state, &args.task, directory, true)
-                .await
-                .map_err(|e| SpawnWorkerError(format!("{e}")))?
-        } else {
-            spawn_worker_from_state(
-                &self.state,
-                &args.task,
-                args.interactive,
-                &args
-                    .suggested_skills
-                    .iter()
-                    .map(String::as_str)
-                    .collect::<Vec<_>>(),
-            )
-            .await
-            .map_err(|e| SpawnWorkerError(format!("{e}")))?
-        };
-
-        // Link the worker to project/worktree if specified (fire-and-forget update).
-        if args.project_id.is_some() || args.worktree_id.is_some() {
-            self.state.process_run_logger.log_worker_project_link(
-                worker_id,
-                args.project_id.as_deref(),
-                args.worktree_id.as_deref(),
-            );
+        // Validate directory requirement for opencode workers before queueing.
+        if is_opencode && resolved_directory.is_none() {
+            return Err(SpawnWorkerError(
+                "directory is required for opencode workers (set directory, project_id, or worktree_id)".into(),
+            ));
         }
 
-        let worker_type_label = if is_opencode { "OpenCode" } else { "builtin" };
-        // OpenCode workers are always interactive regardless of args.interactive.
-        let effectively_interactive = args.interactive || is_opencode;
-        let message = if effectively_interactive {
-            format!(
-                "Interactive {worker_type_label} worker {worker_id} spawned for: {}. Route follow-ups with route_to_worker.",
-                args.task
-            )
-        } else {
-            format!(
-                "{worker_type_label} worker {worker_id} spawned for: {}. It will report back when done.",
-                args.task
-            )
-        };
-        let readiness_note = if readiness.ready {
-            String::new()
-        } else {
-            let reason = readiness
-                .reason
-                .map(|value| value.as_str())
-                .unwrap_or("unknown");
-            format!(
-                " Readiness note: warmup is not fully ready ({reason}, state: {:?}); a warmup pass may already be running or was queued in the background.",
-                readiness.warmup_state
-            )
+        // Build the queue request and try to spawn (or queue if limit reached).
+        let request = crate::agent::channel_dispatch::QueuedWorkerSpawn {
+            task: args.task.clone(),
+            interactive: args.interactive,
+            suggested_skills: args.suggested_skills.clone(),
+            worker_type: if is_opencode {
+                crate::agent::channel_dispatch::QueuedWorkerType::OpenCode
+            } else {
+                crate::agent::channel_dispatch::QueuedWorkerType::Builtin
+            },
+            directory: resolved_directory,
+            project_id: args.project_id.clone(),
+            worktree_id: args.worktree_id.clone(),
+            queued_at: chrono::Utc::now(),
         };
 
-        Ok(SpawnWorkerOutput {
-            worker_id,
-            spawned: true,
-            interactive: effectively_interactive,
-            message: format!("{message}{readiness_note}"),
-        })
+        let spawn_result = crate::agent::channel_dispatch::spawn_or_queue_worker(
+            &self.state,
+            request,
+        )
+        .await
+        .map_err(|e| SpawnWorkerError(format!("{e}")))?;
+
+        match spawn_result {
+            Some(worker_id) => {
+                // Worker spawned immediately.
+                // Link the worker to project/worktree if specified.
+                if args.project_id.is_some() || args.worktree_id.is_some() {
+                    self.state.process_run_logger.log_worker_project_link(
+                        worker_id,
+                        args.project_id.as_deref(),
+                        args.worktree_id.as_deref(),
+                    );
+                }
+
+                let worker_type_label = if is_opencode { "OpenCode" } else { "builtin" };
+                let effectively_interactive = args.interactive || is_opencode;
+                let message = if effectively_interactive {
+                    format!(
+                        "Interactive {worker_type_label} worker {worker_id} spawned for: {}. Route follow-ups with route_to_worker.",
+                        args.task
+                    )
+                } else {
+                    format!(
+                        "{worker_type_label} worker {worker_id} spawned for: {}. It will report back when done.",
+                        args.task
+                    )
+                };
+                let readiness_note = if readiness.ready {
+                    String::new()
+                } else {
+                    let reason = readiness
+                        .reason
+                        .map(|value| value.as_str())
+                        .unwrap_or("unknown");
+                    format!(
+                        " Readiness note: warmup is not fully ready ({reason}, state: {:?}); a warmup pass may already be running or was queued in the background.",
+                        readiness.warmup_state
+                    )
+                };
+
+                Ok(SpawnWorkerOutput {
+                    worker_id,
+                    spawned: true,
+                    interactive: effectively_interactive,
+                    queued: false,
+                    message: format!("{message}{readiness_note}"),
+                })
+            }
+            None => {
+                // Queued — worker limit reached, will auto-spawn when a slot opens.
+                let queue_len = self.state.worker_queue.read().await.len();
+                let max_workers = **self.state.deps.runtime_config.max_concurrent_workers.load();
+                Ok(SpawnWorkerOutput {
+                    worker_id: WorkerId::nil(),
+                    spawned: false,
+                    interactive: args.interactive || is_opencode,
+                    queued: true,
+                    message: format!(
+                        "Worker limit reached ({max_workers} concurrent). Task queued at position {queue_len}: \"{}\". \
+                         It will auto-spawn when a running worker completes. No action needed.",
+                        args.task
+                    ),
+                })
+            }
+        }
     }
 }
 
@@ -508,6 +535,7 @@ impl Tool for DetachedSpawnWorkerTool {
             worker_id,
             spawned: true,
             interactive: false,
+            queued: false,
             message: format!(
                 "Worker {worker_id} spawned for: {}. It will report back when done.",
                 args.task

--- a/src/update.rs
+++ b/src/update.rs
@@ -105,8 +105,14 @@ pub fn new_shared_status() -> SharedUpdateStatus {
             }
         }
         Deployment::Native => {
-            status.cannot_apply_reason =
-                Some("Native/source installs update manually (rebuild + restart).".to_string());
+            let has_source = crate::upgrade::resolve_source_dir(None).is_ok();
+            status.can_apply = has_source;
+            if !has_source {
+                status.cannot_apply_reason = Some(
+                    "Source directory not found. Set SPACEBOT_SRC_DIR or clone to ~/.spacebot-src."
+                        .to_string(),
+                );
+            }
         }
         Deployment::Hosted => {
             status.cannot_apply_reason = Some(
@@ -231,13 +237,21 @@ struct ApplyCapability {
 
 async fn detect_apply_capability(deployment: Deployment) -> ApplyCapability {
     match deployment {
-        Deployment::Native => ApplyCapability {
-            can_apply: false,
-            cannot_apply_reason: Some(
-                "Native/source installs update manually (rebuild + restart).".to_string(),
-            ),
-            docker_image: None,
-        },
+        Deployment::Native => {
+            let has_source = crate::upgrade::resolve_source_dir(None).is_ok();
+            ApplyCapability {
+                can_apply: has_source,
+                cannot_apply_reason: if has_source {
+                    None
+                } else {
+                    Some(
+                        "Source directory not found. Set SPACEBOT_SRC_DIR or clone to ~/.spacebot-src."
+                            .to_string(),
+                    )
+                },
+                docker_image: None,
+            }
+        }
         Deployment::Hosted => ApplyCapability {
             can_apply: false,
             cannot_apply_reason: Some(

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -143,10 +143,8 @@ pub fn build_release(
     // Cargo writes progress to stderr
     let stderr = child.stderr.take().unwrap();
     let reader = BufReader::new(stderr);
-    for line in reader.lines() {
-        if let Ok(line) = line {
-            on_line(&line);
-        }
+    for line in reader.lines().map_while(Result::ok) {
+        on_line(&line);
     }
 
     let status = child.wait()?;

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -31,15 +31,16 @@ pub fn resolve_source_dir(explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
         return validate_source_dir(&p);
     }
 
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
     let default = home.join(".spacebot-src");
     validate_source_dir(&default)
 }
 
 fn validate_source_dir(dir: &Path) -> anyhow::Result<PathBuf> {
-    let dir = dir.canonicalize().map_err(|e| {
-        anyhow::anyhow!("source directory '{}' not found: {e}", dir.display())
-    })?;
+    let dir = dir
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("source directory '{}' not found: {e}", dir.display()))?;
 
     if !dir.join("Cargo.toml").exists() {
         anyhow::bail!(
@@ -48,10 +49,7 @@ fn validate_source_dir(dir: &Path) -> anyhow::Result<PathBuf> {
         );
     }
     if !dir.join(".git").exists() {
-        anyhow::bail!(
-            "'{}' is not a git repository",
-            dir.display()
-        );
+        anyhow::bail!("'{}' is not a git repository", dir.display());
     }
 
     Ok(dir)
@@ -128,10 +126,7 @@ pub fn pull(source_dir: &Path) -> anyhow::Result<String> {
 }
 
 /// Build the release binary, streaming cargo output to the callback.
-pub fn build_release(
-    source_dir: &Path,
-    on_line: impl Fn(&str),
-) -> anyhow::Result<PathBuf> {
+pub fn build_release(source_dir: &Path, on_line: impl Fn(&str)) -> anyhow::Result<PathBuf> {
     let mut child = Command::new("cargo")
         .args(["build", "--release"])
         .current_dir(source_dir)
@@ -171,12 +166,8 @@ pub fn install_binary(built: &Path, install_path: &Path) -> anyhow::Result<()> {
 
     let tmp_path = parent.join(".spacebot.upgrade.tmp");
 
-    std::fs::copy(built, &tmp_path).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to copy binary to {}: {e}",
-            tmp_path.display()
-        )
-    })?;
+    std::fs::copy(built, &tmp_path)
+        .map_err(|e| anyhow::anyhow!("failed to copy binary to {}: {e}", tmp_path.display()))?;
 
     // Preserve executable permissions
     #[cfg(unix)]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,230 @@
+//! Native source-based upgrade: fetch, build, swap binary, restart service.
+//!
+//! This module powers `spacebot upgrade` for native/source installs.
+//! It automates: git fetch → git pull → cargo build --release → stop → copy → restart.
+
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Result of checking for available updates.
+#[derive(Debug)]
+pub struct UpgradeCheck {
+    pub has_updates: bool,
+    pub commit_count: usize,
+    pub commit_summaries: Vec<String>,
+    pub local_head: String,
+    pub remote_head: String,
+}
+
+/// Locate the source directory. Checks (in order):
+/// 1. Explicit `--source-dir` argument
+/// 2. `SPACEBOT_SRC_DIR` environment variable
+/// 3. `~/.spacebot-src` (convention on this machine)
+pub fn resolve_source_dir(explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(dir) = explicit {
+        return validate_source_dir(dir);
+    }
+
+    if let Ok(env_dir) = std::env::var("SPACEBOT_SRC_DIR") {
+        let p = PathBuf::from(env_dir);
+        return validate_source_dir(&p);
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
+    let default = home.join(".spacebot-src");
+    validate_source_dir(&default)
+}
+
+fn validate_source_dir(dir: &Path) -> anyhow::Result<PathBuf> {
+    let dir = dir.canonicalize().map_err(|e| {
+        anyhow::anyhow!("source directory '{}' not found: {e}", dir.display())
+    })?;
+
+    if !dir.join("Cargo.toml").exists() {
+        anyhow::bail!(
+            "'{}' does not look like a Spacebot source checkout (no Cargo.toml)",
+            dir.display()
+        );
+    }
+    if !dir.join(".git").exists() {
+        anyhow::bail!(
+            "'{}' is not a git repository",
+            dir.display()
+        );
+    }
+
+    Ok(dir)
+}
+
+/// Resolve the install path for the binary.
+pub fn resolve_install_path(explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p.to_path_buf());
+    }
+
+    // Use the path of the currently running binary
+    let current = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("cannot determine current binary path: {e}"))?;
+    Ok(current)
+}
+
+/// Fetch from remote and check if there are new commits.
+pub fn check_for_updates(
+    source_dir: &Path,
+    remote: &str,
+    branch: &str,
+) -> anyhow::Result<UpgradeCheck> {
+    // git fetch
+    run_git(source_dir, &["fetch", remote])?;
+
+    let remote_ref = format!("{remote}/{branch}");
+
+    // Get local HEAD
+    let local_head = run_git(source_dir, &["rev-parse", "HEAD"])?;
+    let local_head = local_head.trim().to_string();
+
+    // Get remote HEAD
+    let remote_head = run_git(source_dir, &["rev-parse", &remote_ref])?;
+    let remote_head = remote_head.trim().to_string();
+
+    if local_head == remote_head {
+        return Ok(UpgradeCheck {
+            has_updates: false,
+            commit_count: 0,
+            commit_summaries: vec![],
+            local_head,
+            remote_head,
+        });
+    }
+
+    // Get new commits
+    let range = format!("HEAD..{remote_ref}");
+    let log_output = run_git(source_dir, &["log", "--oneline", &range])?;
+    let summaries: Vec<String> = log_output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Ok(UpgradeCheck {
+        has_updates: true,
+        commit_count: summaries.len(),
+        commit_summaries: summaries,
+        local_head,
+        remote_head,
+    })
+}
+
+/// Get the current branch name.
+pub fn current_branch(source_dir: &Path) -> anyhow::Result<String> {
+    let output = run_git(source_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    Ok(output.trim().to_string())
+}
+
+/// Pull latest changes.
+pub fn pull(source_dir: &Path) -> anyhow::Result<String> {
+    run_git(source_dir, &["pull"])
+}
+
+/// Build the release binary, streaming cargo output to the callback.
+pub fn build_release(
+    source_dir: &Path,
+    on_line: impl Fn(&str),
+) -> anyhow::Result<PathBuf> {
+    let mut child = Command::new("cargo")
+        .args(["build", "--release"])
+        .current_dir(source_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to spawn cargo build: {e}"))?;
+
+    // Cargo writes progress to stderr
+    let stderr = child.stderr.take().unwrap();
+    let reader = BufReader::new(stderr);
+    for line in reader.lines() {
+        if let Ok(line) = line {
+            on_line(&line);
+        }
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        anyhow::bail!("cargo build failed with exit code {}", status);
+    }
+
+    let binary = source_dir.join("target/release/spacebot");
+    if !binary.exists() {
+        anyhow::bail!("built binary not found at {}", binary.display());
+    }
+
+    Ok(binary)
+}
+
+/// Install the built binary to the target path.
+/// Uses a temp file + rename for atomicity.
+pub fn install_binary(built: &Path, install_path: &Path) -> anyhow::Result<()> {
+    let parent = install_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("install path has no parent directory"))?;
+
+    let tmp_path = parent.join(".spacebot.upgrade.tmp");
+
+    std::fs::copy(built, &tmp_path).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to copy binary to {}: {e}",
+            tmp_path.display()
+        )
+    })?;
+
+    // Preserve executable permissions
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&tmp_path, perms)?;
+    }
+
+    std::fs::rename(&tmp_path, install_path).map_err(|e| {
+        // Clean up tmp file on rename failure
+        let _ = std::fs::remove_file(&tmp_path);
+        anyhow::anyhow!(
+            "failed to rename {} → {}: {e}",
+            tmp_path.display(),
+            install_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Restart the spacebot systemd user service.
+pub fn restart_service() -> anyhow::Result<()> {
+    let output = Command::new("systemctl")
+        .args(["--user", "restart", "spacebot"])
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run systemctl: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("systemctl restart failed: {stderr}");
+    }
+
+    Ok(())
+}
+
+fn run_git(dir: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run git {}: {e}", args.join(" ")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {} failed: {stderr}", args.join(" "));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,317 @@
+//! Startup catch-up and health watchdog.
+//!
+//! - **Catch-up**: After boot, scans enabled repos for open issues that were
+//!   missed during downtime (no `prd-generated` label) and injects synthetic
+//!   webhook messages so the agent processes them.
+//!
+//! - **Watchdog**: Periodically checks whether the daemon is still processing
+//!   messages. If no activity is observed for a configurable timeout, the
+//!   process exits so systemd can restart it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+
+use crate::registry::RegistryStore;
+use crate::{InboundMessage, MessageContent};
+
+// ---------------------------------------------------------------------------
+// Startup catch-up
+// ---------------------------------------------------------------------------
+
+/// Issue metadata returned by `gh issue list --json`.
+#[derive(Debug, serde::Deserialize)]
+struct GhIssue {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    labels: Vec<GhLabel>,
+    #[serde(rename = "createdAt")]
+    #[allow(dead_code)]
+    created_at: String,
+    author: Option<GhAuthor>,
+    url: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct GhAuthor {
+    login: String,
+}
+
+/// Scan all enabled repos for the given agent and inject synthetic
+/// `issues.opened` messages for any open issues that lack the
+/// `prd-generated` label (i.e. were missed during downtime).
+///
+/// Only considers issues created in the last 24 hours to avoid
+/// re-processing ancient issues on first deploy.
+pub async fn run_startup_catchup(
+    agent_id: &str,
+    registry_store: &Arc<RegistryStore>,
+    injection_tx: &mpsc::Sender<crate::ChannelInjection>,
+) {
+    let repos = match registry_store.list_repos(agent_id, true).await {
+        Ok(repos) => repos,
+        Err(error) => {
+            tracing::warn!(%error, "startup catch-up: failed to list repos");
+            return;
+        }
+    };
+
+    if repos.is_empty() {
+        tracing::debug!("startup catch-up: no enabled repos, skipping");
+        return;
+    }
+
+    let mut total_injected = 0u32;
+
+    for repo in &repos {
+        let full_name = &repo.full_name;
+        let issues = match discover_unprocessed_issues(full_name).await {
+            Ok(issues) => issues,
+            Err(error) => {
+                tracing::warn!(
+                    repo = %full_name,
+                    %error,
+                    "startup catch-up: failed to query issues"
+                );
+                continue;
+            }
+        };
+
+        for issue in &issues {
+            let author = issue
+                .author
+                .as_ref()
+                .map(|a| a.login.as_str())
+                .unwrap_or("unknown");
+
+            let labels: Vec<&str> = issue.labels.iter().map(|l| l.name.as_str()).collect();
+            let labels_str = if labels.is_empty() {
+                "none".to_string()
+            } else {
+                labels.join(", ")
+            };
+
+            let body_preview = issue
+                .body
+                .as_deref()
+                .unwrap_or("")
+                .chars()
+                .take(500)
+                .collect::<String>();
+
+            let content = format!(
+                "GitHub webhook: issues.opened\n\
+                 Repo: {full_name}\n\
+                 Issue #{number}: {title}\n\
+                 Author: {author}\n\
+                 Labels: {labels_str}\n\
+                 URL: {url}\n\
+                 Body:\n{body}",
+                number = issue.number,
+                title = issue.title,
+                url = issue.url,
+                body = body_preview,
+            );
+
+            let conversation_id = format!("webhook:github:{full_name}");
+
+            let mut metadata = HashMap::new();
+            metadata.insert(
+                "webhook_conversation_id".into(),
+                serde_json::Value::String(format!("github:{full_name}")),
+            );
+            metadata.insert(
+                "display_name".into(),
+                serde_json::Value::String("github-webhook".into()),
+            );
+            metadata.insert(
+                "sender_display_name".into(),
+                serde_json::Value::String("github-webhook".into()),
+            );
+            metadata.insert(
+                crate::metadata_keys::CHANNEL_NAME.into(),
+                serde_json::Value::String(format!("github:{full_name}")),
+            );
+            metadata.insert(
+                "startup_catchup".into(),
+                serde_json::Value::Bool(true),
+            );
+
+            let message = InboundMessage {
+                id: uuid::Uuid::new_v4().to_string(),
+                source: "webhook".into(),
+                adapter: Some("webhook".into()),
+                conversation_id: conversation_id.clone(),
+                sender_id: "github-webhook".into(),
+                agent_id: Some(Arc::from(agent_id)),
+                content: MessageContent::Text(content),
+                timestamp: chrono::Utc::now(),
+                metadata,
+                formatted_author: Some("github-webhook".into()),
+            };
+
+            let injection = crate::ChannelInjection {
+                conversation_id,
+                agent_id: agent_id.to_string(),
+                message,
+            };
+
+            if let Err(error) = injection_tx.send(injection).await {
+                tracing::warn!(
+                    repo = %full_name,
+                    issue = issue.number,
+                    %error,
+                    "startup catch-up: failed to inject issue"
+                );
+            } else {
+                tracing::info!(
+                    repo = %full_name,
+                    issue = issue.number,
+                    title = %issue.title,
+                    "startup catch-up: injected missed issue"
+                );
+                total_injected += 1;
+            }
+        }
+    }
+
+    if total_injected > 0 {
+        tracing::info!(
+            count = total_injected,
+            "startup catch-up complete: injected missed issues"
+        );
+    } else {
+        tracing::info!("startup catch-up complete: no missed issues found");
+    }
+}
+
+/// Query GitHub for open issues on `repo` that do NOT have the
+/// `prd-generated` label and were created in the last 24 hours.
+async fn discover_unprocessed_issues(repo: &str) -> anyhow::Result<Vec<GhIssue>> {
+    let since = (chrono::Utc::now() - chrono::Duration::hours(24))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // gh issue list with search query: no prd-generated label, created since cutoff
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            &format!("-label:prd-generated created:>{since}"),
+            "--json",
+            "number,title,body,labels,createdAt,author,url",
+            "--limit",
+            "20",
+        ])
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to run gh: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("gh issue list failed: {stderr}");
+    }
+
+    let issues: Vec<GhIssue> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow::anyhow!("failed to parse gh output: {e}"))?;
+
+    Ok(issues)
+}
+
+// ---------------------------------------------------------------------------
+// Health watchdog
+// ---------------------------------------------------------------------------
+
+/// Spawn a background task that monitors message processing activity.
+///
+/// If no messages are processed for `timeout` duration, the process exits
+/// with code 1 so systemd can restart it. The watchdog checks every
+/// `check_interval`.
+///
+/// Returns a handle that should be used to report activity via
+/// `WatchdogHandle::ping()`.
+pub fn spawn_watchdog(timeout: Duration, check_interval: Duration) -> WatchdogHandle {
+    let last_activity = Arc::new(std::sync::atomic::AtomicU64::new(
+        instant_to_epoch_secs(Instant::now()),
+    ));
+
+    let handle = WatchdogHandle {
+        last_activity: last_activity.clone(),
+    };
+
+    tokio::spawn(async move {
+        tracing::info!(
+            timeout_secs = timeout.as_secs(),
+            check_interval_secs = check_interval.as_secs(),
+            "health watchdog started"
+        );
+
+        loop {
+            tokio::time::sleep(check_interval).await;
+
+            let last = last_activity.load(std::sync::atomic::Ordering::Relaxed);
+            let now = instant_to_epoch_secs(Instant::now());
+            let elapsed = Duration::from_secs(now.saturating_sub(last));
+
+            if elapsed > timeout {
+                tracing::error!(
+                    elapsed_secs = elapsed.as_secs(),
+                    timeout_secs = timeout.as_secs(),
+                    "health watchdog: no activity detected, exiting for restart"
+                );
+                // Give tracing a moment to flush
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                std::process::exit(1);
+            } else {
+                tracing::debug!(
+                    elapsed_secs = elapsed.as_secs(),
+                    "health watchdog: activity detected, all good"
+                );
+            }
+        }
+    });
+
+    handle
+}
+
+/// Handle for reporting activity to the watchdog.
+#[derive(Clone)]
+pub struct WatchdogHandle {
+    last_activity: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl WatchdogHandle {
+    /// Report that a message was processed, resetting the watchdog timer.
+    pub fn ping(&self) {
+        self.last_activity.store(
+            instant_to_epoch_secs(Instant::now()),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+}
+
+/// Convert an `Instant` to a monotonic epoch-seconds value.
+/// Uses `Instant::now().elapsed()` trick to get a stable u64 for atomic ops.
+fn instant_to_epoch_secs(instant: Instant) -> u64 {
+    // We use system time here since Instant doesn't expose raw values.
+    // This is fine — we only compare deltas, not absolute values.
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        // Adjust for the difference between `instant` and `Instant::now()`
+        .wrapping_sub(Instant::now().duration_since(instant).as_secs())
+}

--- a/tests/bulletin.rs
+++ b/tests/bulletin.rs
@@ -113,6 +113,7 @@ async fn bootstrap_deps() -> anyhow::Result<spacebot::AgentDeps> {
         mcp_manager,
         task_store,
         project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite.clone())),
+        registry_store: Arc::new(spacebot::registry::RegistryStore::new(db.sqlite.clone())),
         cron_tool: None,
         runtime_config,
         event_tx,

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -238,6 +238,7 @@ async fn dump_channel_context() {
         worker_inputs: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         worker_injections: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         reserved_tasks: Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new())),
+        worker_queue: Arc::new(tokio::sync::RwLock::new(std::collections::VecDeque::new())),
         status_block,
         deps: deps.clone(),
         conversation_logger,
@@ -476,6 +477,7 @@ async fn dump_all_contexts() {
         worker_inputs: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         worker_injections: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         reserved_tasks: Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new())),
+        worker_queue: Arc::new(tokio::sync::RwLock::new(std::collections::VecDeque::new())),
         status_block: Arc::new(tokio::sync::RwLock::new(
             spacebot::agent::status::StatusBlock::new(),
         )),

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -112,6 +112,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         mcp_manager,
         task_store,
         project_store: Arc::new(spacebot::projects::ProjectStore::new(db.sqlite.clone())),
+        registry_store: Arc::new(spacebot::registry::RegistryStore::new(db.sqlite.clone())),
         cron_tool: None,
         runtime_config,
         event_tx,


### PR DESCRIPTION
## Problem

Interactive workers that call `set_status(kind="outcome")` get permanently stuck in `idle` status, causing a crash-loop:

1. Worker completes task and calls `set_status(kind="outcome")`
2. Worker unconditionally enters the follow-up loop and sets itself to `idle`
3. `input_rx.recv().await` blocks forever — circular dependency:
   - `WorkerComplete` only fires after `worker.run()` returns
   - `worker.run()` only returns when the follow-up loop exits  
   - The loop only exits when the sender is dropped
   - The sender is only dropped on `WorkerComplete`
4. Health watchdog detects no activity after 600s → kills process
5. On restart, idle worker is resumed but produces no activity → repeat

This results in **permanent crash-loop** with restarts every ~10 minutes. Restart counter reached 1194+ on our instance.

## Fix

**`src/agent/worker.rs`**: Before entering the follow-up loop, check `outcome_signaled()`. If the worker already signaled a terminal outcome, drop `input_rx` immediately so `WorkerComplete` can fire normally.

**`src/conversation/history.rs`**: Harden `log_worker_idle()` with a conditional UPDATE that skips terminal states (`done`/`failed`/`completed`/`cancelled`). This prevents a race condition where two fire-and-forget `tokio::spawn` DB updates execute out of order.

## Test plan

- [x] `cargo check` passes
- [x] Deployed to production instance — no more crash-loop, workers complete normally
- [ ] Verify workers that need follow-up (non-outcome) still enter idle correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)