### PR TITLE
Fix forked workers exiting immediately and false memory-persistence failures

### DIFF
--- a/src/agent/branch.rs
+++ b/src/agent/branch.rs
@@ -4,7 +4,7 @@ use crate::error::Result;
 use crate::hooks::SpacebotHook;
 use crate::llm::SpacebotModel;
 use crate::llm::routing::is_context_overflow_error;
-use crate::tools::MemoryPersistenceContractState;
+use crate::tools::{MemoryPersistenceContractState, MemoryPersistenceTerminalOutcome};
 use crate::{AgentDeps, BranchId, ChannelId, ProcessEvent, ProcessId, ProcessType};
 use rig::agent::AgentBuilder;
 use rig::completion::CompletionModel;
@@ -161,6 +161,16 @@ impl Branch {
                     break partial;
                 }
                 Err(rig::completion::PromptError::PromptCancelled { reason, .. })
+                    if SpacebotHook::is_memory_persistence_complete_reason(&reason) =>
+                {
+                    self.hook.set_completion_contract_request_active(false);
+                    tracing::info!(
+                        branch_id = %self.id,
+                        "memory persistence branch reached terminal outcome"
+                    );
+                    break self.memory_persistence_conclusion();
+                }
+                Err(rig::completion::PromptError::PromptCancelled { reason, .. })
                     if enforce_memory_contract
                         && SpacebotHook::is_memory_persistence_contract_reason(&reason) =>
                 {
@@ -277,6 +287,28 @@ impl Branch {
         tracing::info!(branch_id = %self.id, "branch completed");
 
         Ok(conclusion)
+    }
+
+    /// Describe the recorded terminal outcome for the branch log. Memory
+    /// persistence branches complete silently, so this text is only ever
+    /// surfaced to operators.
+    fn memory_persistence_conclusion(&self) -> String {
+        match self
+            .memory_persistence_contract
+            .as_ref()
+            .and_then(|contract| contract.terminal_outcome())
+        {
+            Some(MemoryPersistenceTerminalOutcome::Saved { saved_memory_ids }) => {
+                format!(
+                    "Memory persistence complete: {} memories saved.",
+                    saved_memory_ids.len()
+                )
+            }
+            Some(MemoryPersistenceTerminalOutcome::NoMemories { reason }) => {
+                format!("Memory persistence complete: no memories saved ({reason}).")
+            }
+            None => "Memory persistence complete.".to_string(),
+        }
     }
 
     /// Compact history down to what the context window has left once this

--- a/src/agent/ingestion.rs
+++ b/src/agent/ingestion.rs
@@ -560,6 +560,18 @@ fn classify_chunk_prompt_result(
             );
             Ok(())
         }
