### PR TITLE
feat(memory): expand working-memory event semantics

### DIFF
--- a/docs/design-docs/working-memory-implementation-plan.md
+++ b/docs/design-docs/working-memory-implementation-plan.md
@@ -158,6 +158,12 @@ pub enum WorkingMemoryEventType {
     CronExecuted,
     MemorySaved,
     Decision,
+    UserCorrection,
+    DecisionRevised,
+    DeadlineSet,
+    BlockedOn,
+    Constraint,
+    Outcome,
     Error,
     TaskUpdate,
     AgentMessage,
@@ -861,7 +867,8 @@ Update `prompts/en/memory_persistence.md.j2` to add:
 In addition to saving graph memories, identify key decisions and important events
 from the conversation. For each, include it in the `events` field of
 memory_persistence_complete. Events should be one-line summaries with a type
-("decision", "error", "system") and importance score (0.0-1.0).
+("decision", "user_correction", "decision_revised", "deadline_set", "blocked_on",
+"constraint", "outcome", "error", "system") and importance score (0.0-1.0).
 ```
 
 Update `src/tools/memory_persistence_complete.rs`:

--- a/docs/design-docs/working-memory.md
+++ b/docs/design-docs/working-memory.md
@@ -75,6 +75,18 @@ pub enum WorkingMemoryEventType {
     MemorySaved,
     /// A decision was made (extracted from conversation)
     Decision,
+    /// The user corrected a prior assumption, instruction, or framing
+    UserCorrection,
+    /// A prior decision changed after feedback or new information
+    DecisionRevised,
+    /// A concrete due date, deadline, or scheduled milestone was set
+    DeadlineSet,
+    /// Progress is waiting on approval, missing input, or an external dependency
+    BlockedOn,
+    /// A hard requirement, limitation, or non-negotiable boundary was stated
+    Constraint,
+    /// A task, branch, or delegated step reached a clear terminal result
+    Outcome,
     /// An error or failure occurred
     Error,
     /// A task was created or updated
@@ -455,7 +467,7 @@ The periodic memory persistence branch currently runs every 50 user messages. Re
 
 ### Persistence Branch Dual Output
 
-The memory persistence branch gains a second responsibility: in addition to saving graph memories, it emits `Decision` and `MemorySaved` events into the working memory log. This connects the two systems:
+The memory persistence branch gains a second responsibility: in addition to saving graph memories, it emits typed conversational events into the working memory log. This connects the two systems:
 
 ```
 Persistence branch runs:
@@ -463,11 +475,11 @@ Persistence branch runs:
   2. Reads conversation history since last run
   3. Saves new graph memories via memory_save (as today)
   4. Identifies key decisions and events
-  5. Emits working memory events for each decision identified
+  5. Emits working memory events for each important event identified
   6. Calls memory_persistence_complete
 ```
 
-Step 5 is new. The persistence branch prompt is updated to instruct it to identify decisions explicitly. The `memory_persistence_complete` tool gains an optional `events` field:
+Step 5 is new. The persistence branch prompt is updated to identify durable temporal events explicitly: decisions, user corrections, revised decisions, concrete deadlines, blockers, constraints, terminal outcomes, errors, and system events. The `memory_persistence_complete` tool gains an optional `events` field:
 
 ```rust
 pub struct MemoryPersistenceCompleteArgs {
@@ -477,7 +489,7 @@ pub struct MemoryPersistenceCompleteArgs {
 }
 
 pub struct WorkingMemoryEventInput {
-    pub event_type: String,       // "decision", "error", etc.
+    pub event_type: String,       // "decision", "blocked_on", "outcome", etc.
     pub summary: String,
     pub importance: Option<f32>,
 }
@@ -490,13 +502,17 @@ The majority of working memory events are captured programmatically, with zero L
 | Event            | Emitter                                      | How                                                                  |
 | ---------------- | -------------------------------------------- | -------------------------------------------------------------------- |
 | Worker spawned   | `spawn_worker` tool handler                  | After successful spawn, write event with task description as summary |
-| Worker completed | Worker state machine terminal transition     | Write event with worker result summary (truncated to 200 chars)      |
-| Branch completed | Branch return path in channel                | Write event with branch conclusion (truncated to 200 chars)          |
+| Worker completed | Worker state machine terminal transition     | Write typed result, blocker, constraint, or deadline event when the summary uses a recognized prefix; otherwise write `WorkerCompleted` |
+| Branch completed | Branch return path in channel                | Write typed result, blocker, constraint, or deadline event when the summary uses a recognized prefix; otherwise write `BranchCompleted` |
 | Cron executed    | Cron scheduler after job completes           | Write event with cron name + outcome                                 |
 | Memory saved     | `memory_save` tool handler                   | Write event with memory type + content preview                       |
-| Task updated     | Task tool handlers                           | Write event with task title + new status                             |
+| Task updated     | Task tool handlers                           | Write `Outcome` when a task transitions to `done`; otherwise write `TaskUpdate` with task status |
+| Duplicate worker | `spawn_worker` duplicate guard               | Write `BlockedOn` with the active worker ID and duplicate task preview |
+| Agent delegation | `send_agent_message` tool handler            | Write `Outcome` when delegation creates the cross-agent task          |
 | Error            | SpacebotHook on tool failure, worker failure | Write event with error description                                   |
 | System           | Startup, config change, maintenance          | Write event with description                                         |
+
+Branch and worker summaries may opt into richer event types with these prefixes: `outcome:`, `blocked_on:` or `blocked on:`, `constraint:`, and `deadline_set:` or `deadline:`. The prefix is stripped before rendering the event summary.
 
 Each emitter calls `working_memory_store.record_event()` as a fire-and-forget `tokio::spawn`. The message processing pipeline never waits on event recording.
 

--- a/prompts/en/memory_persistence.md.j2
+++ b/prompts/en/memory_persistence.md.j2
@@ -32,13 +32,17 @@ This is an automatic process triggered periodically during conversation. You are
      - `"decision"` for commitments or choices made
      - `"user_correction"` when the user corrects a prior assumption, instruction, or framing
      - `"decision_revised"` when a prior choice changes after feedback or new information
+     - `"deadline_set"` when the conversation establishes a concrete due date, deadline, or scheduled milestone
+     - `"blocked_on"` when progress is waiting on an approval, dependency, missing input, or external action
+     - `"constraint"` when the user or system states a hard requirement, limitation, or non-negotiable boundary
+     - `"outcome"` when a task, branch, or delegated step reaches a clear terminal result worth retaining in temporal memory
      - `"error"` for failures or problems
      - `"system"` for other notable events
    - `summary`: one-line description of what happened
    - Normalize relative time references to absolute dates/times with timezone
      (for example `2026-03-31T14:20:00-04:00`) so downstream memory checks are
      stable across sessions.
-   - `importance`: 0.0-1.0 score (`decision`, `user_correction`, and `decision_revised` are typically 0.6-0.8)
+   - `importance`: 0.0-1.0 score (`decision`, `user_correction`, `decision_revised`, `blocked_on`, and `outcome` are typically 0.6-0.8)
    - Events feed the agent's temporal working memory — they help the agent remember *what happened today*, not just facts.
 
 5. **Finish with the terminal tool.** You must call `memory_persistence_complete` before finishing:

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -119,6 +119,70 @@ fn should_flush_coalesce_buffer_for_event(event: &ProcessEvent) -> bool {
     )
 }
 
+fn classify_conversational_event_summary(
+    summary: &str,
+    default_event_type: crate::memory::WorkingMemoryEventType,
+) -> (crate::memory::WorkingMemoryEventType, String) {
+    let trimmed = summary.trim();
+    if trimmed.is_empty() {
+        return (default_event_type, String::new());
+    }
+
+    if let Some((prefix, rest)) = trimmed.split_once(':') {
+        let rest_trimmed = rest.trim();
+        let prefix = prefix.trim().to_ascii_lowercase().replace([' ', '-'], "_");
+        if prefix == "outcome" {
+            return (
+                crate::memory::WorkingMemoryEventType::Outcome,
+                rest_trimmed.to_string(),
+            );
+        }
+        if prefix == "blocked_on" {
+            return (
+                crate::memory::WorkingMemoryEventType::BlockedOn,
+                rest_trimmed.to_string(),
+            );
+        }
+        if prefix == "constraint" {
+            return (
+                crate::memory::WorkingMemoryEventType::Constraint,
+                rest_trimmed.to_string(),
+            );
+        }
+        if prefix == "deadline_set" || prefix == "deadline" {
+            return (
+                crate::memory::WorkingMemoryEventType::DeadlineSet,
+                rest_trimmed.to_string(),
+            );
+        }
+    }
+
+    (default_event_type, trimmed.to_string())
+}
+
+fn format_conversational_event_summary(
+    event_type: crate::memory::WorkingMemoryEventType,
+    source: &str,
+    event_summary: &str,
+) -> String {
+    let label = match event_type {
+        crate::memory::WorkingMemoryEventType::Outcome => "outcome",
+        crate::memory::WorkingMemoryEventType::BlockedOn => "blocked on",
+        crate::memory::WorkingMemoryEventType::Constraint => "constraint",
+        crate::memory::WorkingMemoryEventType::DeadlineSet => "deadline set",
+        crate::memory::WorkingMemoryEventType::Error => "failed",
+        crate::memory::WorkingMemoryEventType::BranchCompleted
+        | crate::memory::WorkingMemoryEventType::WorkerCompleted => "completed",
+        _ => "concluded",
+    };
+
+    if event_summary.is_empty() {
+        format!("{source} {label}")
+    } else {
+        format!("{source} {label}: {event_summary}")
+    }
+}
+
 fn sentence_contains_decision_marker(sentence: &str) -> bool {
     let sentence_lower = sentence.to_ascii_lowercase();
     DECISION_MARKERS
@@ -3224,11 +3288,19 @@ impl Channel {
                     } else {
                         conclusion.clone()
                     };
+                    let (event_type, event_summary) = classify_conversational_event_summary(
+                        &summary,
+                        crate::memory::WorkingMemoryEventType::BranchCompleted,
+                    );
                     self.deps
                         .working_memory
                         .emit(
-                            crate::memory::WorkingMemoryEventType::BranchCompleted,
-                            format!("Branch concluded: {summary}"),
+                            event_type,
+                            format_conversational_event_summary(
+                                event_type,
+                                "Branch",
+                                &event_summary,
+                            ),
                         )
                         .channel(self.id.to_string())
                         .importance(0.7)
@@ -3297,20 +3369,18 @@ impl Channel {
                 } else {
                     result.clone()
                 };
-                let event_type = if *success {
+                let default_event_type = if *success {
                     crate::memory::WorkingMemoryEventType::WorkerCompleted
                 } else {
                     crate::memory::WorkingMemoryEventType::Error
                 };
+                let (event_type, event_summary) =
+                    classify_conversational_event_summary(&worker_summary, default_event_type);
                 self.deps
                     .working_memory
                     .emit(
                         event_type,
-                        if *success {
-                            format!("Worker completed: {worker_summary}")
-                        } else {
-                            format!("Worker failed: {worker_summary}")
-                        },
+                        format_conversational_event_summary(event_type, "Worker", &event_summary),
                     )
                     .channel(self.id.to_string())
                     .importance(if *success { 0.6 } else { 0.8 })
@@ -3890,12 +3960,13 @@ fn is_dm_conversation_id(conv_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        ObserveModeFallbackState, compute_listen_mode_invocation, decision_user_id,
-        extract_decision_summary_from_reply, is_dm_conversation_id, recv_channel_event,
+        ObserveModeFallbackState, classify_conversational_event_summary,
+        compute_listen_mode_invocation, decision_user_id, extract_decision_summary_from_reply,
+        format_conversational_event_summary, is_dm_conversation_id, recv_channel_event,
         should_process_event_for_channel, should_send_discord_quiet_mode_ping_ack,
         should_send_quiet_mode_fallback,
     };
-    use crate::memory::MemoryType;
+    use crate::memory::{MemoryType, WorkingMemoryEventType};
     use crate::{AgentId, ChannelId, InboundMessage, MessageContent, ProcessEvent, ProcessId};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -4134,6 +4205,98 @@ mod tests {
         };
 
         assert!(!should_process_event_for_channel(&event, &channel_id));
+    }
+
+    #[test]
+    fn conversational_event_summary_extracts_outcome_prefix() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "outcome: implemented the migration safety check",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::Outcome);
+        assert_eq!(summary, "implemented the migration safety check");
+    }
+
+    #[test]
+    fn conversational_event_summary_extracts_blocked_on_prefix() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "blocked_on: waiting for review from infra",
+            WorkingMemoryEventType::Error,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::BlockedOn);
+        assert_eq!(summary, "waiting for review from infra");
+    }
+
+    #[test]
+    fn conversational_event_summary_falls_back_to_default_type() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "completed with no blockers",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::WorkerCompleted);
+        assert_eq!(summary, "completed with no blockers");
+    }
+
+    #[test]
+    fn conversational_event_summary_extracts_constraint_prefix_case_insensitively() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "CoNsTrAiNt: must keep migrations immutable",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::Constraint);
+        assert_eq!(summary, "must keep migrations immutable");
+    }
+
+    #[test]
+    fn conversational_event_summary_is_case_insensitive_across_prefixes() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "OUTCOME: implemented the follow-up",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::Outcome);
+        assert_eq!(summary, "implemented the follow-up");
+
+        let (event_type, summary) = classify_conversational_event_summary(
+            "Blocked_On: waiting on reviewer signoff",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::BlockedOn);
+        assert_eq!(summary, "waiting on reviewer signoff");
+
+        let (event_type, summary) = classify_conversational_event_summary(
+            "blocked on: user approval",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::BlockedOn);
+        assert_eq!(summary, "user approval");
+    }
+
+    #[test]
+    fn conversational_event_summary_treats_empty_prefixed_content_as_empty_summary() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "outcome:   ",
+            WorkingMemoryEventType::WorkerCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::Outcome);
+        assert!(summary.is_empty());
+        assert_eq!(
+            format_conversational_event_summary(event_type, "Worker", &summary),
+            "Worker outcome"
+        );
+    }
+
+    #[test]
+    fn conversational_event_summary_extracts_deadline_prefix() {
+        let (event_type, summary) = classify_conversational_event_summary(
+            "deadline-set: ship by 2026-04-20",
+            WorkingMemoryEventType::BranchCompleted,
+        );
+        assert_eq!(event_type, WorkingMemoryEventType::DeadlineSet);
+        assert_eq!(summary, "ship by 2026-04-20");
+        assert_eq!(
+            format_conversational_event_summary(event_type, "Branch", &summary),
+            "Branch deadline set: ship by 2026-04-20"
+        );
     }
 
     #[test]

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -98,6 +98,7 @@ const CHANGE_COMPARISON_VERBS: &[&str] = &[
     "proceed with ",
 ];
 const BRANCH_CANCELLED_PREFIX: &str = "Branch cancelled:";
