### PR TITLE
fix(ci): pin Rust 1.97.1, bump ethnum, clear clippy lints on current stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      # Toolchain pinned to match rust-toolchain.toml — bump both together.
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.97.1
           components: clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -40,6 +42,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.97.1
           components: rustfmt
 
       - name: cargo fmt
@@ -55,6 +58,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "euclid"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pinned so local builds and CI compile with the same rustc/clippy.
+# CI reads this version via .github/workflows/ci.yml — bump both together.
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]

--- a/src/api/activity.rs
+++ b/src/api/activity.rs
@@ -256,7 +256,7 @@ pub(super) async fn get_activity(
 
     let mut days: HashMap<String, ActivityDay> = HashMap::new();
 
-    for (_agent_id, pool) in pools.iter() {
+    for pool in pools.values() {
         query_count(
             pool,
             "conversation_messages",

--- a/src/api/channels.rs
+++ b/src/api/channels.rs
@@ -197,7 +197,7 @@ pub(super) async fn channel_messages(
     let limit = query.limit.min(100);
     let fetch_limit = limit + 1;
 
-    for (_agent_id, pool) in pools.iter() {
+    for pool in pools.values() {
         let logger = ProcessRunLogger::new(pool.clone());
         match logger
             .load_channel_timeline(&query.channel_id, fetch_limit, query.before.as_deref())
@@ -424,7 +424,7 @@ pub(super) async fn cancel_process(
             // Fallback for detached workers (for example after restart): no live
             // channel state exists, but the DB row is still marked running.
             let pools = state.agent_pools.load();
-            for (_agent_id, pool) in pools.iter() {
+            for pool in pools.values() {
                 let logger = ProcessRunLogger::new(pool.clone());
                 match logger.cancel_running_detached_worker(worker_id).await {
                     Ok(true) => {

--- a/src/api/workers.rs
+++ b/src/api/workers.rs
@@ -150,7 +150,7 @@ pub(super) async fn list_workers(
     let live_statuses = {
         let blocks = state.channel_status_blocks.read().await;
         let mut map = std::collections::HashMap::new();
-        for (_channel_id, status_block) in blocks.iter() {
+        for status_block in blocks.values() {
             let block = status_block.read().await;
             for worker in &block.active_workers {
                 map.insert(

--- a/src/llm/model.rs
+++ b/src/llm/model.rs
@@ -2318,12 +2318,9 @@ fn completion_choice_to_streaming_choices(
 }
 
 fn extract_sse_block(buffer: &mut String) -> Option<String> {
-    let (block_end, separator_len) = if let Some(index) = buffer.find("\n\n") {
-        (index, 2)
-    } else if let Some(index) = buffer.find("\r\n\r\n") {
-        (index, 4)
-    } else {
-        return None;
+    let (block_end, separator_len) = match buffer.find("\n\n") {
+        Some(index) => (index, 2),
+        None => (buffer.find("\r\n\r\n")?, 4),
     };
 
     let block = buffer[..block_end].to_string();

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -766,7 +766,7 @@ fn task_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Task> {
             .try_get::<Option<String>, _>("worker_id")
             .ok()
             .flatten()
-            .and_then(|value| if value.is_empty() { None } else { Some(value) }),
+            .filter(|value| !value.is_empty()),
         created_by: row
             .try_get("created_by")
             .context("failed to read task created_by")?,

--- a/src/tools/spawn_worker.rs
+++ b/src/tools/spawn_worker.rs
@@ -516,7 +516,7 @@ impl Tool for DetachedSpawnWorkerTool {
             .working_memory
             .emit(
                 crate::memory::WorkingMemoryEventType::WorkerSpawned,
-                format!("Worker spawned (cortex): {}", &args.task),
+                format!("Worker spawned (cortex): {}", args.task),
             )
             .importance(0.5)
             .record();


### PR DESCRIPTION
CI has been red for every Rust check since stable moved past 1.93, on every PR and on main itself. Two causes stacked:

- `ethnum` 1.5.2 (pulled in via `jsonb`) fails to compile on current stable — `error[E0512]` on a `mem::transmute(())` into `TryFromIntError`. Fixed upstream in 1.5.3.
- once past that, clippy on 1.97 flags 7 lints in existing code that `-Dwarnings` turns into errors.

Because the workflow floated on `dtolnay/rust-toolchain@stable`, every stable release could (and did) break all open PRs at once, while local builds on older toolchains kept passing — which is why it went unnoticed.

Changes:
- bump `ethnum` 1.5.2 -> 1.5.3 in the lockfile
- pin the toolchain to 1.97.1 via `rust-toolchain.toml` and in `ci.yml`, so local builds and CI compile with the same rustc/clippy and a stable release can't take down CI again
- fix the 7 clippy lints (`.values()` instead of iterating map tuples, `Option::filter`, `?` operator, redundant `format!` ref)

Verified locally on 1.97.1: fmt, `clippy --all-targets` with `-Dwarnings`, 875 lib tests, `gate-pr`.

> [!NOTE]
> **Summary:** Fixes CI failures by pinning Rust to 1.97.1, updating ethnum to 1.5.3, and clearing 7 clippy lints across activity, channels, workers, model, task store, and spawn_worker modules. All changes maintain existing functionality while ensuring consistent builds across local and CI environments.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [d027b9d](https://github.com/spacedriveapp/spacebot/commit/d027b9d5e29f23424d3e35ebd0400260e385afec). This will update automatically on new commits.</sub>