### PR TITLE
[codex] Preserve participant roles in knowledge synthesis

### DIFF
--- a/docs/design-docs/working-memory-implementation-plan.md
+++ b/docs/design-docs/working-memory-implementation-plan.md
@@ -667,13 +667,15 @@ Create `prompts/en/cortex_knowledge_synthesis.md.j2`:
 Synthesize the agent's long-term knowledge into a concise briefing.
 Focus on:
 - Active goals and strategic direction
+- Stable participant or user role facts that affect future work
 - Cross-cutting themes and patterns
 - Known gaps in knowledge ("I don't have current information on X")
 - Accumulated observations
 
-Do NOT include: identity/role information, recent events or activity,
-channel-specific context, or user profiles. Those are provided by other
-context layers.
+Do NOT include: the agent's own identity or role, recent events or activity,
+channel-specific context, or full user profiles. Those are provided by other
+context layers. Keep concise participant-role facts here until participant
+context owns them.
 
 Maximum {{ max_words }} words.
 ```

--- a/docs/design-docs/working-memory-triage.md
+++ b/docs/design-docs/working-memory-triage.md
@@ -14,8 +14,8 @@ Findings from CodeRabbit review + bug reports. Tracking resolution before merge.
 - [x] **R2 — Bulletin fallback gate too aggressive** (`prompts/en/channel.md.j2:172`)
   Condition `not working_memory and not knowledge_synthesis` hides bulletin when working memory exists but knowledge synthesis hasn't run yet. **Fixed in PR #570:** fallback now depends on missing `knowledge_synthesis`, and prompt data preserves that original absence.
 
-- [ ] **R3 — Don't exclude participant-role facts yet** (`prompts/en/cortex_knowledge_synthesis.md.j2:21`)
-  Exclusion of "The user is the CEO" drops participant context with nowhere else to live until Phase 6 ships.
+- [x] **R3 — Don't exclude participant-role facts yet** (`prompts/en/cortex_knowledge_synthesis.md.j2:21`)
+  Exclusion of "The user is the CEO" drops participant context with nowhere else to live until Phase 6 ships. **Fixed in this slice:** knowledge synthesis now preserves concise participant/user role facts when they affect future routing, authority, relationships, or interpretation.
 
 - [ ] **R4 — Raw worker task in working memory** (`src/agent/channel_dispatch.rs:596`)
   `task` from user input persisted verbatim; could capture secrets/PII. Truncate and scrub.

--- a/prompts/en/cortex_knowledge_synthesis.md.j2
+++ b/prompts/en/cortex_knowledge_synthesis.md.j2
@@ -1,24 +1,26 @@
-You are the cortex's knowledge synthesizer. You receive pre-gathered memory data and must distill it into a concise briefing of what the agent KNOWS — not who it is or what happened recently.
+You are the cortex's knowledge synthesizer. You receive pre-gathered memory data and must distill it into a concise briefing of what the agent KNOWS. Do not restate the agent's own identity or recent activity.
 
 ## Include ONLY
 
 - Decisions that constrain future choices ("we decided to use X", "the approach is Y")
 - Active goals and strategic direction
 - User preferences and working patterns
+- Stable participant or user role facts that affect future routing, authority, relationships, or interpretation
 - Cross-cutting themes across conversations
 - Known knowledge gaps ("no current information on X")
 - Standing instructions or policies
 
 ## NEVER Include
 
-These are provided by other layers — repeating them wastes tokens:
+These are provided by other layers. Repeating them wastes tokens:
 
 - Who the agent is, its role, or the company description (Layer 1: Identity)
 - What happened today/yesterday/this week (Layer 2: Working Memory)
 - System status, uptime, memory usage, fleet health (Layer 2: Status Block)
 - Weather, time, or other ephemeral data
 - Product descriptions or GitHub star counts (Layer 1: Identity)
-- "The user is the CEO" or similar role statements (Layer 1: Identity)
+
+Keep participant-role facts concise. Until participant context owns them, role statements like "the user is the CEO" belong here when they affect future work.
 
 ## Output Format
 

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -852,5 +852,17 @@ mod tests {
         assert!(prompt.contains("Bulletin fallback"));
         assert!(!prompt.contains("## Knowledge Context"));
     }
+
+    #[test]
+    fn knowledge_synthesis_prompt_preserves_participant_roles() {
+        let engine = PromptEngine::new("en").expect("prompt engine should build");
+        let prompt = engine
+            .render_static("cortex_knowledge_synthesis")
+            .expect("knowledge synthesis prompt should render");
+
+        assert!(prompt.contains("Stable participant or user role facts"));
+        assert!(prompt.contains("the user is the CEO"));
+        assert!(!prompt.contains("\"The user is the CEO\" or similar role statements"));
+    }
 }
 // to support multiple languages at compile time.


### PR DESCRIPTION
## Summary
- Updates the cortex knowledge synthesis prompt to preserve concise participant/user role facts when they affect future work.
- Keeps the exclusion for the agent's own identity, recent activity, status, and ephemeral data.
- Marks R3 fixed in the working-memory triage tracker and aligns the implementation plan prompt boundary.

## Testing
- `cargo test -p spacebot prompts::engine::tests::knowledge_synthesis_prompt_preserves_participant_roles -- --test-threads=1`
- `cargo test -p spacebot prompts::engine::tests -- --test-threads=1`
- `cargo fmt --all`
- `just preflight`
- `just gate-pr`

## Notes
- This is stacked on #570 and closes working-memory triage item R3.

> [!NOTE]
> **AI-Generated Summary**: This PR updates the cortex knowledge synthesis prompt to properly preserve stable participant role facts that influence future decision-making and context assembly. The change refines what gets stored in the agent's knowledge synthesis layer—excluding the agent's own identity and ephemeral data while retaining user role information like "the CEO" that provides behavioral context for future interactions. The implementation includes a targeted test verifying that participant roles are preserved while role explanations and full user profiles are appropriately excluded.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [9447a87](https://github.com/spacedriveapp/spacebot/commit/9447a873ed710c66c3c1b1297124bfead94de5dd). This will update automatically on new commits.</sub>