### PR TITLE
feat: honor "*" allow-all wildcard in Slack/Mattermost/Twitch user allowlists

### DIFF
--- a/src/config/permissions.rs
+++ b/src/config/permissions.rs
@@ -191,6 +191,17 @@ impl SlackPermissions {
             dm_allowed_users,
         }
     }
+
+    /// Whether `user_id` may DM the bot. Fail-closed: an empty allowlist
+    /// blocks all DMs. A `"*"` entry is an explicit allow-all wildcard
+    /// (consistent with the Signal adapter's convention).
+    pub fn dm_user_allowed(&self, user_id: &str) -> bool {
+        !self.dm_allowed_users.is_empty()
+            && self
+                .dm_allowed_users
+                .iter()
+                .any(|u| u == "*" || u == user_id)
+    }
 }
 
 /// Hot-reloadable Telegram permission filters.
@@ -322,6 +333,18 @@ impl TwitchPermissions {
             channel_filter,
             allowed_users,
         }
+    }
+
+    /// Whether `login` may interact with the bot. Fail-open: an empty
+    /// allowlist accepts all users (Twitch's existing semantics). A `"*"`
+    /// entry is an explicit allow-all wildcard; matching is case-insensitive
+    /// (Twitch logins are case-insensitive).
+    pub fn user_allowed(&self, login: &str) -> bool {
+        self.allowed_users.is_empty()
+            || self
+                .allowed_users
+                .iter()
+                .any(|u| u == "*" || u.eq_ignore_ascii_case(login))
     }
 }
 
@@ -529,6 +552,17 @@ impl MattermostPermissions {
             dm_allowed_users,
         }
     }
+
+    /// Whether `user_id` may DM the bot. Fail-closed: an empty allowlist
+    /// blocks all DMs. A `"*"` entry is an explicit allow-all wildcard
+    /// (consistent with the Signal adapter's convention).
+    pub fn dm_user_allowed(&self, user_id: &str) -> bool {
+        !self.dm_allowed_users.is_empty()
+            && self
+                .dm_allowed_users
+                .iter()
+                .any(|u| u == "*" || u == user_id)
+    }
 }
 
 fn binding_adapter_selector_matches(binding: &Binding, adapter_selector: Option<&str>) -> bool {
@@ -583,5 +617,97 @@ mod base64_tests {
         assert!(!is_valid_base64("not@valid!base64"));
         assert!(!is_valid_base64(""));
         assert!(!is_valid_base64("   "));
+    }
+}
+
+#[cfg(test)]
+mod dm_wildcard_tests {
+    use super::*;
+
+    fn slack(users: Vec<&str>) -> SlackPermissions {
+        SlackPermissions {
+            workspace_filter: None,
+            channel_filter: HashMap::new(),
+            dm_allowed_users: users.into_iter().map(String::from).collect(),
+        }
+    }
+
+    fn mattermost(users: Vec<&str>) -> MattermostPermissions {
+        MattermostPermissions {
+            team_filter: None,
+            channel_filter: HashMap::new(),
+            dm_allowed_users: users.into_iter().map(String::from).collect(),
+        }
+    }
+
+    fn twitch(users: Vec<&str>) -> TwitchPermissions {
+        TwitchPermissions {
+            channel_filter: None,
+            allowed_users: users.into_iter().map(String::from).collect(),
+        }
+    }
+
+    // --- Slack: fail-closed DM allowlist ---
+
+    #[test]
+    fn slack_wildcard_allows_any_user() {
+        let p = slack(vec!["*"]);
+        assert!(p.dm_user_allowed("U123"));
+        assert!(p.dm_user_allowed("U-anyone-else"));
+    }
+
+    #[test]
+    fn slack_empty_blocks_all() {
+        assert!(!slack(vec![]).dm_user_allowed("U123"));
+    }
+
+    #[test]
+    fn slack_specific_is_exact_match() {
+        let p = slack(vec!["U123"]);
+        assert!(p.dm_user_allowed("U123"));
+        assert!(!p.dm_user_allowed("U999"));
+    }
+
+    // --- Mattermost: fail-closed DM allowlist (same shape as Slack) ---
+
+    #[test]
+    fn mattermost_wildcard_allows_any_user() {
+        assert!(mattermost(vec!["*"]).dm_user_allowed("user-id-abc"));
+    }
+
+    #[test]
+    fn mattermost_empty_blocks_all() {
+        assert!(!mattermost(vec![]).dm_user_allowed("user-id-abc"));
+    }
+
+    #[test]
+    fn mattermost_specific_is_exact_match() {
+        let p = mattermost(vec!["user-id-abc"]);
+        assert!(p.dm_user_allowed("user-id-abc"));
+        assert!(!p.dm_user_allowed("other-user"));
+    }
+
+    // --- Twitch: fail-open user allowlist, case-insensitive ---
+
+    #[test]
+    fn twitch_empty_allows_all() {
+        assert!(twitch(vec![]).user_allowed("anyone"));
+    }
+
+    #[test]
+    fn twitch_wildcard_allows_all() {
+        // Before this change, ["*"] would have rejected everyone except a
+        // literal "*" login — the footgun this wildcard support removes.
+        let p = twitch(vec!["*"]);
+        assert!(p.user_allowed("SomeStreamer"));
+        assert!(p.user_allowed("another_viewer"));
+    }
+
+    #[test]
+    fn twitch_specific_is_case_insensitive() {
+        let p = twitch(vec!["CoolMod"]);
+        assert!(p.user_allowed("coolmod"));
+        assert!(p.user_allowed("COOLMOD"));
+        assert!(!p.user_allowed("someone_else"));
     }
 }

