### PR TITLE
fix(router): never await channel delivery in the shared inbound router

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,6 +9,7 @@ pub mod channel_prompt;
 pub mod compactor;
 pub mod cortex;
 pub mod cortex_chat;
+pub mod inbound_relay;
 pub mod ingestion;
 #[cfg(test)]
 mod invariant_harness;

--- a/src/agent/inbound_relay.rs
+++ b/src/agent/inbound_relay.rs
@@ -56,11 +56,16 @@ impl InboundRelay {
     /// Enqueue a message for in-order delivery to the channel. Never blocks.
     /// Fails only when the relay task has exited (channel shut down).
     pub fn send(&self, message: InboundMessage) -> Result<(), RelaySendError> {
-        self.tx
-            .send(message)
-            .map_err(|error| RelaySendError(Box::new(error.0)))?;
-
+        // Count before enqueueing: the relay task decrements after each
+        // forward, and incrementing after `tx.send` would let it observe the
+        // counter at zero while a message is in flight, underflowing it.
         let depth = self.state.queued.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if let Err(error) = self.tx.send(message) {
+            self.state.queued.fetch_sub(1, Ordering::Relaxed);
+            return Err(RelaySendError(Box::new(error.0)));
+        }
+
         let warn_at = self.state.warn_at.load(Ordering::Relaxed);
         if depth >= warn_at
             && self
@@ -186,6 +191,50 @@ mod tests {
             assert!(
                 tokio::time::Instant::now() < deadline,
                 "relay should reject sends after the channel receiver dropped"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn depth_accounting_survives_concurrent_drain() {
+        let (channel_tx, mut channel_rx) = mpsc::channel(1);
+        let relay = spawn("conv", "agent", channel_tx);
+
+        // Drain concurrently so the relay task's decrements race the
+        // sender's increments. A decrement observing the counter at zero
+        // underflows and panics in debug builds.
+        let consumer = tokio::spawn(async move {
+            let mut received = 0usize;
+            while channel_rx.recv().await.is_some() {
+                received += 1;
+                if received == 2000 {
+                    break;
+                }
+            }
+            received
+        });
+
+        for id in 0..2000 {
+            relay.send(message(id)).expect("relay accepts while alive");
+            if id % 32 == 0 {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        assert_eq!(consumer.await.expect("consumer task"), 2000);
+
+        // Once the relay task finishes forwarding, the counter must return
+        // to exactly zero — any drift means accounting raced.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if relay.state.queued.load(Ordering::Relaxed) == 0 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "relay depth never returned to zero: {}",
+                relay.state.queued.load(Ordering::Relaxed)
             );
             tokio::task::yield_now().await;
         }

--- a/src/agent/inbound_relay.rs
+++ b/src/agent/inbound_relay.rs
@@ -1,0 +1,211 @@
+//! Order-preserving relay between the shared inbound router and a channel's
+//! bounded message queue.
+//!
+//! The router's select loop must never await a single channel's queue: a
+//! saturated channel would stall inbound delivery for every other
+//! conversation. Each active channel gets a relay task that owns the awaited
+//! send into the channel's bounded queue; the router enqueues through
+//! [`InboundRelay::send`], which never blocks.
+//!
+//! Per-channel FIFO ordering is preserved because every message for a channel
+//! flows through that channel's single relay task. Overflow beyond the
+//! channel's bounded queue accumulates in the relay, where queue depth is
+//! tracked and logged so a stalled channel is visible instead of silently
+//! freezing the router.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::mpsc;
+
+use crate::InboundMessage;
+
+/// Relay depth at which pressure warnings begin. Warnings repeat at each
+/// doubling above this so a runaway channel logs O(log n) lines, not O(n).
+const PRESSURE_WARN_DEPTH: usize = 128;
+
+/// Non-blocking sender half handed to the router.
+#[derive(Clone)]
+pub struct InboundRelay {
+    tx: mpsc::UnboundedSender<InboundMessage>,
+    state: Arc<RelayState>,
+}
+
+struct RelayState {
+    conversation_id: String,
+    agent_id: String,
+    queued: AtomicUsize,
+    warn_at: AtomicUsize,
+}
+
+/// Returned when the relay task has stopped, which means the channel's event
+/// loop is gone. Carries the message back (boxed — `InboundMessage` is large
+/// and this is the cold path) so the caller can requeue it.
+#[derive(Debug)]
+pub struct RelaySendError(pub Box<InboundMessage>);
+
+impl std::fmt::Display for RelaySendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "channel relay closed")
+    }
+}
+
+impl std::error::Error for RelaySendError {}
+
+impl InboundRelay {
+    /// Enqueue a message for in-order delivery to the channel. Never blocks.
+    /// Fails only when the relay task has exited (channel shut down).
+    pub fn send(&self, message: InboundMessage) -> Result<(), RelaySendError> {
+        self.tx
+            .send(message)
+            .map_err(|error| RelaySendError(Box::new(error.0)))?;
+
+        let depth = self.state.queued.fetch_add(1, Ordering::Relaxed) + 1;
+        let warn_at = self.state.warn_at.load(Ordering::Relaxed);
+        if depth >= warn_at
+            && self
+                .state
+                .warn_at
+                .compare_exchange(
+                    warn_at,
+                    warn_at.saturating_mul(2),
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+        {
+            tracing::warn!(
+                conversation_id = %self.state.conversation_id,
+                agent_id = %self.state.agent_id,
+                depth,
+                "channel is not draining its message queue; relay is buffering"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Spawn a relay task that forwards messages into `channel_tx`, and return
+/// the non-blocking sender for the router. The task exits when either side
+/// closes: all `InboundRelay` clones dropped, or the channel's receiver gone.
+pub fn spawn(
+    conversation_id: &str,
+    agent_id: &str,
+    channel_tx: mpsc::Sender<InboundMessage>,
+) -> InboundRelay {
+    let (tx, mut rx) = mpsc::unbounded_channel::<InboundMessage>();
+    let state = Arc::new(RelayState {
+        conversation_id: conversation_id.to_string(),
+        agent_id: agent_id.to_string(),
+        queued: AtomicUsize::new(0),
+        warn_at: AtomicUsize::new(PRESSURE_WARN_DEPTH),
+    });
+
+    let relay_state = state.clone();
+    tokio::spawn(async move {
+        while let Some(message) = rx.recv().await {
+            if channel_tx.send(message).await.is_err() {
+                tracing::debug!(
+                    conversation_id = %relay_state.conversation_id,
+                    agent_id = %relay_state.agent_id,
+                    "channel receiver dropped; relay exiting"
+                );
+                break;
+            }
+
+            let depth = relay_state.queued.fetch_sub(1, Ordering::Relaxed) - 1;
+            if depth == 0
+                && relay_state
+                    .warn_at
+                    .swap(PRESSURE_WARN_DEPTH, Ordering::Relaxed)
+                    > PRESSURE_WARN_DEPTH
+            {
+                tracing::info!(
+                    conversation_id = %relay_state.conversation_id,
+                    agent_id = %relay_state.agent_id,
+                    "channel relay drained after pressure"
+                );
+            }
+        }
+    });
+
+    InboundRelay { tx, state }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(id: usize) -> InboundMessage {
+        let mut message = InboundMessage::empty();
+        message.id = id.to_string();
+        message
+    }
+
+    #[tokio::test]
+    async fn enqueue_does_not_block_on_full_channel_queue() {
+        let (channel_tx, _channel_rx) = mpsc::channel(1);
+        let relay = spawn("conv", "agent", channel_tx);
+
+        // Nothing consumes the channel queue, so anything past its capacity
+        // buffers in the relay. All sends must complete without awaiting.
+        for id in 0..200 {
+            relay.send(message(id)).expect("relay accepts while alive");
+        }
+    }
+
+    #[tokio::test]
+    async fn preserves_fifo_order_through_pressure() {
+        let (channel_tx, mut channel_rx) = mpsc::channel(2);
+        let relay = spawn("conv", "agent", channel_tx);
+
+        for id in 0..50 {
+            relay.send(message(id)).expect("relay accepts while alive");
+        }
+
+        for expected in 0..50 {
+            let received = channel_rx.recv().await.expect("message delivered");
+            assert_eq!(received.id, expected.to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn send_fails_once_channel_receiver_is_gone() {
+        let (channel_tx, channel_rx) = mpsc::channel(1);
+        let relay = spawn("conv", "agent", channel_tx);
+        drop(channel_rx);
+
+        // The relay only notices on its next forward attempt; give it one
+        // message to trip on, then wait for the task to exit.
+        let _ = relay.send(message(0));
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if relay.send(message(1)).is_err() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "relay should reject sends after the channel receiver dropped"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_message_on_relay_shutdown() {
+        let (channel_tx, channel_rx) = mpsc::channel(1);
+        let relay = spawn("conv", "agent", channel_tx);
+        drop(channel_rx);
+
+        let _ = relay.send(message(0));
+        loop {
+            match relay.send(message(7)) {
+                Ok(()) => tokio::task::yield_now().await,
+                Err(RelaySendError(returned)) => {
+                    assert_eq!(returned.id, "7");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,9 +176,12 @@ enum SecretsCommand {
     },
 }
 
-/// Tracks an active conversation channel and its message sender.
+/// Tracks an active conversation channel and its message relay.
 struct ActiveChannel {
-    message_tx: mpsc::Sender<spacebot::InboundMessage>,
+    /// Non-blocking, order-preserving path into the channel's message queue.
+    /// The router must never await channel delivery: a saturated channel
+    /// would stall inbound routing for every other conversation.
+    relay: spacebot::agent::inbound_relay::InboundRelay,
     /// Retained so the outbound routing task stays alive.
     _outbound_handle: tokio::task::JoinHandle<()>,
 }
@@ -2172,7 +2175,11 @@ async fn run(
                     active_channels.insert(
                         channel_key,
                         ActiveChannel {
-                            message_tx: channel_tx,
+                            relay: spacebot::agent::inbound_relay::spawn(
+                                &conversation_id,
+                                agent_id,
+                                channel_tx,
+                            ),
                             _outbound_handle: outbound_handle,
                         },
                     );
@@ -2415,7 +2422,11 @@ async fn run(
                     });
 
                     active_channels.insert(channel_key.clone(), ActiveChannel {
-                        message_tx: channel_tx,
+                        relay: spacebot::agent::inbound_relay::spawn(
+                            &conversation_id,
+                            &agent_id,
+                            channel_tx,
+                        ),
                         _outbound_handle: outbound_handle,
                     });
 
@@ -2427,9 +2438,9 @@ async fn run(
                 }
 
                 // Forward the message to the channel
-                if let Some(message_tx) = active_channels
+                if let Some(relay) = active_channels
                     .get(&channel_key)
-                    .map(|active| active.message_tx.clone())
+                    .map(|active| active.relay.clone())
                 {
                     let mut pending_delivery_failed = false;
                     if let Some(pending_injections) = deferred_injections.remove(&channel_key) {
@@ -2437,13 +2448,13 @@ async fn run(
                         let mut pending_injections = pending_injections.into_iter();
 
                         while let Some(injection_message) = pending_injections.next() {
-                            if let Err(error) = message_tx.send(injection_message).await {
+                            if let Err(error) = relay.send(injection_message) {
                                 tracing::warn!(
                                     conversation_id = %conversation_id,
                                     agent_id = %agent_id,
                                     "failed to deliver deferred injected message to channel"
                                 );
-                                remaining_injections.push(error.0);
+                                remaining_injections.push(*error.0);
                                 remaining_injections.extend(pending_injections);
                                 // Also re-queue the current inbound message so it isn't lost
                                 remaining_injections.push(message.clone());
@@ -2484,7 +2495,7 @@ async fn run(
                         attachments: inbound_attachments,
                     }).ok();
 
-                    if let Err(error) = message_tx.send(message).await {
+                    if let Err(error) = relay.send(message) {
                         tracing::error!(
                             conversation_id = %conversation_id,
                             %error,
@@ -2515,11 +2526,11 @@ async fn run(
                     injection.conversation_id.clone(),
                 );
 
-                if let Some(message_tx) = active_channels
+                if let Some(relay) = active_channels
                     .get(&channel_key)
-                    .map(|active| active.message_tx.clone())
+                    .map(|active| active.relay.clone())
                 {
-                    if let Err(error) = message_tx.send(injection.message.clone()).await {
+                    if let Err(error) = relay.send(injection.message.clone()) {
                         tracing::warn!(
                             %error,
                             conversation_id = %injection.conversation_id,


### PR DESCRIPTION
The main select loop forwarded inbound messages with an awaited `send` into each channel's bounded (64) queue — three sites: the inbound forward, deferred injection replay, and cross-agent injection. All three sit in the single shared router task, so one channel that stops draining (long tool call, wedged LLM stream) fills its queue and blocks the router on the await. From that moment no conversation on any agent receives messages until the stuck channel drains. Classic head-of-line blocking at the fan-in.

**The fix**: each active channel gets an `InboundRelay` (`src/agent/inbound_relay.rs`). The router enqueues with a synchronous, never-blocking send; a per-channel relay task owns the awaited forward into the channel's bounded queue. A saturated channel now stalls only its own relay task.

Semantics preserved:
- per-channel FIFO order — single relay per channel, one queue in, one queue out
- send failure still means "channel is gone" — all three router recovery paths (`active_channels` eviction, deferred-injection requeue) work unchanged, they just no longer await
- `Channel` itself, cron's ephemeral channels, and coalescing are untouched — the 64-slot consumer queue still bounds what the channel event loop sees

Overflow beyond the bounded queue buffers in the relay with depth tracking: a warning at depth 128 and each doubling after (O(log n) log lines, not O(n)), plus a drained notice — so a stalling channel is loud instead of invisibly freezing the fleet.

```rust
// router side — was: message_tx.send(message).await
if let Err(error) = relay.send(message) {
    // relay task exited -> channel died; same eviction path as before
}
```

Tests cover: enqueue never blocks against a full, unconsumed channel queue; FIFO holds through pressure; sends fail (and hand the message back) once the channel receiver is gone.

> [!NOTE]
> This PR introduces an `InboundRelay` to decouple the shared router task from individual channel delivery, preventing head-of-line blocking when a channel's queue saturates. The router now uses non-blocking sends; relay tasks handle bounded queue delivery asynchronously. Pressure is tracked and logged per-channel (O(log n) warnings on overflow), and all existing recovery semantics are preserved.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [676e0add](https://github.com/spacedriveapp/spacebot/commit/676e0add). This will update automatically on new commits.</sub>
