### PR TITLE
fix(interface): add tailwind-radix package for spaceui

### DIFF
--- a/interface/bun.lock
+++ b/interface/bun.lock
@@ -61,6 +61,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "openapi-typescript": "^7",
         "tailwindcss": "^4.2.2",
+        "tailwindcss-radix": "^4.0.2",
         "typescript": "^5.6.2",
         "vite": "^6.0.0",
       },
@@ -1626,6 +1627,8 @@
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
+
+    "tailwindcss-radix": ["tailwindcss-radix@4.0.2", "", { "peerDependencies": { "tailwindcss": "^3.0 || ^4.0" } }, "sha512-Uoa2BUCfWKGCjQPXbj4X4Q4EWAeCsvhj0udn0IupeNcvuLbqRXvC5+bKAqsngIne5mrRUPTy/IqMXGh81YyrCA=="],
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 

--- a/interface/package.json
+++ b/interface/package.json
@@ -65,6 +65,7 @@
 		"@vitejs/plugin-react": "^4.3.4",
 		"openapi-typescript": "^7",
 		"tailwindcss": "^4.2.2",
+		"tailwindcss-radix": "^4.0.2",
 		"typescript": "^5.6.2",
 		"vite": "^6.0.0"
 	},

--- a/interface/src/styles.css
+++ b/interface/src/styles.css
@@ -7,6 +7,7 @@
 @layer opencode-portals;
 
 @import "tailwindcss";
+@plugin "tailwindcss-radix";
 
 /* SpaceUI design tokens */
 @import "@spacedrive/tokens/theme";


### PR DESCRIPTION
The toggle switches in the settings UI aren't actually toggling. Currently:
<img width="1900" height="1128" alt="chrome_ROaIIIVzAq" src="https://github.com/user-attachments/assets/df0e37f3-2d31-4c93-9b84-01fb72114388" />

This is caused by `tailwindcss-radix` being missing. As per [SpaceUI](https://github.com/spacedriveapp/spaceui/blob/a48b17047d3ff1d05268acb6f88a79460ad4fa7b/docs/TAILWIND-V4-MIGRATION.md?plain=1#L381), consumers are expected to load their own plugins, and we didn't have that package installed. I've added the relevant package to the interface's package.json and imported it in the css, and it fixes the problem.

<img width="1616" height="863" alt="zen_8ylkMhg0Jw" src="https://github.com/user-attachments/assets/34887b07-0c02-4a32-a645-0b1f17fee7e6" />