### PR TITLE
fix(daemon): import blocking IPC IO traits

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,6 +14,7 @@ use tracing_subscriber::fmt::format;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
+use std::io::{BufRead as _, Write as _};
 use std::path::PathBuf;
 use std::time::Instant;
 


### PR DESCRIPTION
Summary

This PR fixes a compile error (E0599) in `src/daemon.rs` by importing missing blocking I/O traits, specifically bringing `write_all`/`flush`/`read_line` into scope for synchronous `UnixStream` usage. No behavioral changes are intended.

Files changed

- `src/daemon.rs`: add `use std::io::{BufRead as _, Write as _};` to bring blocking I/O trait methods into scope.

Verification performed

- Ran repository gate locally in Nix dev shell:

  - `nix develop .#backend --command "bash -lc './scripts/gate-pr.sh' 2>&1 | tee /tmp/gate-pr-output.txt'"`
  - When linker OOMs occurred during parallel test linking, re-ran with serialized builds:

    `CARGO_BUILD_JOBS=1 ./scripts/gate-pr.sh`

- Final local output: `[gate-pr] all gate checks passed`.
- Local logs saved at `/tmp/gate-pr-output.txt`.

Commits

- `fix(daemon): import blocking IPC IO traits` (applied to this branch via cherry-pick)

Notes

- No `migrations/` files were modified.
- Residual risk: low — the change resolves a compile error by bringing trait methods into scope.
- If CI runners hit linker memory limits, consider serializing builds or increasing runner resources.
