### PR TITLE
fix(routing): use fully qualified Anthropic model ID

### DIFF
--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -3,6 +3,10 @@
 use crate::ProcessType;
 use std::collections::HashMap;
 
+/// Default Anthropic model identifier. Centralized here so bumping the dated
+/// model ID only requires a single change.
+const DEFAULT_ANTHROPIC_MODEL: &str = "anthropic/claude-sonnet-4-20250514";
+
 /// Model routing configuration. Lives on the agent config (via defaults).
 /// Determines which LLM model each process type uses, with task-type
 /// overrides for workers/branches and fallback chains for resilience.
@@ -36,7 +40,7 @@ pub struct RoutingConfig {
 
 impl Default for RoutingConfig {
     fn default() -> Self {
-        Self::for_model("anthropic/claude-sonnet-4-20250514".into())
+        Self::for_model(DEFAULT_ANTHROPIC_MODEL.into())
     }
 }
 
@@ -164,7 +168,7 @@ pub fn is_context_overflow_error(error_message: &str) -> bool {
 /// each provider sane defaults so things work out of the box.
 pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
     match provider {
-        "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4-20250514".into()),
+        "anthropic" => RoutingConfig::for_model(DEFAULT_ANTHROPIC_MODEL.into()),
         "openrouter" => {
             let channel: String = "openrouter/anthropic/claude-sonnet-4-20250514".into();
             let worker: String = "openrouter/anthropic/claude-haiku-4.5-20250514".into();

--- a/src/llm/routing.rs
+++ b/src/llm/routing.rs
@@ -36,7 +36,7 @@ pub struct RoutingConfig {
 
 impl Default for RoutingConfig {
     fn default() -> Self {
-        Self::for_model("anthropic/claude-sonnet-4".into())
+        Self::for_model("anthropic/claude-sonnet-4-20250514".into())
     }
 }
 
@@ -164,7 +164,7 @@ pub fn is_context_overflow_error(error_message: &str) -> bool {
 /// each provider sane defaults so things work out of the box.
 pub fn defaults_for_provider(provider: &str) -> RoutingConfig {
     match provider {
-        "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4".into()),
+        "anthropic" => RoutingConfig::for_model("anthropic/claude-sonnet-4-20250514".into()),
         "openrouter" => {
             let channel: String = "openrouter/anthropic/claude-sonnet-4-20250514".into();
             let worker: String = "openrouter/anthropic/claude-haiku-4.5-20250514".into();


### PR DESCRIPTION
## Summary

- The default routing model `"anthropic/claude-sonnet-4"` is not a valid model identifier
- The Anthropic API requires the fully qualified ID with date suffix: `"anthropic/claude-sonnet-4-20250514"`
- This especially affects OAuth users where the short alias is not resolved

## Changes

- `src/llm/routing.rs`: Update both default model references to use fully qualified ID

## Test plan

- [ ] Verify default model routing works with API key auth
- [ ] Verify default model routing works with OAuth auth
- [ ] Verify model selection in Settings UI shows correct model

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)