+        // The chunk signalled its terminal outcome, so the loop stopped before
+        // the trailing LLM call. The caller verifies the outcome was recorded.
+        Err(PromptError::PromptCancelled { reason, .. })
+            if SpacebotHook::is_memory_persistence_complete_reason(&reason) =>
+        {
+            tracing::debug!(
+                file = %filename,
+                chunk = %format!("{chunk_number}/{total_chunks}"),
+                "chunk processed"
+            );
+            Ok(())
+        }
         Err(PromptError::MaxTurnsError { .. }) => {
             tracing::warn!(
                 file = %filename,

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -607,10 +607,13 @@ impl Worker {
             .tool_server_handle(worker_tool_server)
             .build();
 
-        // If this is a resumed worker, load the prior history into `history`
-        // (not `compacted_history`) so the LLM sees it as conversation context
-        // on the next follow-up call.
-        let resuming = self.prior_history.is_some();
+        // Seed `history` (not `compacted_history`) so the LLM sees prior
+        // messages as conversation context. Two distinct cases populate it: a
+        // resumed worker carrying its own transcript, and a fresh worker
+        // forking the channel's history. Only the former has already relayed a
+        // result, so resumption is keyed off the state the worker was built
+        // with, not off the presence of history.
+        let resuming = self.state == WorkerState::WaitingForInput;
         let mut history = self.prior_history.take().unwrap_or_default();
         let mut compacted_history = Vec::new();
 
@@ -622,6 +625,12 @@ impl Worker {
             );
             self.hook.send_status("resumed — waiting for input");
             self.hook.send_worker_idle();
+        } else if !history.is_empty() {
+            tracing::info!(
+                worker_id = %self.id,
+                forked_messages = history.len(),
+                "worker seeded with forked channel history"
+            );
         }
 
         // Run the initial task in segments with compaction checkpoints

--- a/src/conversation/history.rs
+++ b/src/conversation/history.rs
@@ -1028,7 +1028,13 @@ impl ProcessRunLogger {
                 .try_get::<chrono::DateTime<chrono::Utc>, _>("completed_at")
                 .ok()
                 .map(|t| t.to_rfc3339()),
-            transcript_blob: row.try_get("transcript").ok(),
+            // A NULL blob decodes to an empty vec rather than erroring, so
+            // read it as nullable and drop empties — callers treat `None` as
+            // "no persisted transcript" and fall back to the live cache.
+            transcript_blob: row
+                .try_get::<Option<Vec<u8>>, _>("transcript")
+                .unwrap_or(None)
+                .filter(|blob| !blob.is_empty()),
             tool_calls: row.try_get::<i64, _>("tool_calls").unwrap_or(0),
             opencode_session_id: row.try_get("opencode_session_id").ok(),
             opencode_port: row.try_get::<i32, _>("opencode_port").ok(),

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -90,6 +90,9 @@ impl SpacebotHook {
     /// PromptCancelled reason used for memory-persistence contract retries.
     pub const MEMORY_PERSISTENCE_CONTRACT_REASON: &str =
         "spacebot_memory_persistence_contract_retry";
+    /// PromptCancelled reason used once a memory-persistence run has recorded
+    /// its terminal outcome and the loop should stop.
+    pub const MEMORY_PERSISTENCE_COMPLETE_REASON: &str = "spacebot_memory_persistence_complete";
     /// Maximum nudge retries per prompt request.
     pub const TOOL_NUDGE_MAX_RETRIES: usize = 2;
     /// Maximum completion-contract retries per prompt request.
@@ -257,6 +260,12 @@ impl SpacebotHook {
 
     pub fn is_memory_persistence_contract_reason(reason: &str) -> bool {
         reason == Self::MEMORY_PERSISTENCE_CONTRACT_REASON
+    }
+
+    /// Return true if a PromptCancelled reason indicates the memory-persistence
+    /// run recorded its terminal outcome and stopped deliberately.
+    pub fn is_memory_persistence_complete_reason(reason: &str) -> bool {
+        reason == Self::MEMORY_PERSISTENCE_COMPLETE_REASON
     }
 
     /// Drain and return all buffered injected messages.
@@ -1366,12 +1375,20 @@ where
             );
         }
 
+        // The terminal completion tool ends a memory-persistence run. Stopping
+        // here skips the trailing LLM call that has nothing left to say —
+        // providers answer it with an empty message, which the response parser
+        // rejects and which surfaced as a failed branch even though every
+        // memory had already been persisted.
         if !is_tool_error
             && tool_name == "memory_persistence_complete"
             && let Some(contract_state) = &self.memory_persistence_contract
             && let Some(outcome) = Self::parse_memory_persistence_terminal_outcome(result)
         {
             contract_state.set_terminal_outcome(outcome);
+            return HookAction::Terminate {
+                reason: Self::MEMORY_PERSISTENCE_COMPLETE_REASON.into(),
+            };
         }
 
         // A successful tool call proves the worker is still productive.
@@ -2447,6 +2464,55 @@ mod tests {
         )
         .await;
 
+        assert!(matches!(action, HookAction::Continue));
+    }
+
+    #[tokio::test]
+    async fn memory_persistence_terminal_outcome_stops_the_loop() {
+        for result in [
+            "{\"success\":true,\"outcome\":\"no_memories\",\"saved_memory_ids\":[],\"reason\":\"No durable facts found\"}",
+            "{\"success\":true,\"outcome\":\"saved\",\"saved_memory_ids\":[\"mem_real_1\"]}",
+        ] {
+            let (hook, contract_state) = make_memory_persistence_hook();
+
+            let action = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+                &hook,
+                "memory_persistence_complete",
+                None,
+                "internal_1",
+                "{}",
+                result,
+            )
+            .await;
+
+            assert!(contract_state.has_terminal_outcome());
+            match action {
+                HookAction::Terminate { reason } => assert!(
+                    SpacebotHook::is_memory_persistence_complete_reason(&reason),
+                    "unexpected terminate reason: {reason}"
+                ),
+                HookAction::Continue => {
+                    panic!("terminal outcome should stop the loop before the trailing LLM call")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn memory_persistence_tool_error_does_not_stop_the_loop() {
+        let (hook, contract_state) = make_memory_persistence_hook();
+
+        let action = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "memory_persistence_complete",
+            None,
+            "internal_1",
+            "{}",
+            "Toolset error: memory_persistence_complete failed: saved_memory_ids mismatch",
+        )
+        .await;
+
+        assert!(!contract_state.has_terminal_outcome());
         assert!(matches!(action, HookAction::Continue));
     }
 }


### PR DESCRIPTION
Two bugs from the worker-reliability work, both found by testing #633 against a live instance.

## Forked workers never ran

Forking channel history by default populated `prior_history` for every new worker. `run_inner` read that field as "this worker already ran and relayed its result", so every forked worker skipped its task loop entirely and returned an empty result in about a millisecond:

```
05:11:42.605543  worker starting      task=Clone the GitHub repository...
05:11:42.605854  resuming interactive worker with prior history  prior_messages=2
05:11:42.606735  worker completed
```

No LLM call, no tools, nothing. The agent got empty results back and re-spawned the same worker four times trying to verify work that never happened.

`prior_history` was carrying two meanings: a resumed idle worker, and a fresh worker seeded with channel context. Only the first has already relayed a result, and the state machine already distinguishes them — `Worker::resume` is the only pre-run site that sets `WaitingForInput`:

```rust
let resuming = self.state == WorkerState::WaitingForInput;
```

Second, `worker_runs.transcript` was read as `Vec<u8>`. A NULL blob decodes to an empty vec rather than erroring, so NULL became `Some([])`, failed the gzip header read with `unexpected end of file`, and suppressed the live-transcript fallback — which is why worker transcripts came back empty in the UI and via `worker_inspect`.

## Memory persistence reported failure after succeeding

A persistence run called `memory_persistence_complete`, then took one more LLM turn with nothing left to say. The provider answers that with an empty `message`, the Responses parser rejects it, and the branch reported:

```
Branch failed: CompletionError: ResponseError: empty or unsupported response from
OpenAI ChatGPT Responses API ... received output types: message
```

Every memory had already been persisted. Channel turns already terminate after `reply`/`skip` for exactly this reason; the branch's terminal tool never got the same treatment. The hook now terminates once a valid terminal outcome is recorded, branches conclude from that outcome, and ingestion treats the signal as a completed chunk. Tool errors still continue, so the contract-retry path is unchanged.

This also drops one LLM call per persistence run and per ingestion chunk.

## Testing

Two hook tests cover the new termination: a valid terminal outcome stops the loop with the right reason (both `saved` and `no_memories`), and a tool error does not. Full lib suite passes at 1100.

The worker fix has no test — nothing constructs a `Worker` outside `channel_dispatch` with live `AgentDeps`, so covering resume-vs-fork needs a test fixture that doesn't exist yet. Worth adding separately, since this is the second bug in that path.
