### PR TITLE
fix(channel): retry retrigger relay sends to avoid dropped final replies

### DIFF
--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -40,7 +40,6 @@ use std::collections::HashSet;
 use std::sync::{Arc, Weak};
 use tokio::sync::broadcast;
 use tokio::sync::{RwLock, mpsc};
-use tokio::time::{Duration, sleep};
 
 /// Shared cache of in-flight worker transcript steps, keyed by worker ID.
 pub type LiveWorkerTranscripts =
@@ -2960,6 +2959,10 @@ impl Channel {
         })
     }
 
+    /// Send outbound text and record send metrics. Returns `true` on success.
+    ///
+    /// Failure here means the outbound response channel's receiver has closed
+    /// (e.g. shutdown) — `mpsc::Sender::send` does not fail transiently.
     async fn send_outbound_text(&self, text: String, error_context: &str) -> bool {
         match self.send_routed(OutboundResponse::Text(text)).await {
             Ok(()) => {
@@ -2986,54 +2989,6 @@ impl Channel {
                 false
             }
         }
-    }
-
-    async fn send_outbound_text_with_retry(
-        &self,
-        text: String,
-        error_context: &str,
-        max_attempts: usize,
-    ) -> bool {
-        let attempts = max_attempts.max(1);
-        for attempt in 1..=attempts {
-            if self
-                .send_outbound_text(text.clone(), error_context)
-                .await
-            {
-                if attempt > 1 {
-                    tracing::info!(
-                        channel_id = %self.id,
-                        attempt,
-                        attempts,
-                        "outbound relay succeeded after retry"
-                    );
-                }
-                return true;
-            }
-
-            if attempt < attempts {
-                let delay_ms = match attempt {
-                    1 => 250,
-                    2 => 1_000,
-                    _ => 2_000,
-                };
-                tracing::warn!(
-                    channel_id = %self.id,
-                    attempt,
-                    attempts,
-                    delay_ms,
-                    "outbound relay failed; retrying"
-                );
-                sleep(Duration::from_millis(delay_ms)).await;
-            }
-        }
-
-        tracing::warn!(
-            channel_id = %self.id,
-            attempts,
-            "outbound relay failed after retries"
-        );
-        false
     }
 
     /// Dispatch the LLM result: send fallback text, log errors, clean up typing.
@@ -3111,23 +3066,14 @@ impl Channel {
                                 self.state
                                     .conversation_logger
                                     .log_bot_message(&self.state.channel_id, &final_text);
-                                let delivered = self
-                                    .send_outbound_text_with_retry(
+                                if self
+                                    .send_outbound_text(
                                         final_text,
                                         "failed to send retrigger fallback reply",
-                                        3,
                                     )
-                                    .await;
-                                if delivered {
+                                    .await
+                                {
                                     replied_flag.store(true, std::sync::atomic::Ordering::Relaxed);
-                                } else {
-                                    let _ = self
-                                        .send_outbound_text_with_retry(
-                                            "Delivery issue: your background result is preserved. Send 'continue' to replay it.".to_string(),
-                                            "failed to send relay failure backup notice",
-                                            1,
-                                        )
-                                        .await;
                                 }
                             }
                         }
@@ -3189,23 +3135,14 @@ impl Channel {
                                 self.state
                                     .conversation_logger
                                     .log_bot_message(&self.state.channel_id, &final_text);
-                                let delivered = self
-                                    .send_outbound_text_with_retry(
+                                if self
+                                    .send_outbound_text(
                                         final_text,
                                         "failed to send retrigger fallback reply",
-                                        3,
                                     )
-                                    .await;
-                                if delivered {
+                                    .await
+                                {
                                     replied_flag.store(true, std::sync::atomic::Ordering::Relaxed);
-                                } else {
-                                    let _ = self
-                                        .send_outbound_text_with_retry(
-                                            "Delivery issue: your background result is preserved. Send 'continue' to replay it.".to_string(),
-                                            "failed to send relay failure backup notice",
-                                            1,
-                                        )
-                                        .await;
                                 }
                             }
                         }
@@ -3262,10 +3199,9 @@ impl Channel {
                                     Some(self.agent_display_name()),
                                     tool_calls_json,
                                 );
-                            self.send_outbound_text_with_retry(
+                            self.send_outbound_text(
                                 final_text,
                                 "failed to send fallback reply",
-                                2,
                             )
                             .await;
                         }

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -40,6 +40,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, Weak};
 use tokio::sync::broadcast;
 use tokio::sync::{RwLock, mpsc};
+use tokio::time::{Duration, sleep};
 
 /// Shared cache of in-flight worker transcript steps, keyed by worker ID.
 pub type LiveWorkerTranscripts =
@@ -2959,8 +2960,7 @@ impl Channel {
         })
     }
 
