### PR TITLE
fix(interface): route Switch through local Toggle to fix Tailwind v4 off-color state

### DIFF
--- a/interface/src/components/ChannelSettingCard.tsx
+++ b/interface/src/components/ChannelSettingCard.tsx
@@ -21,7 +21,7 @@ import {
 	DialogTitle,
 	DialogFooter,
 } from "@spacedrive/primitives";
-import {Switch} from "@spacedrive/primitives";
+import {Toggle as Switch} from "@/ui/Toggle";
 import {PlatformIcon} from "@/lib/platformIcons";
 import {
 	isValidE164,

--- a/interface/src/components/PromptInspectModal.tsx
+++ b/interface/src/components/PromptInspectModal.tsx
@@ -14,7 +14,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@spacedrive/primitives";
-import {Switch} from "@spacedrive/primitives";
+import {Toggle as Switch} from "@/ui/Toggle";
 
 interface PromptInspectModalProps {
 	open: boolean;

--- a/interface/src/components/agent-config/ConfigSectionEditor.tsx
+++ b/interface/src/components/agent-config/ConfigSectionEditor.tsx
@@ -7,8 +7,8 @@ import {
 	SelectValue,
 	SelectContent,
 	SelectItem,
-	Switch,
 } from "@spacedrive/primitives";
+import {Toggle as Switch} from "@/ui/Toggle";
 import {ModelSelect} from "@/components/ModelSelect";
 import {TagInput} from "@/components/TagInput";
 import {supportsAdaptiveThinking} from "./utils";

--- a/interface/src/components/settings/ServerSection.tsx
+++ b/interface/src/components/settings/ServerSection.tsx
@@ -1,7 +1,8 @@
 import {useState, useEffect} from "react";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {api} from "@/api/client";
-import {Button, Input, Switch} from "@spacedrive/primitives";
+import {Button, Input} from "@spacedrive/primitives";
+import {Toggle as Switch} from "@/ui/Toggle";
 import type {GlobalSettingsSectionProps} from "./types";
 
 export function ServerSection({settings, isLoading}: GlobalSettingsSectionProps) {

--- a/interface/src/routes/AgentCron.tsx
+++ b/interface/src/routes/AgentCron.tsx
@@ -34,7 +34,7 @@ import {
 	SelectContent,
 	SelectItem,
 } from "@spacedrive/primitives";
-import {Switch} from "@spacedrive/primitives";
+import {Toggle as Switch} from "@/ui/Toggle";
 
 // -- Helpers --
 


### PR DESCRIPTION
## Problem

Every toggle in the Spacebot dashboard renders with the unchecked background color even when `data-state="checked"` is correctly set on the underlying `<button>`. Visible repro: Settings → Channels → Telegram "Enabled" switch. Also affects the Server API toggle, Agent Cron toggles, Prompt Inspect capture toggle, and every section in the Config editor (coalesce, memory, browser, projects).

## Root cause

`@spacedrive/primitives`' `Switch` ships a className containing `radix-state-checked:bg-accent` — a Radix v0.x / Tailwind v3-era class variant. Spacebot's `interface/package.json` pins `tailwindcss: ^4.2.2` with `@tailwindcss/vite: ^4.2.2`. Tailwind v4 removed the `radix-state-*:` variant family in favor of `data-[state=*]:*` attribute selectors, and Radix v1.x (the resolved `@radix-ui/react-switch@1.2.6`) emits `data-state="checked"` on the element instead of the `radix-state-checked` class. The selector never matches → `bg-app-line` always wins.

## Fix

Routes all 5 Switch consumers in `interface/` through the local `interface/src/ui/Toggle.tsx` wrapper, which uses the modern `data-[state=checked]:bg-accent data-[state=unchecked]:bg-app-dark-box` selector and is a drop-in replacement (forwards all Radix `Root` props via spread, accepts the same `size: "sm" | "md" | "lg"` literals). Aliased as `Toggle as Switch` so the JSX call sites are byte-identical — zero call-site diff.

This is the consumer-side workaround. The durable fix belongs in the `@spacedrive/primitives` package — see the companion PR.

## Verification

- `bunx tsc --noEmit` in `interface/` passes
- All 5 call sites inspected: only `checked`, `onCheckedChange`, `disabled`, and `size` props are used, all of which Toggle supports
- `interface/src/ui/Toggle.tsx` is a 59-line wrapper with no new dependencies

> [!NOTE]
> This PR fixes toggle state styling issues by routing all Switch imports through a local Toggle wrapper that uses modern Tailwind v4 `data-[state=*]:` selectors instead of the deprecated Radix v0.x `radix-state-*:` class variants. The fix affects 5 files (ChannelSettingCard, PromptInspectModal, ConfigSectionEditor, ServerSection, and AgentCron) with zero visible changes to call sites since the wrapper is aliased as `Toggle as Switch`.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [0e1e1b2c](https://github.com/spacedriveapp/spacebot/commit/0e1e1b2c9a1f5b86cac36990e7142cb0fb1ddc85). This will update automatically on new commits.</sub>