+const BRANCH_CANCELLED_SENTENCE: &str = "Branch cancelled.";
 
 async fn recv_channel_event(
     event_rx: &mut broadcast::Receiver<ProcessEvent>,
@@ -196,7 +197,7 @@ fn truncate_working_memory_summary(summary: &str) -> String {
 fn branch_working_memory_event_summary(
     conclusion: &str,
 ) -> (crate::memory::WorkingMemoryEventType, String) {
-    if let Some(reason) = conclusion.strip_prefix(BRANCH_CANCELLED_PREFIX) {
+    if let Some(reason) = parse_branch_cancellation_reason(conclusion) {
         let reason = truncate_working_memory_summary(reason.trim());
         let summary = if reason.is_empty() {
             "Branch cancelled".to_string()
@@ -215,6 +216,17 @@ fn branch_working_memory_event_summary(
         event_type,
         format_conversational_event_summary(event_type, "Branch", &event_summary),
     )
+}
+
+fn parse_branch_cancellation_reason(conclusion: &str) -> Option<&str> {
+    let trimmed = conclusion.trim();
+    if let Some(rest) = trimmed.strip_prefix(BRANCH_CANCELLED_PREFIX) {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix(BRANCH_CANCELLED_SENTENCE) {
+        return Some(rest);
+    }
+    None
 }
 
 fn sentence_contains_decision_marker(sentence: &str) -> bool {
@@ -530,9 +542,9 @@ impl ChannelState {
 
         let reason = crate::summarize_first_non_empty_line(reason, crate::EVENT_SUMMARY_MAX_CHARS);
         let conclusion = if reason.is_empty() {
-            "Branch cancelled.".to_string()
+            BRANCH_CANCELLED_SENTENCE.to_string()
         } else {
-            format!("Branch cancelled: {reason}")
+            format!("{BRANCH_CANCELLED_PREFIX} {reason}")
         };
         self.process_run_logger
             .log_branch_completed(branch_id, &conclusion);
@@ -3299,7 +3311,7 @@ impl Channel {
                     // Regular branch: accumulate result for the next retrigger.
                     // The result text will be embedded directly in the retrigger
                     // message so the LLM knows exactly which process produced it.
-                    let branch_success = !conclusion.starts_with(BRANCH_CANCELLED_PREFIX);
+                    let branch_success = parse_branch_cancellation_reason(conclusion).is_none();
                     self.pending_results.push(PendingResult {
                         process_type: "branch",
                         process_id: branch_id.to_string(),
@@ -4324,6 +4336,14 @@ mod tests {
 
         assert_eq!(event_type, WorkingMemoryEventType::Error);
         assert_eq!(summary, "Branch cancelled: superseded by user request");
+    }
+
+    #[test]
+    fn branch_working_memory_event_records_sentence_cancellation_as_error() {
+        let (event_type, summary) = branch_working_memory_event_summary("Branch cancelled.");
+
+        assert_eq!(event_type, WorkingMemoryEventType::Error);
+        assert_eq!(summary, "Branch cancelled");
     }
 
     #[test]

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -97,6 +97,7 @@ const CHANGE_COMPARISON_VERBS: &[&str] = &[
     "go with ",
     "proceed with ",
 ];
+const BRANCH_CANCELLED_PREFIX: &str = "Branch cancelled:";
 
 async fn recv_channel_event(
     event_rx: &mut broadcast::Receiver<ProcessEvent>,
@@ -181,6 +182,39 @@ fn format_conversational_event_summary(
     } else {
         format!("{source} {label}: {event_summary}")
     }
+}
+
+fn truncate_working_memory_summary(summary: &str) -> String {
+    if summary.len() > 200 {
+        let boundary = summary.floor_char_boundary(200);
+        format!("{}...", &summary[..boundary])
+    } else {
+        summary.to_string()
+    }
+}
+
+fn branch_working_memory_event_summary(
+    conclusion: &str,
+) -> (crate::memory::WorkingMemoryEventType, String) {
+    if let Some(reason) = conclusion.strip_prefix(BRANCH_CANCELLED_PREFIX) {
+        let reason = truncate_working_memory_summary(reason.trim());
+        let summary = if reason.is_empty() {
+            "Branch cancelled".to_string()
+        } else {
+            format!("Branch cancelled: {reason}")
+        };
+        return (crate::memory::WorkingMemoryEventType::Error, summary);
+    }
+
+    let summary = truncate_working_memory_summary(conclusion);
+    let (event_type, event_summary) = classify_conversational_event_summary(
+        &summary,
+        crate::memory::WorkingMemoryEventType::BranchCompleted,
+    );
+    (
+        event_type,
+        format_conversational_event_summary(event_type, "Branch", &event_summary),
+    )
 }
 
 fn sentence_contains_decision_marker(sentence: &str) -> bool {
@@ -3265,7 +3299,7 @@ impl Channel {
                     // Regular branch: accumulate result for the next retrigger.
                     // The result text will be embedded directly in the retrigger
                     // message so the LLM knows exactly which process produced it.
-                    let branch_success = !conclusion.starts_with("Branch cancelled:");
+                    let branch_success = !conclusion.starts_with(BRANCH_CANCELLED_PREFIX);
                     self.pending_results.push(PendingResult {
                         process_type: "branch",
                         process_id: branch_id.to_string(),
@@ -3281,27 +3315,11 @@ impl Channel {
                         );
                     }
 
-                    // Truncate for working memory — full conclusion lives in branch_runs.
-                    let summary = if conclusion.len() > 200 {
-                        let boundary = conclusion.floor_char_boundary(200);
-                        format!("{}...", &conclusion[..boundary])
-                    } else {
-                        conclusion.clone()
-                    };
-                    let (event_type, event_summary) = classify_conversational_event_summary(
-                        &summary,
-                        crate::memory::WorkingMemoryEventType::BranchCompleted,
-                    );
+                    let (event_type, event_summary) =
+                        branch_working_memory_event_summary(conclusion);
                     self.deps
                         .working_memory
-                        .emit(
-                            event_type,
-                            format_conversational_event_summary(
-                                event_type,
-                                "Branch",
-                                &event_summary,
-                            ),
-                        )
+                        .emit(event_type, event_summary)
                         .channel(self.id.to_string())
                         .importance(0.7)
                         .record();
@@ -3960,11 +3978,11 @@ fn is_dm_conversation_id(conv_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        ObserveModeFallbackState, classify_conversational_event_summary,
-        compute_listen_mode_invocation, decision_user_id, extract_decision_summary_from_reply,
-        format_conversational_event_summary, is_dm_conversation_id, recv_channel_event,
-        should_process_event_for_channel, should_send_discord_quiet_mode_ping_ack,
-        should_send_quiet_mode_fallback,
+        ObserveModeFallbackState, branch_working_memory_event_summary,
+        classify_conversational_event_summary, compute_listen_mode_invocation, decision_user_id,
+        extract_decision_summary_from_reply, format_conversational_event_summary,
+        is_dm_conversation_id, recv_channel_event, should_process_event_for_channel,
+        should_send_discord_quiet_mode_ping_ack, should_send_quiet_mode_fallback,
     };
     use crate::memory::{MemoryType, WorkingMemoryEventType};
     use crate::{AgentId, ChannelId, InboundMessage, MessageContent, ProcessEvent, ProcessId};
@@ -4297,6 +4315,15 @@ mod tests {
             format_conversational_event_summary(event_type, "Branch", &summary),
             "Branch deadline set: ship by 2026-04-20"
         );
+    }
+
+    #[test]
+    fn branch_working_memory_event_records_cancellation_as_error() {
+        let (event_type, summary) =
+            branch_working_memory_event_summary("Branch cancelled: superseded by user request");
+
+        assert_eq!(event_type, WorkingMemoryEventType::Error);
+        assert_eq!(summary, "Branch cancelled: superseded by user request");
     }
 
     #[test]

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -10,7 +10,7 @@
 //! conversations: worker lifecycle, branch conclusions, cron executions,
 //! decisions, errors.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
@@ -43,6 +43,14 @@ pub enum WorkingMemoryEventType {
     UserCorrection,
     /// A prior decision was revised.
     DecisionRevised,
+    /// A concrete deadline or due date was set.
+    DeadlineSet,
+    /// Progress is currently blocked on an external dependency or prerequisite.
+    BlockedOn,
+    /// An explicit constraint was stated.
+    Constraint,
+    /// A task or branch reached a terminal result.
+    Outcome,
     /// An error or failure occurred.
     Error,
     /// A task was created or updated.
@@ -68,6 +76,10 @@ impl WorkingMemoryEventType {
             Self::Decision => "decision",
             Self::UserCorrection => "user_correction",
             Self::DecisionRevised => "decision_revised",
+            Self::DeadlineSet => "deadline_set",
+            Self::BlockedOn => "blocked_on",
+            Self::Constraint => "constraint",
+            Self::Outcome => "outcome",
             Self::Error => "error",
             Self::TaskUpdate => "task_update",
             Self::AgentMessage => "agent_message",
@@ -87,6 +99,10 @@ impl WorkingMemoryEventType {
             "decision" => Some(Self::Decision),
             "user_correction" => Some(Self::UserCorrection),
             "decision_revised" => Some(Self::DecisionRevised),
+            "deadline_set" => Some(Self::DeadlineSet),
+            "blocked_on" => Some(Self::BlockedOn),
+            "constraint" => Some(Self::Constraint),
+            "outcome" => Some(Self::Outcome),
             "error" => Some(Self::Error),
             "task_update" => Some(Self::TaskUpdate),
             "agent_message" => Some(Self::AgentMessage),
@@ -214,13 +230,13 @@ impl WorkingMemoryStore {
     pub async fn get_events_for_day(&self, day: &str) -> Result<Vec<WorkingMemoryEvent>> {
         let rows = sqlx::query(
             "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-             FROM working_memory_events WHERE day = ? ORDER BY timestamp ASC",
+             FROM working_memory_events WHERE day = ? ORDER BY timestamp ASC, id ASC",
         )
         .bind(day)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows.iter().map(row_to_event).collect())
+        rows.iter().map(row_to_event).collect()
     }
 
     /// Get recent events for a channel, used for context injection.
@@ -231,7 +247,7 @@ impl WorkingMemoryStore {
     ) -> Result<Vec<WorkingMemoryEvent>> {
         let rows = sqlx::query(
             "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-             FROM working_memory_events WHERE channel_id = ? ORDER BY timestamp DESC LIMIT ?",
+             FROM working_memory_events WHERE channel_id = ? ORDER BY timestamp DESC, id DESC LIMIT ?",
         )
         .bind(channel_id)
         .bind(limit as i64)
@@ -239,7 +255,8 @@ impl WorkingMemoryStore {
         .await?;
 
         // Reverse so oldest-first for rendering.
-        let mut events: Vec<WorkingMemoryEvent> = rows.iter().map(row_to_event).collect();
+        let mut events: Vec<WorkingMemoryEvent> =
+            rows.iter().map(row_to_event).collect::<Result<Vec<_>>>()?;
         events.reverse();
         Ok(events)
     }
@@ -252,14 +269,15 @@ impl WorkingMemoryStore {
     ) -> Result<Vec<WorkingMemoryEvent>> {
         let rows = sqlx::query(
             "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-             FROM working_memory_events WHERE importance >= ? ORDER BY timestamp DESC LIMIT ?",
+             FROM working_memory_events WHERE importance >= ? ORDER BY timestamp DESC, id DESC LIMIT ?",
         )
         .bind(min_importance)
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
 
-        let mut events: Vec<WorkingMemoryEvent> = rows.iter().map(row_to_event).collect();
+        let mut events: Vec<WorkingMemoryEvent> =
+            rows.iter().map(row_to_event).collect::<Result<Vec<_>>>()?;
         events.reverse();
         Ok(events)
     }
@@ -272,14 +290,15 @@ impl WorkingMemoryStore {
     ) -> Result<Vec<WorkingMemoryEvent>> {
         let rows = sqlx::query(
             "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-             FROM working_memory_events WHERE user_id = ? ORDER BY timestamp DESC LIMIT ?",
+             FROM working_memory_events WHERE user_id = ? ORDER BY timestamp DESC, id DESC LIMIT ?",
         )
         .bind(user_id)
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
 
-        let mut events: Vec<WorkingMemoryEvent> = rows.iter().map(row_to_event).collect();
+        let mut events: Vec<WorkingMemoryEvent> =
+            rows.iter().map(row_to_event).collect::<Result<Vec<_>>>()?;
         events.reverse();
         Ok(events)
     }
@@ -294,7 +313,7 @@ impl WorkingMemoryStore {
             Some(after_ts) => {
                 sqlx::query(
                     "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-                     FROM working_memory_events WHERE day = ? AND timestamp > ? ORDER BY timestamp ASC",
+                     FROM working_memory_events WHERE day = ? AND timestamp > ? ORDER BY timestamp ASC, id ASC",
                 )
                 .bind(day)
                 .bind(after_ts)
@@ -304,7 +323,7 @@ impl WorkingMemoryStore {
             None => {
                 sqlx::query(
                     "SELECT id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day \
-                     FROM working_memory_events WHERE day = ? ORDER BY timestamp ASC",
+                     FROM working_memory_events WHERE day = ? ORDER BY timestamp ASC, id ASC",
                 )
                 .bind(day)
                 .fetch_all(&self.pool)
@@ -312,7 +331,7 @@ impl WorkingMemoryStore {
             }
         };
 
-        Ok(rows.iter().map(row_to_event).collect())
+        rows.iter().map(row_to_event).collect()
     }
 
     /// Count events for a channel since a timestamp (for density trigger).
@@ -339,7 +358,7 @@ impl WorkingMemoryStore {
     ) -> Result<Option<DateTime<Utc>>> {
         let row = sqlx::query(
             "SELECT time_range_end FROM working_memory_intraday_syntheses \
-             WHERE day = ? ORDER BY time_range_start DESC LIMIT 1",
+             WHERE day = ? ORDER BY time_range_start DESC, id DESC LIMIT 1",
         )
         .bind(day)
         .fetch_optional(&self.pool)
@@ -379,7 +398,7 @@ impl WorkingMemoryStore {
     pub async fn get_intraday_syntheses(&self, day: &str) -> Result<Vec<IntradaySynthesis>> {
         let rows = sqlx::query(
             "SELECT id, day, time_range_start, time_range_end, summary, event_count, created_at \
-             FROM working_memory_intraday_syntheses WHERE day = ? ORDER BY time_range_start ASC",
+             FROM working_memory_intraday_syntheses WHERE day = ? ORDER BY time_range_start ASC, id ASC",
         )
         .bind(day)
         .fetch_all(&self.pool)
@@ -688,13 +707,13 @@ pub async fn render_channel_activity_map(
          LEFT JOIN conversation_messages m ON m.id = ( \
             SELECT id FROM conversation_messages \
             WHERE channel_id = c.id \
-            ORDER BY created_at DESC \
+            ORDER BY created_at DESC, id DESC \
             LIMIT 1 \
          ) \
          WHERE c.id != ? \
            AND c.is_active = 1 \
            AND (m.created_at IS NULL OR m.created_at > datetime('now', ?)) \
-         ORDER BY m.created_at DESC NULLS LAST \
+         ORDER BY m.created_at DESC NULLS LAST, c.id ASC \
          LIMIT ?",
     )
     .bind(exclude_channel_id)
@@ -828,6 +847,10 @@ fn format_event_line(event: &WorkingMemoryEvent, current_channel_id: &str) -> St
         WorkingMemoryEventType::Decision => "Decision",
         WorkingMemoryEventType::UserCorrection => "User correction",
         WorkingMemoryEventType::DecisionRevised => "Decision revised",
+        WorkingMemoryEventType::DeadlineSet => "Deadline set",
+        WorkingMemoryEventType::BlockedOn => "Blocked on",
+        WorkingMemoryEventType::Constraint => "Constraint",
+        WorkingMemoryEventType::Outcome => "Outcome",
         WorkingMemoryEventType::Error => "Error",
         WorkingMemoryEventType::TaskUpdate => "Task update",
         WorkingMemoryEventType::AgentMessage => "Agent message",
@@ -866,7 +889,7 @@ async fn get_topic_hints(
     let query = format!(
         "SELECT channel_id, summary FROM ( \
             SELECT channel_id, summary, \
-                   ROW_NUMBER() OVER (PARTITION BY channel_id ORDER BY timestamp DESC) AS rn \
+                   ROW_NUMBER() OVER (PARTITION BY channel_id ORDER BY timestamp DESC, id DESC) AS rn \
             FROM working_memory_events \
             WHERE event_type = 'branch_completed' \
               AND channel_id IN ({in_clause}) \
@@ -1020,12 +1043,18 @@ impl WorkingMemoryEventBuilder {
 // Row mapping helpers
 // ---------------------------------------------------------------------------
 
-fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> WorkingMemoryEvent {
+fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> Result<WorkingMemoryEvent> {
+    let id: String = row.get("id");
     let event_type_str: String = row.get("event_type");
-    WorkingMemoryEvent {
-        id: row.get("id"),
-        event_type: WorkingMemoryEventType::parse(&event_type_str)
-            .unwrap_or(WorkingMemoryEventType::System),
+    let Some(event_type) = WorkingMemoryEventType::parse(&event_type_str) else {
+        return Err(Error::Other(anyhow::anyhow!(
+            "unknown working memory event_type '{event_type_str}' for event {id}"
+        )));
+    };
+
+    Ok(WorkingMemoryEvent {
+        id,
+        event_type,
         timestamp: row.get("timestamp"),
         channel_id: row.get("channel_id"),
         user_id: row.get("user_id"),
@@ -1033,7 +1062,7 @@ fn row_to_event(row: &sqlx::sqlite::SqliteRow) -> WorkingMemoryEvent {
         detail: row.get("detail"),
         importance: row.get("importance"),
         day: row.get("day"),
-    }
+    })
 }
 
 fn row_to_intraday_synthesis(row: &sqlx::sqlite::SqliteRow) -> IntradaySynthesis {
@@ -1159,7 +1188,7 @@ mod tests {
         let store = setup_test_store().await;
         let today = store.today();
 
-        for event_type in [
+        let inserted = [
             WorkingMemoryEventType::BranchCompleted,
             WorkingMemoryEventType::WorkerSpawned,
             WorkingMemoryEventType::WorkerCompleted,
@@ -1168,13 +1197,19 @@ mod tests {
             WorkingMemoryEventType::Decision,
             WorkingMemoryEventType::UserCorrection,
             WorkingMemoryEventType::DecisionRevised,
+            WorkingMemoryEventType::DeadlineSet,
+            WorkingMemoryEventType::BlockedOn,
+            WorkingMemoryEventType::Constraint,
+            WorkingMemoryEventType::Outcome,
             WorkingMemoryEventType::Error,
             WorkingMemoryEventType::TaskUpdate,
             WorkingMemoryEventType::AgentMessage,
             WorkingMemoryEventType::System,
             WorkingMemoryEventType::MemoryPromoted,
             WorkingMemoryEventType::MemoryDemoted,
-        ] {
+        ];
+
+        for event_type in inserted {
             let event = WorkingMemoryEvent {
                 id: Uuid::new_v4().to_string(),
                 event_type,
@@ -1190,12 +1225,43 @@ mod tests {
         }
 
         let events = store.get_events_for_day(&today).await.unwrap();
-        assert_eq!(events.len(), 14);
+        assert_eq!(events.len(), inserted.len());
 
         // Verify all types survived the roundtrip.
         let types: Vec<WorkingMemoryEventType> = events.iter().map(|e| e.event_type).collect();
         assert!(types.contains(&WorkingMemoryEventType::BranchCompleted));
         assert!(types.contains(&WorkingMemoryEventType::MemoryDemoted));
+    }
+
+    #[tokio::test]
+    async fn unknown_event_type_returns_decode_error() {
+        let store = setup_test_store().await;
+        let today = store.today();
+
+        sqlx::query(
+            "INSERT INTO working_memory_events \
+             (id, event_type, timestamp, channel_id, user_id, summary, detail, importance, day) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("wm_unknown")
+        .bind("unknown_type")
+        .bind(Utc::now())
+        .bind(Option::<String>::None)
+        .bind(Option::<String>::None)
+        .bind("unknown event")
+        .bind(Option::<String>::None)
+        .bind(0.5_f32)
+        .bind(&today)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let error = store.get_events_for_day(&today).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unknown working memory event_type 'unknown_type' for event wm_unknown")
+        );
     }
 
     #[tokio::test]

--- a/src/memory/working.rs
+++ b/src/memory/working.rs
@@ -884,14 +884,16 @@ async fn get_topic_hints(
     let placeholders: Vec<&str> = (0..channel_ids.len()).map(|_| "?").collect();
     let in_clause = placeholders.join(", ");
 
-    // We need the most recent BranchCompleted per channel. Use a window
-    // function approach that works in a single pass.
+    // Semantic branch conclusions are stored by event type, so keep topic hints
+    // scoped to summaries emitted from branches.
     let query = format!(
         "SELECT channel_id, summary FROM ( \
             SELECT channel_id, summary, \
                    ROW_NUMBER() OVER (PARTITION BY channel_id ORDER BY timestamp DESC, id DESC) AS rn \
             FROM working_memory_events \
-            WHERE event_type = 'branch_completed' \
+            WHERE (event_type = 'branch_completed' \
+                   OR (event_type IN ('outcome', 'blocked_on', 'constraint', 'deadline_set') \
+                       AND summary LIKE 'Branch %')) \
               AND channel_id IN ({in_clause}) \
         ) WHERE rn = 1"
     );
@@ -1261,6 +1263,54 @@ mod tests {
             error
                 .to_string()
                 .contains("unknown working memory event_type 'unknown_type' for event wm_unknown")
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_hints_include_branch_semantic_terminal_events() {
+        let store = setup_test_store().await;
+        let today = store.today();
+        let base = Utc::now();
+
+        insert_event(
+            &store.pool,
+            &WorkingMemoryEvent {
+                id: Uuid::new_v4().to_string(),
+                event_type: WorkingMemoryEventType::Outcome,
+                timestamp: base,
+                channel_id: Some("chan-1".to_string()),
+                user_id: None,
+                summary: "Branch outcome: selected the task-store transaction fix".to_string(),
+                detail: None,
+                importance: 0.7,
+                day: today.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        insert_event(
+            &store.pool,
+            &WorkingMemoryEvent {
+                id: Uuid::new_v4().to_string(),
+                event_type: WorkingMemoryEventType::Outcome,
+                timestamp: base + chrono::Duration::minutes(1),
+                channel_id: Some("chan-1".to_string()),
+                user_id: None,
+                summary: "Task #12 completed".to_string(),
+                detail: None,
+                importance: 0.7,
+                day: today,
+            },
+        )
+        .await
+        .unwrap();
+
+        let channel_ids = vec!["chan-1".to_string()];
+        let hints = get_topic_hints(&store.pool, &channel_ids).await.unwrap();
+
+        assert_eq!(
+            hints.get("chan-1").map(String::as_str),
+            Some("Branch outcome: selected the task-store transaction fix")
         );
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -5,5 +5,5 @@ pub mod store;
 
 pub use store::{
     CreateTaskInput, Task, TaskListFilter, TaskPriority, TaskStatus, TaskStore, TaskSubtask,
-    UpdateTaskInput,
+    TaskUpdateResult, UpdateTaskInput, WorkerTaskUpdateResult,
 };

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -9,6 +9,8 @@ use anyhow::Context as _;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+#[cfg(test)]
+use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Row as _, SqlitePool};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -181,6 +183,11 @@ pub struct TaskStore {
 impl TaskStore {
     pub fn new(pool: SqlitePool) -> Self {
         Self { pool }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        &self.pool
     }
 
     /// Maximum number of retries when a concurrent create races on the
@@ -671,61 +678,65 @@ fn read_optional_timestamp(row: &sqlx::sqlite::SqliteRow, column: &str) -> Optio
 }
 
 #[cfg(test)]
+pub(crate) async fn setup_test_store() -> TaskStore {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite should connect");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            task_number INTEGER NOT NULL UNIQUE,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT NOT NULL DEFAULT 'backlog',
+            priority TEXT NOT NULL DEFAULT 'medium',
+            owner_agent_id TEXT NOT NULL,
+            assigned_agent_id TEXT NOT NULL,
+            subtasks TEXT,
+            metadata TEXT,
+            source_memory_id TEXT,
+            worker_id TEXT,
+            created_by TEXT NOT NULL,
+            approved_at TEXT,
+            approved_by TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+            completed_at TEXT
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("tasks schema should be created");
+
+    sqlx::query(
+        "CREATE TABLE task_number_seq (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            next_number INTEGER NOT NULL DEFAULT 1
+        )",
+    )
+    .execute(&pool)
+    .await
+    .expect("task_number_seq should be created");
+
+    sqlx::query("INSERT INTO task_number_seq (id, next_number) VALUES (1, 1)")
+        .execute(&pool)
+        .await
+        .expect("sequence seed should be inserted");
+
+    TaskStore::new(pool)
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::sqlite::SqlitePoolOptions;
 
     async fn setup_store() -> TaskStore {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .expect("in-memory sqlite should connect");
-
-        sqlx::query(
-            r#"
-            CREATE TABLE tasks (
-                id TEXT PRIMARY KEY,
-                task_number INTEGER NOT NULL UNIQUE,
-                title TEXT NOT NULL,
-                description TEXT,
-                status TEXT NOT NULL DEFAULT 'backlog',
-                priority TEXT NOT NULL DEFAULT 'medium',
-                owner_agent_id TEXT NOT NULL,
-                assigned_agent_id TEXT NOT NULL,
-                subtasks TEXT,
-                metadata TEXT,
-                source_memory_id TEXT,
-                worker_id TEXT,
-                created_by TEXT NOT NULL,
-                approved_at TEXT,
-                approved_by TEXT,
-                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                completed_at TEXT
-            )
-            "#,
-        )
-        .execute(&pool)
-        .await
-        .expect("tasks schema should be created");
-
-        sqlx::query(
-            "CREATE TABLE task_number_seq (
-                id INTEGER PRIMARY KEY CHECK (id = 1),
-                next_number INTEGER NOT NULL DEFAULT 1
-            )",
-        )
-        .execute(&pool)
-        .await
-        .expect("task_number_seq should be created");
-
-        sqlx::query("INSERT INTO task_number_seq (id, next_number) VALUES (1, 1)")
-            .execute(&pool)
-            .await
-            .expect("sequence seed should be inserted");
-
-        TaskStore::new(pool)
+        setup_test_store().await
     }
 
     fn self_assigned_input(title: &str, status: TaskStatus) -> CreateTaskInput {

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -428,32 +428,36 @@ impl TaskStore {
             .await
             .context("failed to open worker task update transaction")?;
 
-        let row = sqlx::query(&format!(
-            "{SELECT_COLUMNS} FROM tasks WHERE worker_id = ? ORDER BY updated_at DESC LIMIT 1"
+        let exact_row = sqlx::query(&format!(
+            "{SELECT_COLUMNS} FROM tasks WHERE worker_id = ? AND task_number = ?"
         ))
         .bind(worker_id)
+        .bind(task_number)
         .fetch_optional(&mut *tx)
         .await
-        .context("failed to fetch task by worker id for update")?;
+        .context("failed to fetch worker task by id and number for update")?;
 
-        let Some(row) = row else {
+        let Some(row) = exact_row else {
+            let assigned_task_number = sqlx::query_scalar::<_, i64>(
+                "SELECT task_number FROM tasks WHERE worker_id = ? ORDER BY task_number DESC LIMIT 1",
+            )
+            .bind(worker_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .context("failed to fetch any task by worker id for update")?;
+
             tx.commit()
                 .await
-                .context("failed to commit empty worker task update transaction")?;
+                .context("failed to commit unmatched worker task update transaction")?;
+            if let Some(assigned_task_number) = assigned_task_number {
+                return Ok(WorkerTaskUpdateResult::WrongTask {
+                    assigned_task_number,
+                });
+            }
             return Ok(WorkerTaskUpdateResult::NotAssigned);
         };
 
         let current = task_from_row(row)?;
-        if current.task_number != task_number {
-            let assigned_task_number = current.task_number;
-            tx.commit()
-                .await
-                .context("failed to commit rejected worker task update transaction")?;
-            return Ok(WorkerTaskUpdateResult::WrongTask {
-                assigned_task_number,
-            });
-        }
-
         let previous_status = current.status;
         let task = Self::update_current_in_tx(&mut tx, task_number, current, input).await?;
 
@@ -926,6 +930,59 @@ mod tests {
 
         assert_eq!(result.previous_status, TaskStatus::InProgress);
         assert_eq!(result.task.status, TaskStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn update_worker_task_prefers_exact_match_with_duplicate_worker_bindings() {
+        let store = setup_store().await;
+        let first = store
+            .create(self_assigned_input("first task", TaskStatus::InProgress))
+            .await
+            .expect("first task should be created");
+        let second = store
+            .create(self_assigned_input("second task", TaskStatus::InProgress))
+            .await
+            .expect("second task should be created");
+
+        let shared_worker_id = "worker-shared";
+        store
+            .update(
+                first.task_number,
+                UpdateTaskInput {
+                    worker_id: Some(shared_worker_id.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("first worker binding should update");
+        store
+            .update(
+                second.task_number,
+                UpdateTaskInput {
+                    worker_id: Some(shared_worker_id.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("second worker binding should update");
+
+        let result = store
+            .update_worker_task(
+                shared_worker_id,
+                first.task_number,
+                UpdateTaskInput {
+                    metadata: Some(serde_json::json!({"target": "first"})),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("worker-scoped update should succeed");
+
+        let WorkerTaskUpdateResult::Updated(result) = result else {
+            panic!("expected exact task update despite duplicate worker bindings");
+        };
+        assert_eq!(result.task.task_number, first.task_number);
+        assert_eq!(result.task.metadata["target"], "first");
     }
 
     #[tokio::test]

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -161,6 +161,19 @@ pub struct UpdateTaskInput {
     pub assigned_agent_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct TaskUpdateResult {
+    pub previous_status: TaskStatus,
+    pub task: Task,
+}
+
+#[derive(Debug, Clone)]
+pub enum WorkerTaskUpdateResult {
+    Updated(Box<TaskUpdateResult>),
+    NotAssigned,
+    WrongTask { assigned_task_number: i64 },
+}
+
 /// Filters for listing tasks from the global store.
 #[derive(Debug, Clone, Default)]
 pub struct TaskListFilter {
@@ -357,10 +370,111 @@ impl TaskStore {
     }
 
     pub async fn update(&self, task_number: i64, input: UpdateTaskInput) -> Result<Option<Task>> {
-        let Some(current) = self.get_by_number(task_number).await? else {
+        Ok(self
+            .update_with_status_transition(task_number, input)
+            .await?
+            .map(|result| result.task))
+    }
+
+    pub async fn update_with_status_transition(
+        &self,
+        task_number: i64,
+        input: UpdateTaskInput,
+    ) -> Result<Option<TaskUpdateResult>> {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open task update transaction")?;
+
+        let row = sqlx::query(&format!(
+            "{SELECT_COLUMNS} FROM tasks WHERE task_number = ?"
+        ))
+        .bind(task_number)
+        .fetch_optional(&mut *tx)
+        .await
+        .context("failed to fetch task by number for update")?;
+
+        let Some(row) = row else {
+            tx.commit()
+                .await
+                .context("failed to commit empty task update transaction")?;
             return Ok(None);
         };
 
+        let current = task_from_row(row)?;
+        let previous_status = current.status;
+        let task = Self::update_current_in_tx(&mut tx, task_number, current, input).await?;
+
+        tx.commit()
+            .await
+            .context("failed to commit task update transaction")?;
+
+        Ok(Some(TaskUpdateResult {
+            previous_status,
+            task,
+        }))
+    }
+
+    pub async fn update_worker_task(
+        &self,
+        worker_id: &str,
+        task_number: i64,
+        input: UpdateTaskInput,
+    ) -> Result<WorkerTaskUpdateResult> {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open worker task update transaction")?;
+
+        let row = sqlx::query(&format!(
+            "{SELECT_COLUMNS} FROM tasks WHERE worker_id = ? ORDER BY updated_at DESC LIMIT 1"
+        ))
+        .bind(worker_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .context("failed to fetch task by worker id for update")?;
+
+        let Some(row) = row else {
+            tx.commit()
+                .await
+                .context("failed to commit empty worker task update transaction")?;
+            return Ok(WorkerTaskUpdateResult::NotAssigned);
+        };
+
+        let current = task_from_row(row)?;
+        if current.task_number != task_number {
+            let assigned_task_number = current.task_number;
+            tx.commit()
+                .await
+                .context("failed to commit rejected worker task update transaction")?;
+            return Ok(WorkerTaskUpdateResult::WrongTask {
+                assigned_task_number,
+            });
+        }
+
+        let previous_status = current.status;
+        let task = Self::update_current_in_tx(&mut tx, task_number, current, input).await?;
+
+        tx.commit()
+            .await
+            .context("failed to commit worker task update transaction")?;
+
+        Ok(WorkerTaskUpdateResult::Updated(Box::new(
+            TaskUpdateResult {
+                previous_status,
+                task,
+            },
+        )))
+    }
+
+    async fn update_current_in_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        task_number: i64,
+        current: Task,
+        input: UpdateTaskInput,
+    ) -> Result<Task> {
         if let Some(next_status) = input.status
             && !can_transition(current.status, next_status)
         {
@@ -455,11 +569,19 @@ impl TaskStore {
 
         sql.bind(input.approved_by)
             .bind(task_number)
-            .execute(&self.pool)
+            .execute(&mut **tx)
             .await
             .context("failed to update task")?;
 
-        self.get_by_number(task_number).await
+        let updated = sqlx::query(&format!(
+            "{SELECT_COLUMNS} FROM tasks WHERE task_number = ?"
+        ))
+        .bind(task_number)
+        .fetch_one(&mut **tx)
+        .await
+        .context("failed to fetch updated task")?;
+
+        task_from_row(updated)
     }
 
     pub async fn delete(&self, task_number: i64) -> Result<bool> {
@@ -777,6 +899,33 @@ mod tests {
             .expect_err("pending_approval -> in_progress must fail");
 
         assert!(error.to_string().contains("invalid task status transition"));
+    }
+
+    #[tokio::test]
+    async fn update_with_status_transition_returns_previous_status() {
+        let store = setup_store().await;
+        let created = store
+            .create(self_assigned_input(
+                "track status transition",
+                TaskStatus::InProgress,
+            ))
+            .await
+            .expect("task should be created");
+
+        let result = store
+            .update_with_status_transition(
+                created.task_number,
+                UpdateTaskInput {
+                    status: Some(TaskStatus::Done),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update should succeed")
+            .expect("task should exist");
+
+        assert_eq!(result.previous_status, TaskStatus::InProgress);
+        assert_eq!(result.task.status, TaskStatus::Done);
     }
 
     #[tokio::test]

--- a/src/tools/memory_persistence_complete.rs
+++ b/src/tools/memory_persistence_complete.rs
@@ -109,7 +109,8 @@ pub struct MemoryPersistenceCompleteArgs {
 /// A single event extracted by the persistence branch for the working memory log.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct WorkingMemoryEventInput {
-    /// Event type: "decision", "user_correction", "decision_revised", "error", or "system".
+    /// Event type: "decision", "user_correction", "decision_revised", "deadline_set",
+    /// "blocked_on", "constraint", "outcome", "error", or "system".
     pub event_type: String,
     /// One-line summary of the event.
     pub summary: String,
@@ -170,6 +171,10 @@ impl Tool for MemoryPersistenceCompleteTool {
                                         "decision",
                                         "user_correction",
                                         "decision_revised",
+                                        "deadline_set",
+                                        "blocked_on",
+                                        "constraint",
+                                        "outcome",
                                         "error",
                                         "system"
                                     ],

--- a/src/tools/send_agent_message.rs
+++ b/src/tools/send_agent_message.rs
@@ -285,7 +285,7 @@ impl Tool for SendAgentMessageTool {
         if let Some(working_memory) = &self.working_memory {
             working_memory
                 .emit(
-                    crate::memory::WorkingMemoryEventType::AgentMessage,
+                    crate::memory::WorkingMemoryEventType::Outcome,
                     format!("Delegated task #{task_number} to {target_display}"),
                 )
                 .importance(0.7)
@@ -323,5 +323,104 @@ fn extract_task_title(message: &str) -> String {
     } else {
         let boundary = first_line.floor_char_boundary(120);
         format!("{}...", first_line[..boundary].trim())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::links::{AgentLink, LinkDirection, LinkKind};
+    use crate::memory::working::WorkingMemoryEvent;
+    use crate::memory::{WorkingMemoryEventType, WorkingMemoryStore};
+    use crate::tasks::store::setup_test_store;
+    use arc_swap::ArcSwap;
+    use chrono_tz::Tz;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    async fn wait_for_single_event(store: &WorkingMemoryStore) -> WorkingMemoryEvent {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let events = store
+                    .get_recent_events(10, 0.0)
+                    .await
+                    .expect("working memory query");
+                if let Some(event) = events.into_iter().next() {
+                    break event;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for working memory event")
+    }
+
+    #[tokio::test]
+    async fn send_agent_message_emits_outcome_event() {
+        let task_store = setup_test_store().await;
+        let pool = task_store.pool().clone();
+        sqlx::query(
+            "CREATE TABLE conversation_messages (
+                id TEXT PRIMARY KEY,
+                channel_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                sender_name TEXT,
+                sender_id TEXT,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("conversation messages schema should be created");
+        let task_store = Arc::new(task_store);
+        let conversation_logger = ConversationLogger::new(pool.clone());
+        let working_memory_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite connect");
+        sqlx::migrate!("./migrations")
+            .run(&working_memory_pool)
+            .await
+            .expect("working memory migrations");
+        let working_memory = WorkingMemoryStore::new(working_memory_pool, Tz::UTC);
+
+        let links = Arc::new(ArcSwap::from_pointee(vec![AgentLink {
+            from_agent_id: "planner".to_string(),
+            to_agent_id: "executor".to_string(),
+            direction: LinkDirection::TwoWay,
+            kind: LinkKind::Peer,
+        }]));
+        let agent_names = Arc::new(HashMap::from([
+            ("planner".to_string(), "Planner".to_string()),
+            ("executor".to_string(), "Executor".to_string()),
+        ]));
+
+        let tool = SendAgentMessageTool::new(
+            crate::AgentId::from("planner"),
+            links,
+            agent_names,
+            task_store,
+            conversation_logger,
+        )
+        .with_working_memory(working_memory.clone());
+
+        let output = tool
+            .call(SendAgentMessageArgs {
+                target: "executor".to_string(),
+                message: "Implement the working-memory renderer. Include tests.".to_string(),
+            })
+            .await
+            .expect("send agent message should succeed");
+
+        assert!(output.success);
+
+        let event = wait_for_single_event(&working_memory).await;
+        assert_eq!(event.event_type, WorkingMemoryEventType::Outcome);
+        assert_eq!(event.summary, "Delegated task #1 to Executor");
     }
 }

--- a/src/tools/spawn_worker.rs
+++ b/src/tools/spawn_worker.rs
@@ -29,6 +29,21 @@ impl SpawnWorkerTool {
     }
 }
 
+fn summarize_duplicate_task(task: &str) -> String {
+    let trimmed = task.trim();
+    if trimmed.is_empty() {
+        return "unspecified task".to_string();
+    }
+
+    const MAX_CHARS: usize = 80;
+    if trimmed.len() <= MAX_CHARS {
+        trimmed.to_string()
+    } else {
+        let boundary = trimmed.floor_char_boundary(MAX_CHARS);
+        format!("{}...", &trimmed[..boundary])
+    }
+}
+
 /// Error type for spawn worker tool.
 #[derive(Debug, thiserror::Error)]
 #[error("Worker spawn failed: {0}")]
@@ -188,6 +203,20 @@ impl Tool for SpawnWorkerTool {
         {
             let status = self.state.status_block.read().await;
             if let Some(existing_id) = status.find_duplicate_worker_task(&args.task) {
+                self.state
+                    .deps
+                    .working_memory
+                    .emit(
+                        crate::memory::WorkingMemoryEventType::BlockedOn,
+                        format!(
+                            "Worker spawn blocked on active worker {existing_id} for duplicate task: {}",
+                            summarize_duplicate_task(&args.task)
+                        ),
+                    )
+                    .channel(self.state.channel_id.to_string())
+                    .importance(0.6)
+                    .record();
+
                 return Ok(SpawnWorkerOutput {
                     worker_id: existing_id,
                     spawned: false,

--- a/src/tools/task_create.rs
+++ b/src/tools/task_create.rs
@@ -174,12 +174,25 @@ impl Tool for TaskCreateTool {
         }
 
         if let Some(working_memory) = &self.working_memory {
-            working_memory
-                .emit(
-                    crate::memory::WorkingMemoryEventType::TaskUpdate,
-                    format!("Task created #{}: {}", task.task_number, task.title),
+            let (event_type, summary, importance) = if task.status == TaskStatus::Done {
+                (
+                    crate::memory::WorkingMemoryEventType::Outcome,
+                    format!("Task #{} completed: {}", task.task_number, task.title),
+                    0.7,
                 )
-                .importance(0.5)
+            } else {
+                (
+                    crate::memory::WorkingMemoryEventType::TaskUpdate,
+                    format!(
+                        "Task created #{}: {} (status: {})",
+                        task.task_number, task.title, task.status
+                    ),
+                    0.5,
+                )
+            };
+            working_memory
+                .emit(event_type, summary)
+                .importance(importance)
                 .record();
         }
 
@@ -189,5 +202,72 @@ impl Tool for TaskCreateTool {
             status: task.status.to_string(),
             message: format!("Created task #{}: {}", task.task_number, task.title),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::memory::working::WorkingMemoryEvent;
+    use crate::memory::{WorkingMemoryEventType, WorkingMemoryStore};
+    use crate::tasks::store::setup_test_store;
+    use chrono_tz::Tz;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::time::Duration;
+
+    async fn wait_for_single_event(store: &WorkingMemoryStore) -> WorkingMemoryEvent {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let events = store
+                    .get_recent_events(10, 0.0)
+                    .await
+                    .expect("working memory query");
+                if let Some(event) = events.into_iter().next() {
+                    break event;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for working memory event")
+    }
+
+    #[tokio::test]
+    async fn task_create_emits_task_update_for_new_tasks() {
+        let task_store = Arc::new(setup_test_store().await);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+        let working_memory = WorkingMemoryStore::new(pool, Tz::UTC);
+
+        let tool = TaskCreateTool::new(task_store, "agent-test", "branch")
+            .with_working_memory(working_memory.clone());
+
+        let output = tool
+            .call(TaskCreateArgs {
+                title: "Ship observation MVP".to_string(),
+                description: Some("land the first packet".to_string()),
+                priority: "medium".to_string(),
+                subtasks: Vec::new(),
+                metadata: None,
+            })
+            .await
+            .expect("task create should succeed");
+
+        assert_eq!(output.status, "pending_approval");
+
+        let event = wait_for_single_event(&working_memory).await;
+        assert_eq!(event.event_type, WorkingMemoryEventType::TaskUpdate);
+        assert_eq!(
+            event.summary,
+            "Task created #1: Ship observation MVP (status: pending_approval)"
+        );
     }
 }

--- a/src/tools/task_update.rs
+++ b/src/tools/task_update.rs
@@ -155,41 +155,52 @@ impl Tool for TaskUpdateTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let task_number = i64::from(args.task_number);
-
-        if let TaskUpdateScope::Worker(ref worker_id) = self.scope {
-            let current = self
-                .task_store
-                .get_by_worker_id(&worker_id.to_string())
-                .await
-                .map_err(|error| TaskUpdateError(format!("{error}")))?;
-
-            let Some(task) = current else {
-                return Err(TaskUpdateError(
-                    "worker is not assigned to a task".to_string(),
-                ));
-            };
-
-            if task.task_number != task_number {
-                return Err(TaskUpdateError(format!(
-                    "worker {} can only update task #{}",
-                    worker_id, task.task_number
-                )));
+        let previous_status = match &self.scope {
+            TaskUpdateScope::Branch => {
+                self.task_store
+                    .get_by_number(task_number)
+                    .await
+                    .map_err(|error| TaskUpdateError(format!("{error}")))?
+                    .ok_or_else(|| TaskUpdateError(format!("task #{} not found", task_number)))?
+                    .status
             }
+            TaskUpdateScope::Worker(worker_id) => {
+                let current = self
+                    .task_store
+                    .get_by_worker_id(&worker_id.to_string())
+                    .await
+                    .map_err(|error| TaskUpdateError(format!("{error}")))?;
 
-            // Workers can only update subtasks and metadata — not status, priority,
-            // title, description, worker binding, or approval.
-            if args.title.is_some()
-                || args.description.is_some()
-                || args.status.is_some()
-                || args.priority.is_some()
-                || args.worker_id.is_some()
-                || args.approved_by.is_some()
-            {
-                return Err(TaskUpdateError(
-                    "workers can only update subtasks and metadata".to_string(),
-                ));
+                let Some(task) = current else {
+                    return Err(TaskUpdateError(
+                        "worker is not assigned to a task".to_string(),
+                    ));
+                };
+
+                if task.task_number != task_number {
+                    return Err(TaskUpdateError(format!(
+                        "worker {} can only update task #{}",
+                        worker_id, task.task_number
+                    )));
+                }
+
+                // Workers can only update subtasks and metadata — not status, priority,
+                // title, description, worker binding, or approval.
+                if args.title.is_some()
+                    || args.description.is_some()
+                    || args.status.is_some()
+                    || args.priority.is_some()
+                    || args.worker_id.is_some()
+                    || args.approved_by.is_some()
+                {
+                    return Err(TaskUpdateError(
+                        "workers can only update subtasks and metadata".to_string(),
+                    ));
+                }
+
+                task.status
             }
-        }
+        };
 
         let status = match args.status.as_deref() {
             None => None,
@@ -236,15 +247,27 @@ impl Tool for TaskUpdateTool {
             .ok_or_else(|| TaskUpdateError(format!("task #{} not found", task_number)))?;
 
         if let Some(working_memory) = &self.working_memory {
-            working_memory
-                .emit(
+            let transitioned_to_done =
+                previous_status != TaskStatus::Done && updated.status == TaskStatus::Done;
+            let (event_type, summary, importance) = if transitioned_to_done {
+                (
+                    crate::memory::WorkingMemoryEventType::Outcome,
+                    format!("Task #{} completed", updated.task_number),
+                    0.7,
+                )
+            } else {
+                (
                     crate::memory::WorkingMemoryEventType::TaskUpdate,
                     format!(
                         "Task #{} updated to {}",
                         updated.task_number, updated.status
                     ),
+                    0.4,
                 )
-                .importance(0.4)
+            };
+            working_memory
+                .emit(event_type, summary)
+                .importance(importance)
                 .record();
         }
 
@@ -254,5 +277,235 @@ impl Tool for TaskUpdateTool {
             status: updated.status.to_string(),
             message: format!("Updated task #{}", updated.task_number),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::memory::working::WorkingMemoryEvent;
+    use crate::memory::{WorkingMemoryEventType, WorkingMemoryStore};
+    use crate::tasks::store::setup_test_store;
+    use chrono_tz::Tz;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::time::Duration;
+
+    async fn setup_working_memory() -> Arc<WorkingMemoryStore> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations");
+        WorkingMemoryStore::new(pool, Tz::UTC)
+    }
+
+    async fn wait_for_single_event(store: &WorkingMemoryStore) -> WorkingMemoryEvent {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let events = store
+                    .get_recent_events(10, 0.0)
+                    .await
+                    .expect("working memory query");
+                if let Some(event) = events.into_iter().next() {
+                    break event;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for working memory event")
+    }
+
+    #[tokio::test]
+    async fn task_update_emits_outcome_for_done_status() {
+        let task_store = Arc::new(setup_test_store().await);
+        let working_memory = setup_working_memory().await;
+
+        let created = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: "agent-test".to_string(),
+                title: "Review PR 2".to_string(),
+                description: None,
+                status: TaskStatus::InProgress,
+                priority: TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                source_memory_id: None,
+                created_by: "branch".to_string(),
+            })
+            .await
+            .expect("task should be created");
+
+        let tool = TaskUpdateTool::for_branch(task_store, AgentId::from("agent-test"))
+            .with_working_memory(working_memory.clone());
+
+        let output = tool
+            .call(TaskUpdateArgs {
+                task_number: created.task_number as i32,
+                title: None,
+                description: None,
+                status: Some("done".to_string()),
+                priority: None,
+                subtasks: None,
+                metadata: None,
+                complete_subtask: None,
+                worker_id: None,
+                approved_by: None,
+            })
+            .await
+            .expect("task update should succeed");
+
+        assert_eq!(output.status, "done");
+
+        let event = wait_for_single_event(&working_memory).await;
+        assert_eq!(event.event_type, WorkingMemoryEventType::Outcome);
+        assert_eq!(
+            event.summary,
+            format!("Task #{} completed", created.task_number)
+        );
+    }
+
+    #[tokio::test]
+    async fn task_update_keeps_task_update_event_when_task_was_already_done() {
+        let task_store = Arc::new(setup_test_store().await);
+        let working_memory = setup_working_memory().await;
+
+        let created = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: "agent-test".to_string(),
+                title: "Review merged changes".to_string(),
+                description: None,
+                status: TaskStatus::Done,
+                priority: TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                source_memory_id: None,
+                created_by: "branch".to_string(),
+            })
+            .await
+            .expect("task should be created");
+
+        let tool = TaskUpdateTool::for_branch(task_store, AgentId::from("agent-test"))
+            .with_working_memory(working_memory.clone());
+
+        let output = tool
+            .call(TaskUpdateArgs {
+                task_number: created.task_number as i32,
+                title: Some("Review merged changes carefully".to_string()),
+                description: None,
+                status: None,
+                priority: None,
+                subtasks: None,
+                metadata: None,
+                complete_subtask: None,
+                worker_id: None,
+                approved_by: None,
+            })
+            .await
+            .expect("task update should succeed");
+
+        assert_eq!(output.status, "done");
+
+        let event = wait_for_single_event(&working_memory).await;
+        assert_eq!(event.event_type, WorkingMemoryEventType::TaskUpdate);
+        assert_eq!(
+            event.summary,
+            format!("Task #{} updated to done", created.task_number)
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_scope_checks_assignment_before_global_task_lookup() {
+        let task_store = Arc::new(setup_test_store().await);
+        let assigned = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: "agent-test".to_string(),
+                title: "Assigned task".to_string(),
+                description: None,
+                status: TaskStatus::InProgress,
+                priority: TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                source_memory_id: None,
+                created_by: "branch".to_string(),
+            })
+            .await
+            .expect("assigned task should be created");
+        let other = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: "agent-test".to_string(),
+                title: "Other task".to_string(),
+                description: None,
+                status: TaskStatus::InProgress,
+                priority: TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                source_memory_id: None,
+                created_by: "branch".to_string(),
+            })
+            .await
+            .expect("other task should be created");
+        let worker_id = WorkerId::new_v4();
+        task_store
+            .update(
+                assigned.task_number,
+                crate::tasks::UpdateTaskInput {
+                    worker_id: Some(worker_id.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("worker assignment should update");
+
+        let tool = TaskUpdateTool::for_worker(task_store, AgentId::from("agent-test"), worker_id);
+
+        let existing_foreign = tool
+            .call(TaskUpdateArgs {
+                task_number: other.task_number as i32,
+                title: None,
+                description: None,
+                status: None,
+                priority: None,
+                subtasks: None,
+                metadata: Some(serde_json::json!({"progress": "checked"})),
+                complete_subtask: None,
+                worker_id: None,
+                approved_by: None,
+            })
+            .await
+            .expect_err("foreign task should be rejected");
+        let missing = tool
+            .call(TaskUpdateArgs {
+                task_number: 999,
+                title: None,
+                description: None,
+                status: None,
+                priority: None,
+                subtasks: None,
+                metadata: Some(serde_json::json!({"progress": "checked"})),
+                complete_subtask: None,
+                worker_id: None,
+                approved_by: None,
+            })
+            .await
+            .expect_err("missing task should be rejected the same way");
+
+        assert_eq!(existing_foreign.to_string(), missing.to_string());
+        assert_eq!(
+            existing_foreign.to_string(),
+            format!(
+                "task_update failed: worker {} can only update task #{}",
+                worker_id, assigned.task_number
+            )
+        );
     }
 }

--- a/src/tools/task_update.rs
+++ b/src/tools/task_update.rs
@@ -1,6 +1,8 @@
 //! Task update tool for branch and worker processes.
 
-use crate::tasks::{TaskPriority, TaskStatus, TaskStore, TaskSubtask, UpdateTaskInput};
+use crate::tasks::{
+    TaskPriority, TaskStatus, TaskStore, TaskSubtask, UpdateTaskInput, WorkerTaskUpdateResult,
+};
 use crate::{AgentId, WorkerId};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
@@ -155,52 +157,18 @@ impl Tool for TaskUpdateTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let task_number = i64::from(args.task_number);
-        let previous_status = match &self.scope {
-            TaskUpdateScope::Branch => {
-                self.task_store
-                    .get_by_number(task_number)
-                    .await
-                    .map_err(|error| TaskUpdateError(format!("{error}")))?
-                    .ok_or_else(|| TaskUpdateError(format!("task #{} not found", task_number)))?
-                    .status
-            }
-            TaskUpdateScope::Worker(worker_id) => {
-                let current = self
-                    .task_store
-                    .get_by_worker_id(&worker_id.to_string())
-                    .await
-                    .map_err(|error| TaskUpdateError(format!("{error}")))?;
-
-                let Some(task) = current else {
-                    return Err(TaskUpdateError(
-                        "worker is not assigned to a task".to_string(),
-                    ));
-                };
-
-                if task.task_number != task_number {
-                    return Err(TaskUpdateError(format!(
-                        "worker {} can only update task #{}",
-                        worker_id, task.task_number
-                    )));
-                }
-
-                // Workers can only update subtasks and metadata — not status, priority,
-                // title, description, worker binding, or approval.
-                if args.title.is_some()
-                    || args.description.is_some()
-                    || args.status.is_some()
-                    || args.priority.is_some()
-                    || args.worker_id.is_some()
-                    || args.approved_by.is_some()
-                {
-                    return Err(TaskUpdateError(
-                        "workers can only update subtasks and metadata".to_string(),
-                    ));
-                }
-
-                task.status
-            }
-        };
+        if matches!(self.scope, TaskUpdateScope::Worker(_))
+            && (args.title.is_some()
+                || args.description.is_some()
+                || args.status.is_some()
+                || args.priority.is_some()
+                || args.worker_id.is_some()
+                || args.approved_by.is_some())
+        {
+            return Err(TaskUpdateError(
+                "workers can only update subtasks and metadata".to_string(),
+            ));
+        }
 
         let status = match args.status.as_deref() {
             None => None,
@@ -224,27 +192,51 @@ impl Tool for TaskUpdateTool {
             ),
         };
 
-        let updated = self
-            .task_store
-            .update(
-                task_number,
-                UpdateTaskInput {
-                    title: args.title,
-                    description: args.description,
-                    status,
-                    priority,
-                    subtasks: args.subtasks,
-                    metadata: args.metadata,
-                    worker_id: args.worker_id,
-                    clear_worker_id: false,
-                    approved_by: args.approved_by,
-                    complete_subtask,
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|error| TaskUpdateError(format!("{error}")))?
-            .ok_or_else(|| TaskUpdateError(format!("task #{} not found", task_number)))?;
+        let input = UpdateTaskInput {
+            title: args.title,
+            description: args.description,
+            status,
+            priority,
+            subtasks: args.subtasks,
+            metadata: args.metadata,
+            worker_id: args.worker_id,
+            clear_worker_id: false,
+            approved_by: args.approved_by,
+            complete_subtask,
+            ..Default::default()
+        };
+
+        let update_result = match &self.scope {
+            TaskUpdateScope::Branch => self
+                .task_store
+                .update_with_status_transition(task_number, input)
+                .await
+                .map_err(|error| TaskUpdateError(format!("{error}")))?
+                .ok_or_else(|| TaskUpdateError(format!("task #{} not found", task_number)))?,
+            TaskUpdateScope::Worker(worker_id) => match self
+                .task_store
+                .update_worker_task(&worker_id.to_string(), task_number, input)
+                .await
+                .map_err(|error| TaskUpdateError(format!("{error}")))?
+            {
+                WorkerTaskUpdateResult::Updated(result) => *result,
+                WorkerTaskUpdateResult::NotAssigned => {
+                    return Err(TaskUpdateError(
+                        "worker is not assigned to a task".to_string(),
+                    ));
+                }
+                WorkerTaskUpdateResult::WrongTask {
+                    assigned_task_number,
+                } => {
+                    return Err(TaskUpdateError(format!(
+                        "worker {} can only update task #{}",
+                        worker_id, assigned_task_number
+                    )));
+                }
+            },
+        };
+        let previous_status = update_result.previous_status;
+        let updated = update_result.task;
 
         if let Some(working_memory) = &self.working_memory {
             let transitioned_to_done =


### PR DESCRIPTION
## Summary
- Adds richer working-memory event semantics for deadlines, blockers, constraints, and terminal outcomes.
- Classifies branch and worker summaries into typed conversational events when they use explicit prefixes.
- Emits outcome/blocker events from task delegation, task completion, and duplicate worker suppression.
- Aligns memory persistence prompts and tool schema with the expanded event taxonomy.
- Hardens working-memory event decoding and makes event query ordering deterministic.
- Updates working-memory design docs to match the runtime behavior.

## Testing
- `cargo test -p spacebot task_update -- --test-threads=1 --nocapture`
- `just preflight`
- `just gate-pr`

## Notes
- Ports the #524 semantic-event work onto `main`.
- Closes the P2 review finding by checking worker assignment before any global task-number lookup in worker-scoped `task_update`.

> [!NOTE]
> **AI Summary:** This PR expands the working-memory event system to capture structured conversational semantics. The core addition is a new `WorkingMemoryEventType` enum with 17 event types covering outcomes, blockers, deadlines, constraints, and errors. Events are auto-classified from branch/worker summaries when they use explicit prefixes (e.g., "**Outcome:** ..."), enabling the memory system to track not just facts but the state and progress of work. The task_update tool now validates worker ownership before global task lookups, closing a security/authorization gap. Key files: `src/memory/working.rs` (event types + store), `src/tools/task_update.rs` (worker assignment validation), and updated memory docs.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [0af6765](https://github.com/spacedriveapp/spacebot/commit/0af6765). This will update automatically on new commits.</sub>