### PR TITLE
fix(cli): drop short flags that collide with global -c/-d

### DIFF
--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -15,7 +15,7 @@ pub enum AgentCommand {
         /// Agent ID (e.g. main)
         agent_id: String,
         /// Human-friendly display name
-        #[arg(short, long)]
+        #[arg(long)]
         display_name: Option<String>,
         /// Role description
         #[arg(short, long)]

--- a/src/cli/cron.rs
+++ b/src/cli/cron.rs
@@ -25,7 +25,7 @@ pub enum CronCommand {
         #[arg(short, long)]
         target: String,
         /// 5-field cron expression (takes precedence over --interval)
-        #[arg(short, long)]
+        #[arg(long)]
         cron: Option<String>,
         /// Interval between runs in seconds (default 3600)
         #[arg(short, long)]
@@ -78,7 +78,7 @@ pub enum CronCommand {
         /// Agent ID
         agent: String,
         /// Filter by cron job ID
-        #[arg(short, long)]
+        #[arg(long)]
         cron_id: Option<String>,
         /// Maximum number of executions to return
         #[arg(short, long, default_value_t = 50)]

--- a/src/cli/model.rs
+++ b/src/cli/model.rs
@@ -13,7 +13,7 @@ pub enum ModelCommand {
         #[arg(short, long)]
         provider: Option<String>,
         /// Filter by capability (input_audio, voice_transcription)
-        #[arg(short, long)]
+        #[arg(long)]
         capability: Option<String>,
     },
     /// Clear the model catalog cache and refetch it

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -29,7 +29,7 @@ pub enum ProjectCommand {
         /// Absolute path to the project root directory
         root_path: String,
         /// Project description
-        #[arg(short, long)]
+        #[arg(long)]
         description: Option<String>,
         /// Icon identifier
         #[arg(long)]
@@ -49,7 +49,7 @@ pub enum ProjectCommand {
         #[arg(short, long)]
         name: Option<String>,
         /// New description
-        #[arg(short, long)]
+        #[arg(long)]
         description: Option<String>,
         /// New icon identifier
         #[arg(long)]
@@ -101,7 +101,7 @@ pub enum RepoCommand {
         #[arg(long)]
         default_branch: Option<String>,
         /// Repo description
-        #[arg(short, long)]
+        #[arg(long)]
         description: Option<String>,
     },
     /// Remove a repo from a project (database record only)

--- a/src/cli/secrets.rs
+++ b/src/cli/secrets.rs
@@ -20,7 +20,7 @@ pub enum SecretsCommand {
         /// Secret name (e.g. GH_TOKEN)
         name: String,
         /// Secret category (system or tool)
-        #[arg(short, long)]
+        #[arg(long)]
         category: Option<String>,
         /// Read value from stdin instead of interactive prompt
         #[arg(long)]

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -47,7 +47,7 @@ pub enum TaskCommand {
         #[arg(short, long)]
         assigned: Option<String>,
         /// Task description
-        #[arg(short, long)]
+        #[arg(long)]
         description: Option<String>,
         /// Priority (critical, high, medium, low)
         #[arg(short, long)]
@@ -67,7 +67,7 @@ pub enum TaskCommand {
         #[arg(long)]
         title: Option<String>,
         /// New description
-        #[arg(short, long)]
+        #[arg(long)]
         description: Option<String>,
         /// New status (pending_approval, backlog, ready, in_progress, done)
         #[arg(short, long)]


### PR DESCRIPTION
`cargo test` on main currently fails on `cli::tests::cli_tree_is_valid` — clap's debug assert catches subcommand args whose derived short flags collide with the global `-c` (`--config`) and `-d` (`--debug`) options, introduced with the CLI coverage pass in #625. Since the test binary fail-fasts, this also masks the rest of the suite locally.

Colliding args lose their short and keep the long form only:

- `-d`: `agent create --display-name`, `task create/update --description`, `project create/update --description`, `project milestone add --description`
- `-c`: `cron create --cron`, `cron runs --cron-id`, `secrets list --category`, `model list --capability`

`cli_tree_is_valid` passes again, which also re-validates the whole tree for within-command duplicates.

> [!NOTE]
> This PR removes conflicting short flags (`-d` and `-c`) from 8 subcommand arguments that clashed with the global `--debug` and `--config` flags. The affected arguments now use only their long form. The fix allows the CLI test suite to run without the debug assertion failure.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [52bdced3](https://github.com/spacedriveapp/spacebot/commit/52bdced363a6dde8e548f3906bf96c72331e6a29). This will update automatically on new commits.</sub>