--- a/src/messaging/mattermost.rs
+++ b/src/messaging/mattermost.rs
@@ -1142,13 +1142,10 @@ fn build_message_from_post(
     }
 
     // DM filter: if channel_type is "D", enforce dm_allowed_users (fail-closed)
-    if post.channel_type.as_deref() == Some("D") {
-        if context.permissions.dm_allowed_users.is_empty() {
-            return None;
-        }
-        if !context.permissions.dm_allowed_users.contains(&post.user_id) {
-            return None;
-        }
+    if post.channel_type.as_deref() == Some("D")
+        && !context.permissions.dm_user_allowed(&post.user_id)
+    {
+        return None;
     }
 
     // "D" = direct message, "G" = group DM

--- a/src/messaging/slack.rs
+++ b/src/messaging/slack.rs
@@ -205,7 +205,7 @@ async fn handle_message_event(
             return Ok(());
         }
         if let Some(ref sender_id) = user_id
-            && !perms.dm_allowed_users.contains(sender_id)
+            && !perms.dm_user_allowed(sender_id)
         {
             tracing::debug!(
                 channel_id,

--- a/src/messaging/twitch.rs
+++ b/src/messaging/twitch.rs
@@ -238,9 +238,7 @@ impl Messaging for TwitchAdapter {
                             }
 
                         // User filter
-                        if !permissions.allowed_users.is_empty()
-                            && !permissions.allowed_users.iter().any(|u| u.eq_ignore_ascii_case(&privmsg.sender.login))
-                        {
+                        if !permissions.user_allowed(&privmsg.sender.login) {
                             continue;
                         }
 


### PR DESCRIPTION
## What

Aligns the string-keyed messaging adapters — **Slack**, **Mattermost**, and **Twitch** — to honor a `"*"` allow-all wildcard in their DM / user allowlists, matching the convention the **Signal** adapter already uses.

## Why

Today only Signal treats `"*"` as allow-all. The other adapters match user IDs by exact value, so:

- there is no way to allow **every** DM/user without enumerating each ID (impractical at organization or community scale), and
- a list of `["*"]` silently matches **nobody** — a footgun, since it reads like "allow all" but matches only a literal `"*"` id.

## How

A small helper per permission struct, with each adapter's existing inline check routed through it. Behavior is unchanged except that `"*"` now means allow-all:

- `SlackPermissions::dm_user_allowed` / `MattermostPermissions::dm_user_allowed` — **fail-closed**: an empty list still blocks all DMs; `"*"` allows all.
- `TwitchPermissions::user_allowed` — **fail-open**: an empty list still allows all users (preserving existing behavior); `"*"` allows all; matching stays case-insensitive.

Each adapter's empty-list semantics are preserved exactly.

## Scope

Discord and Telegram parse their allowlists into integer id vectors (`Vec<u64>` / `Vec<i64>`), so `"*"` is not representable there; an allow-all for those would need a separate flag and is left out of scope.

## Tests

Adds unit tests for each adapter covering empty / wildcard / exact (and case-insensitive, for Twitch) matching. `cargo test --lib` is green; `cargo fmt --check` and `cargo clippy` are clean.

> [!NOTE]
> Adds three new helper methods (`SlackPermissions::dm_user_allowed`, `MattermostPermissions::dm_user_allowed`, `TwitchPermissions::user_allowed`) that encapsulate the permission check logic and support wildcard matching. The implementation updates call sites in `slack.rs`, `mattermost.rs`, and `twitch.rs` to use these helpers, consolidating the duplication and fixing the footgun where `["*"]` previously matched nobody. Unit tests cover empty, wildcard, and exact matching scenarios for each adapter, with case-insensitive matching for Twitch.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [d0ee4de](https://github.com/spacedriveapp/spacebot/commit/d0ee4de3a7892d71520dc96ab7cd53b62570485b). This will update automatically on new commits.</sub>