-    /// Send outbound text and record send metrics.
-    async fn send_outbound_text(&self, text: String, error_context: &str) {
+    async fn send_outbound_text(&self, text: String, error_context: &str) -> bool {
         match self.send_routed(OutboundResponse::Text(text)).await {
             Ok(()) => {
                 #[cfg(feature = "metrics")]
@@ -2971,6 +2971,7 @@ impl Channel {
                         .with_label_values(&[&self.deps.agent_id, channel_type])
                         .inc();
                 }
+                true
             }
             Err(error) => {
                 #[cfg(feature = "metrics")]
@@ -2982,8 +2983,57 @@ impl Channel {
                         .inc();
                 }
                 tracing::error!(%error, channel_id = %self.id, "{error_context}");
+                false
             }
         }
+    }
+
+    async fn send_outbound_text_with_retry(
+        &self,
+        text: String,
+        error_context: &str,
+        max_attempts: usize,
+    ) -> bool {
+        let attempts = max_attempts.max(1);
+        for attempt in 1..=attempts {
+            if self
+                .send_outbound_text(text.clone(), error_context)
+                .await
+            {
+                if attempt > 1 {
+                    tracing::info!(
+                        channel_id = %self.id,
+                        attempt,
+                        attempts,
+                        "outbound relay succeeded after retry"
+                    );
+                }
+                return true;
+            }
+
+            if attempt < attempts {
+                let delay_ms = match attempt {
+                    1 => 250,
+                    2 => 1_000,
+                    _ => 2_000,
+                };
+                tracing::warn!(
+                    channel_id = %self.id,
+                    attempt,
+                    attempts,
+                    delay_ms,
+                    "outbound relay failed; retrying"
+                );
+                sleep(Duration::from_millis(delay_ms)).await;
+            }
+        }
+
+        tracing::warn!(
+            channel_id = %self.id,
+            attempts,
+            "outbound relay failed after retries"
+        );
+        false
     }
 
     /// Dispatch the LLM result: send fallback text, log errors, clean up typing.
@@ -3061,11 +3111,24 @@ impl Channel {
                                 self.state
                                     .conversation_logger
                                     .log_bot_message(&self.state.channel_id, &final_text);
-                                self.send_outbound_text(
-                                    final_text,
-                                    "failed to send retrigger fallback reply",
-                                )
-                                .await;
+                                let delivered = self
+                                    .send_outbound_text_with_retry(
+                                        final_text,
+                                        "failed to send retrigger fallback reply",
+                                        3,
+                                    )
+                                    .await;
+                                if delivered {
+                                    replied_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                                } else {
+                                    let _ = self
+                                        .send_outbound_text_with_retry(
+                                            "Delivery issue: your background result is preserved. Send 'continue' to replay it.".to_string(),
+                                            "failed to send relay failure backup notice",
+                                            1,
+                                        )
+                                        .await;
+                                }
                             }
                         }
                     } else {
@@ -3126,11 +3189,24 @@ impl Channel {
                                 self.state
                                     .conversation_logger
                                     .log_bot_message(&self.state.channel_id, &final_text);
-                                self.send_outbound_text(
-                                    final_text,
-                                    "failed to send retrigger fallback reply",
-                                )
-                                .await;
+                                let delivered = self
+                                    .send_outbound_text_with_retry(
+                                        final_text,
+                                        "failed to send retrigger fallback reply",
+                                        3,
+                                    )
+                                    .await;
+                                if delivered {
+                                    replied_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                                } else {
+                                    let _ = self
+                                        .send_outbound_text_with_retry(
+                                            "Delivery issue: your background result is preserved. Send 'continue' to replay it.".to_string(),
+                                            "failed to send relay failure backup notice",
+                                            1,
+                                        )
+                                        .await;
+                                }
                             }
                         }
                     } else {
@@ -3186,8 +3262,12 @@ impl Channel {
                                     Some(self.agent_display_name()),
                                     tool_calls_json,
                                 );
-                            self.send_outbound_text(final_text, "failed to send fallback reply")
-                                .await;
+                            self.send_outbound_text_with_retry(
+                                final_text,
+                                "failed to send fallback reply",
+                                2,
+                            )
+                            .await;
                         }
                     }
 


### PR DESCRIPTION
## Summary
Implements a first-pass mitigation for #581 by hardening retrigger/fallback delivery in `src/agent/channel.rs`.

### What changed
- Added bounded retry/backoff for outbound text sends (`send_outbound_text_with_retry`).
- Applied retries to retrigger plaintext fallback path (where dropped final replies were observed).
- When retrigger fallback send succeeds, marks `replied_flag=true` so relay state is preserved correctly.
- If all retries fail on retrigger relay, sends a short backup notice instructing user to send `continue` to replay preserved result.
- Applied smaller retry to non-retrigger plaintext fallback path.

## Why
Logs showed successful worker completion followed by:
- `retrigger produced text without reply tool, sending as fallback`
- `retrigger relay failed, preserving result in history for next turn`

That leads to user-visible truncation (partial opener, no final rundown). This PR adds retries and clearer user-facing fallback behavior.

## Validation
- `cargo check --all-targets` passes.

## Follow-ups (optional)
- Add adapter-level tests with injected send failure to assert retry + backup notice behavior.
- Include richer transport error metadata from messaging adapters for easier debugging.