### PR TITLE
Add active recall branch

### DIFF
--- a/docs/content/docs/(core)/memory.mdx
+++ b/docs/content/docs/(core)/memory.mdx
@@ -133,6 +133,14 @@ RRF works on ranks rather than scores, which handles the different scales of vec
 
 The branch curates. 50 raw results become 5 relevant, contextualized memories. The channel never sees the noise -- it only gets the branch's conclusion.
 
+### Active Recall
+
+Active recall is a silent branch profile for obvious memory cues like "remember", "last time", "that thing", or "what did we decide". It gives Spacebot a better memory feel without putting raw recall output into the channel.
+
+An active recall branch can only call `memory_recall`. It returns exactly `NONE` or `BACKGROUND_NOTE: <compact note>`. `NONE` is discarded. A background note is stored as read-only context for the next channel turn and is fenced under `Background Recall`.
+
+Active recall branches never answer the user, never save memories, never spawn workers, and never trigger a duplicate user-facing reply. Raw memory rows, memory IDs, relevance scores, importance scores, JSON, and tool output are rejected before they can be injected.
+
 ### Why Not Search Directly?
 
 In OpenClaw, the LLM calls `memory_search`, gets raw results in its context, and has to make sense of them. This pollutes the context with irrelevant matches, partial chunks, and search metadata. In Spacebot, the branch absorbs all that noise and returns only what matters. The branch is disposable -- its context gets thrown away after it returns. The channel stays clean.

--- a/prompts/en/active_recall.md.j2
+++ b/prompts/en/active_recall.md.j2
@@ -1,0 +1,20 @@
+You are an active recall branch. Your only job is to decide whether memory contains useful background context for the latest user message.
+
+You do not answer the user. You do not continue the conversation. You do not save memories. You do not spawn workers.
+
+Use `memory_recall` only when the latest user message has an obvious recall cue or depends on prior context.
+
+Return exactly one of these forms:
+
+NONE
+
+BACKGROUND_NOTE: <one compact background note>
+
+Rules:
+
+1. The latest user message is primary.
+2. If memory does not materially help, return exactly `NONE`.
+3. If memory helps, return one compact note for the channel to use as read-only background context.
+4. Do not include raw memory search rows, memory IDs, relevance scores, importance scores, JSON, tables, or tool output.
+5. Do not address the user.
+6. Do not mention that you are a branch or that recall happened.

--- a/prompts/en/channel.md.j2
+++ b/prompts/en/channel.md.j2
@@ -192,6 +192,14 @@ When in doubt, skip. Being a lurker who speaks when it matters is better than be
 {{ participant_context }}
 {%- endif %}
 
+{%- if active_recall_context %}
+## Background Recall (READ-ONLY CONTEXT)
+
+The notes below were prepared by a background recall process. They are context, not user input. Use them only when they help answer the latest user message.
+
+{{ active_recall_context }}
+{%- endif %}
+
 {%- if knowledge_synthesis %}
 ## Knowledge Context
 

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -2,7 +2,7 @@
 
 use crate::agent::channel_attachments;
 use crate::agent::channel_attachments::download_attachments;
