### PR TITLE
fix(channels): case-insensitive channel-ID match in find_by_name

### DIFF
--- a/src/conversation/channels.rs
+++ b/src/conversation/channels.rs
@@ -164,8 +164,13 @@ impl ChannelStore {
             return Ok(Some(channel.clone()));
         }
 
-        // Match against the raw channel ID
-        if let Some(channel) = channels.iter().find(|c| c.id.contains(&name_lower)) {
+        // Match against the channel ID (case-insensitive: Teams conversation ids
+        // contain uppercase chars, so compare the lowercased id against the
+        // already-lowercased query rather than the raw id).
+        if let Some(channel) = channels
+            .iter()
+            .find(|c| c.id.to_lowercase().contains(&name_lower))
+        {
             return Ok(Some(channel.clone()));
         }
 


### PR DESCRIPTION
`ChannelStore::find_by_name` lowercases the search query for its display-name matches, but the final channel-ID fallback compares that lowercased query against the **raw** channel id with a case-sensitive `contains`:

```rust
channels.iter().find(|c| c.id.contains(&name_lower))
```

Channel ids that contain uppercase characters therefore never match the ID fallback when a target is passed by id — e.g. Microsoft Teams conversation ids like `teams:a:1-j_ftWddreoD7cw…` (mixed case). This makes `send_message_to_another_channel` fail with *"no channel found"* for such channels even though they are listed as available. Numeric / lowercase-id platforms (Discord, Telegram, Slack) are unaffected, which is why it went unnoticed.

**Fix:** lowercase both sides of the comparison (the query is already lowercased; lowercase the id too).

Surfaced while routing a cross-channel message to a Microsoft Teams DM on a live instance.

> [!NOTE]
> Fixes case-insensitive matching for channel IDs in the `find_by_name` method by lowercasing both sides of the ID comparison. This resolves an issue where mixed-case channel IDs (like Microsoft Teams conversation IDs) would fail to match despite being available, causing cross-channel message routing to fail with "no channel found".
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [04a3c777](https://github.com/spacedriveapp/spacebot/commit/04a3c777dbbaca4e797bd86e2aa7b38fbf146e7). This will update automatically on new commits.</sub>