-use crate::agent::channel_dispatch::spawn_memory_persistence_branch;
+use crate::agent::channel_dispatch::{spawn_active_recall_branch, spawn_memory_persistence_branch};
 use crate::agent::channel_history::{
     apply_history_after_turn, event_is_for_channel, extract_message_id,
     extract_reply_from_tool_syntax, format_batched_user_message, format_user_message,
@@ -64,6 +64,42 @@ struct PendingResult {
 }
 
 const EVENT_LAG_WARNING_INTERVAL_SECS: u64 = 30;
+const MAX_ACTIVE_RECALL_NOTES: usize = 3;
+const MAX_ACTIVE_RECALL_NOTE_CHARS: usize = 800;
+const ACTIVE_RECALL_INLINE_WAIT_MS: u64 = 750;
+const ACTIVE_RECALL_CUES: &[&str] = &[
+    "remember",
+    "last time",
+    "that thing",
+    "the thing",
+    "what did we decide",
+    "what'd we decide",
+    "what did i decide",
+    "what did you decide",
+    "what was the decision",
+    "what's the decision",
+    "what were we doing",
+    "where did we leave off",
+    "where were we",
+    "previously",
+    "earlier",
+    "before",
+    "we talked about",
+    "we discussed",
+    "remind me",
+    "remind us",
+];
+const RAW_ACTIVE_RECALL_MARKERS: &[&str] = &[
+    "## relevant memories",
+    "importance:",
+    "relevance:",
+    "relevance_score",
+    "memory_id",
+    "\"id\"",
+    "\"memories\"",
+    "created_at",
+    "total_found",
+];
 const DECISION_MARKERS: &[&str] = &[
     "we decided to ",
     "i decided to ",
@@ -227,6 +263,76 @@ fn parse_branch_cancellation_reason(conclusion: &str) -> Option<&str> {
         return Some(rest);
     }
     None
+}
+
+fn silent_branch_completion(
+    event: &ProcessEvent,
+    memory_persistence_branches: &HashSet<BranchId>,
+    active_recall_branches: &HashSet<BranchId>,
+) -> Option<BranchId> {
+    match event {
+        ProcessEvent::BranchResult { branch_id, .. }
+            if memory_persistence_branches.contains(branch_id)
+                || active_recall_branches.contains(branch_id) =>
+        {
+            Some(*branch_id)
+        }
+        _ => None,
+    }
+}
+
+fn should_trigger_active_recall(raw_text: &str) -> bool {
+    let normalized = raw_text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    if normalized.len() < 8 {
+        return false;
+    }
+
+    ACTIVE_RECALL_CUES
+        .iter()
+        .any(|cue| normalized.contains(cue))
+}
+
+fn parse_active_recall_conclusion(conclusion: &str) -> Option<String> {
+    let trimmed = conclusion.trim();
+    if trimmed == "NONE" {
+        return None;
+    }
+
+    let note = trimmed.strip_prefix("BACKGROUND_NOTE:")?.trim();
+    if note.is_empty() || active_recall_note_contains_raw_rows(note) {
+        return None;
+    }
+
+    let note = if note.len() > MAX_ACTIVE_RECALL_NOTE_CHARS {
+        let boundary = note.floor_char_boundary(MAX_ACTIVE_RECALL_NOTE_CHARS);
+        format!("{}... [truncated]", &note[..boundary])
+    } else {
+        note.to_string()
+    };
+
+    Some(note)
+}
+
+fn active_recall_note_contains_raw_rows(note: &str) -> bool {
+    let lower = note.to_ascii_lowercase();
+    RAW_ACTIVE_RECALL_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+}
+
+fn merge_active_recall_context(existing: Option<String>, next: String) -> Option<String> {
+    if next.trim().is_empty() {
+        return existing;
+    }
+
+    match existing {
+        Some(existing) if !existing.trim().is_empty() => Some(format!("{existing}\n{next}")),
+        _ => Some(next),
+    }
 }
 
 fn sentence_contains_decision_marker(sentence: &str) -> bool {
@@ -717,6 +823,10 @@ pub struct Channel {
     last_persistence_at: std::time::Instant,
     /// Branch IDs for silent memory persistence branches (results not injected into history).
     memory_persistence_branches: HashSet<BranchId>,
+    /// Branch IDs for silent active-recall branches.
+    active_recall_branches: HashSet<BranchId>,
+    /// Accepted active-recall notes waiting to be injected into the next prompt.
+    active_recall_notes: Vec<String>,
     /// Optional Discord reply target captured when each branch was started.
     branch_reply_targets: HashMap<BranchId, String>,
     /// Buffer for coalescing rapid-fire messages.
@@ -903,6 +1013,8 @@ impl Channel {
             message_count: 0,
             last_persistence_at: std::time::Instant::now(),
             memory_persistence_branches: HashSet::new(),
+            active_recall_branches: HashSet::new(),
+            active_recall_notes: Vec::new(),
             branch_reply_targets: HashMap::new(),
             coalesce_buffer: Vec::new(),
             coalesce_deadline: None,
@@ -1995,6 +2107,7 @@ impl Channel {
             empty_to_none(working_memory),
             empty_to_none(channel_activity_map),
             empty_to_none(participant_context),
+            None,
             direct_mode,
         )?;
 
@@ -2215,14 +2328,23 @@ impl Channel {
             }
         }
 
-        let system_prompt = self.build_system_prompt().await?;
+        let is_retrigger = message.source == "system";
+        let mut active_recall_context = self.take_active_recall_context();
+        if let Some(branch_id) = self
+            .maybe_spawn_active_recall(&rewritten_text, is_retrigger)
+            .await
+            && let Some(inline_context) = self.wait_for_active_recall_context(branch_id).await
+        {
+            active_recall_context =
+                merge_active_recall_context(active_recall_context, inline_context);
+        }
+        let system_prompt = self.build_system_prompt(active_recall_context).await?;
 
         {
             let mut reply_target = self.state.reply_target_message_id.write().await;
             *reply_target = extract_message_id(&message);
         }
 
-        let is_retrigger = message.source == "system";
         let attachment_content = if !attachments.is_empty() {
             if let Some(ref saved_data) = saved_attachment_data {
                 // Reuse already-downloaded bytes for images/text; audio still
@@ -2627,7 +2749,10 @@ impl Channel {
     }
 
     /// Assemble the full system prompt using the PromptEngine.
-    async fn build_system_prompt(&self) -> crate::error::Result<String> {
+    async fn build_system_prompt(
+        &self,
+        active_recall_context: Option<String>,
+    ) -> crate::error::Result<String> {
         let rc = &self.deps.runtime_config;
         let prompt_engine = rc.prompts.load();
 
@@ -2700,6 +2825,7 @@ impl Channel {
             empty_to_none(working_memory),
             empty_to_none(channel_activity_map),
             empty_to_none(participant_context),
+            active_recall_context,
             direct_mode,
         )?;
 
@@ -3245,10 +3371,21 @@ impl Channel {
         if !event_is_for_channel(&event, &self.id) {
             return Ok(());
         }
-        // Update status block
+        let silent_branch_completion = silent_branch_completion(
+            &event,
+            &self.memory_persistence_branches,
+            &self.active_recall_branches,
+        );
+
+        // Update status block. Silent branch completions are terminal, but
+        // they must not be exposed as recently completed work.
         {
             let mut status = self.state.status_block.write().await;
-            status.update(&event);
+            if let Some(branch_id) = silent_branch_completion {
+                status.remove_branch(branch_id);
+            } else {
+                status.update(&event);
+            }
         }
 
         let mut should_retrigger = false;
@@ -3283,11 +3420,12 @@ impl Channel {
                     .remove(branch_id)
                     .is_some();
                 let was_memory_persistence = self.memory_persistence_branches.remove(branch_id);
+                let was_active_recall = self.active_recall_branches.remove(branch_id);
                 if !was_active {
-                    if was_memory_persistence {
+                    if was_memory_persistence || was_active_recall {
                         tracing::info!(
                             branch_id = %branch_id,
-                            "stale memory-persistence branch completion ignored"
+                            "stale silent branch completion ignored"
                         );
                     }
                     self.branch_reply_targets.remove(branch_id);
@@ -3307,6 +3445,24 @@ impl Channel {
                 // happened inside the branch via tool calls.
                 if was_memory_persistence {
                     tracing::info!(branch_id = %branch_id, "memory persistence branch completed");
+                } else if was_active_recall {
+                    if let Some(note) = parse_active_recall_conclusion(conclusion) {
+                        self.active_recall_notes.push(note);
+                        if self.active_recall_notes.len() > MAX_ACTIVE_RECALL_NOTES {
+                            let overflow = self.active_recall_notes.len() - MAX_ACTIVE_RECALL_NOTES;
+                            self.active_recall_notes.drain(..overflow);
+                        }
+                        tracing::info!(
+                            branch_id = %branch_id,
+                            note_count = self.active_recall_notes.len(),
+                            "active recall note queued for next turn"
+                        );
+                    } else {
+                        tracing::debug!(
+                            branch_id = %branch_id,
+                            "active recall produced no injectable note"
+                        );
+                    }
                 } else {
                     // Regular branch: accumulate result for the next retrigger.
                     // The result text will be embedded directly in the retrigger
@@ -3770,6 +3926,111 @@ impl Channel {
         }
     }
 
+    async fn maybe_spawn_active_recall(
+        &mut self,
+        latest_user_message: &str,
+        is_retrigger: bool,
+    ) -> Option<BranchId> {
+        if is_retrigger
+            || matches!(self.resolved_settings.memory, MemoryMode::Off)
+            || !should_trigger_active_recall(latest_user_message)
+            || !self.active_recall_branches.is_empty()
+        {
+            return None;
+        }
+
+        match spawn_active_recall_branch(&self.state, latest_user_message).await {
+            Ok(branch_id) => {
+                self.active_recall_branches.insert(branch_id);
+                tracing::info!(
+                    channel_id = %self.id,
+                    branch_id = %branch_id,
+                    "active recall branch spawned"
+                );
+                Some(branch_id)
+            }
+            Err(error) => {
+                tracing::debug!(
+                    channel_id = %self.id,
+                    %error,
+                    "active recall branch skipped"
+                );
+                None
+            }
+        }
+    }
+
+    async fn wait_for_active_recall_context(&mut self, branch_id: BranchId) -> Option<String> {
+        let timeout = std::time::Duration::from_millis(ACTIVE_RECALL_INLINE_WAIT_MS);
+        let result = tokio::time::timeout(timeout, async {
+            loop {
+                match recv_channel_event(&mut self.event_rx).await {
+                    crate::BroadcastRecvResult::Event(event) => {
+                        if !should_process_event_for_channel(&event, &self.id) {
+                            continue;
+                        }
+                        let is_target_result = matches!(
+                            &event,
+                            ProcessEvent::BranchResult {
+                                branch_id: completed_branch_id,
+                                ..
+                            } if *completed_branch_id == branch_id
+                        );
+                        if let Err(error) = self.handle_event(event).await {
+                            tracing::error!(
+                                channel_id = %self.id,
+                                branch_id = %branch_id,
+                                %error,
+                                "error handling active recall event"
+                            );
+                            return None;
+                        }
+                        if is_target_result {
+                            return self.take_active_recall_context();
+                        }
+                    }
+                    crate::BroadcastRecvResult::Lagged(skipped) => {
+                        tracing::warn!(
+                            channel_id = %self.id,
+                            skipped,
+                            "active recall inline wait lagged, falling back to next-turn recall"
+                        );
+                    }
+                    crate::BroadcastRecvResult::Closed => return None,
+                }
+            }
+        })
+        .await;
+
+        match result {
+            Ok(context) => context,
+            Err(_) => {
+                tracing::debug!(
+                    channel_id = %self.id,
+                    branch_id = %branch_id,
+                    wait_ms = ACTIVE_RECALL_INLINE_WAIT_MS,
+                    "active recall did not complete before channel prompt"
+                );
+                None
+            }
+        }
+    }
+
+    fn take_active_recall_context(&mut self) -> Option<String> {
+        if self.active_recall_notes.is_empty() {
+            return None;
+        }
+
+        let notes = std::mem::take(&mut self.active_recall_notes);
+        Some(
+            notes
+                .into_iter()
+                .map(|note| format!("- {note}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+
     /// If prompt capture is enabled for this channel, snapshot the current
     /// system prompt sections and conversation history. The save is
     /// fire-and-forget so it never blocks the agentic loop.
@@ -3993,12 +4254,16 @@ mod tests {
         ObserveModeFallbackState, branch_working_memory_event_summary,
         classify_conversational_event_summary, compute_listen_mode_invocation, decision_user_id,
         extract_decision_summary_from_reply, format_conversational_event_summary,
-        is_dm_conversation_id, recv_channel_event, should_process_event_for_channel,
+        is_dm_conversation_id, merge_active_recall_context, parse_active_recall_conclusion,
+        recv_channel_event, should_process_event_for_channel,
         should_send_discord_quiet_mode_ping_ack, should_send_quiet_mode_fallback,
+        should_trigger_active_recall, silent_branch_completion,
     };
     use crate::memory::{MemoryType, WorkingMemoryEventType};
-    use crate::{AgentId, ChannelId, InboundMessage, MessageContent, ProcessEvent, ProcessId};
-    use std::collections::HashMap;
+    use crate::{
+        AgentId, BranchId, ChannelId, InboundMessage, MessageContent, ProcessEvent, ProcessId,
+    };
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     fn inbound_message(
@@ -4190,6 +4455,147 @@ mod tests {
         };
 
         assert!(should_process_event_for_channel(&event, &channel_id));
+    }
+
+    #[test]
+    fn active_recall_triggers_on_explicit_recall_cues() {
+        assert!(should_trigger_active_recall(
+            "what did we decide about OAuth?"
+        ));
+        assert!(should_trigger_active_recall(
+            "remind me what we did last time"
+        ));
+        assert!(should_trigger_active_recall(
+            "that thing from before is relevant"
+        ));
+    }
+
+    #[test]
+    fn active_recall_skips_short_or_context_free_messages() {
+        assert!(!should_trigger_active_recall("ok"));
+        assert!(!should_trigger_active_recall("can you run the tests now?"));
+    }
+
+    #[test]
+    fn active_recall_none_produces_no_prompt_context() {
+        assert_eq!(parse_active_recall_conclusion("NONE"), None);
+        assert_eq!(parse_active_recall_conclusion("  NONE  "), None);
+    }
+
+    #[test]
+    fn active_recall_accepts_compact_background_note() {
+        assert_eq!(
+            parse_active_recall_conclusion(
+                "BACKGROUND_NOTE: Use the auth migration decision from the prior discussion."
+            ),
+            Some("Use the auth migration decision from the prior discussion.".to_string())
+        );
+    }
+
+    #[test]
+    fn active_recall_rejects_raw_memory_rows() {
+        assert_eq!(
+            parse_active_recall_conclusion(
+                "BACKGROUND_NOTE: ## Relevant Memories\n1. [decision] (importance: 0.90, relevance: 0.80)\n   Use SQLite"
+            ),
+            None
+        );
+        assert_eq!(
+            parse_active_recall_conclusion(
+                "BACKGROUND_NOTE: {\"memories\":[{\"id\":\"abc\",\"content\":\"raw\"}],\"total_found\":1}"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn active_recall_context_merges_inline_note_with_pending_notes() {
+        assert_eq!(
+            merge_active_recall_context(
+                Some("- Use the prior auth decision.".to_string()),
+                "- Prefer the branch-based recall path.".to_string(),
+            ),
+            Some(
+                "- Use the prior auth decision.\n- Prefer the branch-based recall path."
+                    .to_string()
+            )
+        );
+        assert_eq!(
+            merge_active_recall_context(None, "- Use the prior auth decision.".to_string()),
+            Some("- Use the prior auth decision.".to_string())
+        );
+    }
+
+    #[test]
+    fn silent_active_recall_result_does_not_enter_completed_status() {
+        let branch_id: BranchId = uuid::Uuid::new_v4();
+        let channel_id: ChannelId = Arc::from("channel-a");
+        let event = ProcessEvent::BranchResult {
+            agent_id: Arc::from("agent"),
+            branch_id,
+            channel_id,
+            conclusion: "BACKGROUND_NOTE: raw memory row rejected elsewhere".to_string(),
+        };
+        let memory_persistence_branches = HashSet::new();
+        let mut active_recall_branches = HashSet::new();
+        active_recall_branches.insert(branch_id);
+
+        assert_eq!(
+            silent_branch_completion(
+                &event,
+                &memory_persistence_branches,
+                &active_recall_branches,
+            ),
+            Some(branch_id)
+        );
+
+        let mut status = crate::agent::status::StatusBlock::new();
+        status.add_branch(branch_id, "recalling relevant context...");
+        if let Some(branch_id) = silent_branch_completion(
+            &event,
+            &memory_persistence_branches,
+            &active_recall_branches,
+        ) {
+            status.remove_branch(branch_id);
+        } else {
+            status.update(&event);
+        }
+
+        let rendered = status.render();
+        assert!(!rendered.contains("## Active Branches"));
+        assert!(!rendered.contains("## Recently Completed"));
+        assert!(!rendered.contains("raw memory row"));
+    }
+
+    #[test]
+    fn regular_branch_result_still_enters_completed_status() {
+        let branch_id: BranchId = uuid::Uuid::new_v4();
+        let channel_id: ChannelId = Arc::from("channel-a");
+        let event = ProcessEvent::BranchResult {
+            agent_id: Arc::from("agent"),
+            branch_id,
+            channel_id,
+            conclusion: "regular branch conclusion".to_string(),
+        };
+        let memory_persistence_branches = HashSet::new();
+        let active_recall_branches = HashSet::new();
+
+        assert_eq!(
+            silent_branch_completion(
+                &event,
+                &memory_persistence_branches,
+                &active_recall_branches,
+            ),
+            None
+        );
+
+        let mut status = crate::agent::status::StatusBlock::new();
+        status.add_branch(branch_id, "thinking...");
+        status.update(&event);
+
+        let rendered = status.render();
+        assert!(rendered.contains("## Recently Completed"));
+        assert!(rendered.contains("regular branch conclusion"));
     }
 
     #[test]

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -207,6 +207,48 @@ pub(crate) async fn spawn_memory_persistence_branch(
     .await
 }
 
+/// Spawn a silent active-recall branch.
+///
+/// The branch can only use memory recall. Its result is handled specially by
+/// the channel: `NONE` is discarded, while `BACKGROUND_NOTE:` is stored as
+/// read-only context for the next channel turn.
+pub(crate) async fn spawn_active_recall_branch(
+    state: &ChannelState,
+    latest_user_message: &str,
+) -> std::result::Result<BranchId, AgentError> {
+    let prompt_engine = state.deps.runtime_config.prompts.load();
+    let routing = state.deps.runtime_config.routing.load();
+    let model_name = routing.resolve(ProcessType::Branch, None).to_string();
+    let tool_use_enforcement = state.deps.runtime_config.tool_use_enforcement.load();
+    let system_prompt = prompt_engine
+        .render_static("active_recall")
+        .and_then(|prompt| {
+            prompt_engine.maybe_append_tool_use_enforcement(
+                prompt,
+                tool_use_enforcement.as_ref(),
+                &model_name,
+            )
+        })
+        .map_err(|e| AgentError::Other(anyhow::anyhow!("{e}")))?;
+    let prompt = format!(
+        "Latest user message:\n\n{}\n\nReturn exactly `NONE` or `BACKGROUND_NOTE: <one compact note>`.",
+        latest_user_message.trim()
+    );
+
+    spawn_branch(
+        state,
+        "active recall",
+        &prompt,
+        &system_prompt,
+        "recalling relevant context...",
+        "active_recall_branch",
+        BranchSpawnOptions {
+            profile: BranchToolProfile::ActiveRecall,
+        },
+    )
+    .await
+}
+
 fn ensure_dispatch_readiness(state: &ChannelState, dispatch_type: &'static str) {
     let readiness = state.deps.runtime_config.work_readiness();
     if readiness.ready {
@@ -261,7 +303,7 @@ async fn spawn_branch(
     let BranchSpawnOptions { profile } = branch_options;
     let memory_persistence_contract = match &profile {
         BranchToolProfile::MemoryPersistence { contract_state, .. } => Some(contract_state.clone()),
-        BranchToolProfile::Default => None,
+        BranchToolProfile::Default | BranchToolProfile::ActiveRecall => None,
     };
 
     let max_branches = **state.deps.runtime_config.max_concurrent_branches.load();

--- a/src/api/channels.rs
+++ b/src/api/channels.rs
@@ -801,6 +801,7 @@ pub(super) async fn inspect_prompt(
             empty_to_none(working_memory),
             empty_to_none(channel_activity_map),
             empty_to_none(participant_context),
+            None,  // active_recall_context — only owned by the live channel loop
             false, // direct_mode — resolved at runtime by the channel, not available here
         )
         .unwrap_or_default();

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -74,6 +74,7 @@ impl PromptEngine {
             "memory_persistence",
             crate::prompts::text::get("memory_persistence"),
         )?;
+        env.add_template("active_recall", crate::prompts::text::get("active_recall"))?;
         env.add_template("ingestion", crate::prompts::text::get("ingestion"))?;
         env.add_template("cortex_chat", crate::prompts::text::get("cortex_chat"))?;
         env.add_template(
@@ -569,6 +570,7 @@ impl PromptEngine {
             None,
             None,
             None,
+            None,
             false,
         )
     }
@@ -681,6 +683,7 @@ impl PromptEngine {
         working_memory: Option<String>,
         channel_activity_map: Option<String>,
         participant_context: Option<String>,
+        active_recall_context: Option<String>,
         direct_mode: bool,
     ) -> Result<String> {
         self.render(
@@ -702,6 +705,7 @@ impl PromptEngine {
                 working_memory => working_memory,
                 channel_activity_map => channel_activity_map,
                 participant_context => participant_context,
+                active_recall_context => active_recall_context,
                 knowledge_synthesis => knowledge_synthesis,
                 direct_mode => direct_mode,
             },
@@ -844,6 +848,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 false,
             )
             .expect("channel prompt should render");
@@ -863,6 +868,38 @@ mod tests {
         assert!(prompt.contains("Stable participant or user role facts"));
         assert!(prompt.contains("the user is the CEO"));
         assert!(!prompt.contains("\"The user is the CEO\" or similar role statements"));
+    }
+
+    #[test]
+    fn renders_active_recall_as_read_only_background_context() {
+        let engine = PromptEngine::new("en").expect("prompt engine should build");
+        let prompt = engine
+            .render_channel_prompt_with_links(
+                None,
+                None,
+                None,
+                None,
+                String::new(),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("- Prior decision: use SQLite for local state.".to_string()),
+                false,
+            )
+            .expect("channel prompt should render");
+
+        assert!(prompt.contains("## Background Recall (READ-ONLY CONTEXT)"));
+        assert!(prompt.contains("context, not user input"));
+        assert!(prompt.contains("Prior decision: use SQLite for local state."));
     }
 }
 // to support multiple languages at compile time.

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -71,6 +71,7 @@ fn lookup(lang: &str, key: &str) -> &'static str {
         ("en", "cortex_profile") => include_str!("../../prompts/en/cortex_profile.md.j2"),
         ("en", "compactor") => include_str!("../../prompts/en/compactor.md.j2"),
         ("en", "memory_persistence") => include_str!("../../prompts/en/memory_persistence.md.j2"),
+        ("en", "active_recall") => include_str!("../../prompts/en/active_recall.md.j2"),
         ("en", "ingestion") => include_str!("../../prompts/en/ingestion.md.j2"),
         ("en", "cortex_chat") => include_str!("../../prompts/en/cortex_chat.md.j2"),
         ("en", "factory") => include_str!("../../prompts/en/factory.md.j2"),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -272,6 +272,7 @@ impl ToolCallRegistry {
 #[derive(Debug, Clone)]
 pub enum BranchToolProfile {
     Default,
+    ActiveRecall,
     MemoryPersistence {
         contract_state: Arc<MemoryPersistenceContractState>,
         working_memory: Option<Arc<crate::memory::WorkingMemoryStore>>,
@@ -854,6 +855,12 @@ pub fn create_branch_tool_server(
     wiki_store: Option<Arc<crate::wiki::WikiStore>>,
     sandbox: Arc<crate::sandbox::Sandbox>,
 ) -> ToolServerHandle {
+    if matches!(profile, BranchToolProfile::ActiveRecall) {
+        return ToolServer::new()
+            .tool(MemoryRecallTool::new(memory_search))
+            .run();
+    }
+
     let mut memory_save = memory_save_with_events(
         memory_search.clone(),
         agent_id.clone(),


### PR DESCRIPTION
## Summary
- add an active_recall branch prompt that returns either NONE or one fenced background note
- trigger recall on explicit memory/context cues and inject accepted notes as read-only background context
- keep active recall branch results out of completed status while preserving normal branch completion behavior
- document the active recall flow in the memory docs

## Verification
- cargo test --lib active_recall
- cargo test --lib regular_branch_result_still_enters_completed_status
- cargo check --all-targets
- git diff --check
- just preflight
- just gate-pr

## Stack
Stacked on #570 / codex/cortex-synthesis-reliability. Keep draft until the base PR merges or this receives first review.

> [!NOTE]
> This PR introduces an active recall branch mechanism that silently queries memory when the channel detects explicit recall cues like "remember", "last time", or "remind me". The branch returns either NONE or a single compact background note that gets injected as read-only context without blocking channel responsiveness. Key additions include three new memory-related tools (memory_recall, channel_recall, attachment_recall), spawn logic for active recall branches in channel dispatch, and comprehensive documentation. Active recall results bypass the normal completed status to keep the channel UX clean while preserving standard branch completion behavior.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [239b03c](https://github.com/spacedriveapp/spacebot/commit/239b03cf6262f24e66c3db266eb65d13c1ec13d8).</sub>
