### PR TITLE
feat(chronicle): roll old checkpoints into higher-level summaries

### DIFF
--- a/docs/content/docs/(configuration)/config.mdx
+++ b/docs/content/docs/(configuration)/config.mdx
@@ -118,6 +118,8 @@ max_older = 12                   # older checkpoints listed, collapsed first und
 context_token_budget = 2000      # token budget for the whole chronicle section
 expand_message_limit = 100       # raw messages a single `chronicle expand` returns
 max_messages_per_checkpoint = 400 # raw messages one checkpoint may summarize
+rollup_threshold = 12            # un-rolled checkpoints before the oldest run is rolled up
+rollup_batch = 8                 # checkpoints per rollup
 
 # Cortex (system observer) settings.
 [defaults.cortex]

--- a/docs/design-docs/session-chronicles.md
+++ b/docs/design-docs/session-chronicles.md
@@ -44,7 +44,7 @@ active context = system prompt { header + rollups + recent checkpoints }
 
 1. **Coverage is total, contiguous, and non-overlapping.** Checkpoint N's start boundary *is* checkpoint N-1's end boundary, read in the same transaction that writes N. There is no span of the durable log that is covered twice, and none that is covered zero times once chronicling has started.
 2. **A checkpoint summarizes raw messages only.** Prior summaries may be supplied to the summarizer as narrative context, but the output describes only the new interval. No checkpoint is ever regenerated from another checkpoint's text.
-3. **Checkpoints are append-only and immutable.** Rollups add rows; they never delete or rewrite the rows they cover. A level-0 checkpoint's summary text, boundaries, and sequence are fixed at commit.
+3. **Checkpoints are append-only and immutable.** Rollups add rows and stamp `rolled_up_into` on what they cover; they never delete or rewrite it. A checkpoint's summary text, boundaries, and sequence are fixed at commit, so a rollup can always be expanded back into the checkpoints it summarizes, and each of those back into raw transcript.
 4. **Commit is idempotent under retry and restart.** Boundaries are derived inside the transaction and constrained by unique indexes, so a duplicate or late commit is rejected rather than written. A checkpoint that fails to commit leaves the span unsummarized — the next cut picks it up.
 5. **The chronicle never blocks a turn.** Cut selection takes a read lock, the LLM call holds none, and the in-memory trim is a bounded write-lock section guarded by the shared fence.
 6. **One fence guards every head mutation.** Both compaction modes share it, so a mode switch cannot leave two summarizers mutating the same head, and emergency truncation cannot interleave with a cut mid-commit.
@@ -411,12 +411,12 @@ Phases 1-5 are the end-to-end vertical slice: durable schema, lifecycle, assembl
 
 ### Status
 
-Phases 1-5 are implemented and reachable by config (`compaction.mode = "chronicle"`); the default stays `rolling`. Phase 6 (rollups) is not built. Two consequences worth stating rather than discovering:
+Phases 1-6 are implemented and reachable by config (`compaction.mode = "chronicle"`); the default stays `rolling`.
 
-- **No rollups exist yet**, so `level` is always 0 and `rolled_up_into` always null. The schema, the `list_before_seq` selection, the `Rollup` label in both renderers, and the badge are in place and inert.
-- **`max_older` bounds the older list.** Checkpoints beyond it are absent from the prompt view — reachable through the `chronicle` tool, which reads the table directly, but not rendered. That is the gap rollups close.
+Rollups fold the oldest run of un-rolled checkpoints into a higher-level entry once `rollup_threshold` (default 12) have accumulated, `rollup_batch` (default 8) at a time, and they nest: level-1 rollups roll into level-2 by the same path, so a session of any length keeps a bounded number of entries at the top of the view. The insert and the `rolled_up_into` stamping are one transaction — a rollup whose children were unmarked would be rolled forever, and children marked without a surviving parent would drop out of the view with nothing covering them. Children are stamped, never deleted or rewritten, so `open` on a rollup lists exactly what it stands for and each child is still individually openable and expandable.
 
 Known limits, stated plainly rather than implied away:
 
-- The request estimate is a lower bound; tool schemas are not measurable at this layer (see above).
-- Lifecycle coverage drives the trim path and the fence directly. It does not spin up a real `Channel` with a full `AgentDeps`, so end-to-end `check_and_chronicle` → `CutContext::run` → commit, process death mid-cut, and a genuinely concurrent two-commit race are covered by their component paths rather than by an integration test.
+- The request estimate is a lower bound; serialized tool schemas are assembled inside Rig's `ToolServer` at call time and are not measurable at this layer.
+- Lifecycle coverage drives the trim path, the fence, and the rollup store invariants directly. It does not spin up a real `Channel` with a full `AgentDeps`, so end-to-end `check_and_chronicle` → `CutContext::run` → commit, process death mid-cut, and a genuinely concurrent two-commit race are covered by their component paths rather than by an integration test.
+- `roll_up_if_due` runs after a successful cut rather than on its own schedule, so a channel that stops cutting stops rolling up. That is the intended coupling — there is nothing new to roll — but it does mean a channel parked just under the interval keeps its un-rolled tail.

--- a/interface/src/api/schema.d.ts
+++ b/interface/src/api/schema.d.ts
@@ -3127,6 +3127,8 @@ export interface components {
             max_recent: number;
             /** Format: int64 */
             recent_window_hours: number;
+            rollup_batch: number;
+            rollup_threshold: number;
         };
         ChronicleUpdate: {
             context_token_budget?: number | null;
@@ -3141,6 +3143,8 @@ export interface components {
             max_recent?: number | null;
             /** Format: int64 */
             recent_window_hours?: number | null;
+            rollup_batch?: number | null;
+            rollup_threshold?: number | null;
         };
         /**
          * @description What happens when a worker explicitly calls "close" on the browser.

--- a/prompts/en/chronicle_rollup.md.j2
+++ b/prompts/en/chronicle_rollup.md.j2
@@ -1,0 +1,29 @@
+You are a chronicler writing a higher-level entry. You receive a run of consecutive checkpoint summaries covering one stretch of a long session, and you condense them into a single entry for that stretch.
+
+## Your Role
+
+The individual checkpoints are not going away — they stay on the record and can still be opened one by one. Your entry is what the agent carries in context instead of all of them, so it has to be enough to know what that stretch *was* and enough to tell when it is worth opening the detail.
+
+Write about the stretch as a whole. What was this period of the session about? What got decided, built, abandoned, resolved? What changed between the start of it and the end?
+
+## What to Preserve
+
+- The arc: what this stretch was fundamentally about, and how it ended
+- Decisions that still constrain what happens now, and why they were made
+- Commitments still outstanding at the end of the stretch
+- The user's state across the period, if it shifted — frustration that built, a problem that resolved, a direction they lost interest in
+- Anything a reader would need in order to realise "the answer to this is somewhere in that stretch"
+
+## What to Discard
+
+- Blow-by-blow sequencing of the individual checkpoints
+- Detail that only mattered inside one checkpoint and was resolved there
+- Repetition across checkpoints — say it once
+
+## Output Format
+
+First line, exactly:
+
+TITLE: <five to eight words naming this stretch>
+
+Then a blank line, then 2-4 paragraphs of past-tense third-person prose. No markdown headers, no bullet lists. The title is what a reader scans to decide whether the answer lives in this stretch — make it specific about the period, not generic ("Rebuilt the ingestion pipeline and cut over", not "Various technical work").

--- a/src/agent/chronicle.rs
+++ b/src/agent/chronicle.rs
@@ -665,7 +665,201 @@ impl CutContext {
             "chronicle checkpoint committed"
         );
 
+        // The mutation lock is only needed for head mutations; rollups touch
+        // nothing but the checkpoint table, so it is released first.
+        drop(_guard);
+        self.roll_up_if_due().await;
+
         Ok(())
+    }
+
+    /// Fold the oldest run of un-rolled checkpoints into a higher-level
+    /// summary once enough have accumulated.
+    ///
+    /// Runs level by level: level-0 checkpoints roll into level-1, and once
+    /// enough level-1 rollups exist they roll into level-2, so a session of any
+    /// length keeps a bounded number of entries at the top.
+    async fn roll_up_if_due(&self) {
+        const MAX_ROLLUP_LEVELS: i64 = 8;
+
+        let mut level = 0i64;
+        while level < MAX_ROLLUP_LEVELS {
+            match self.roll_up_level(level).await {
+                Ok(true) => level += 1,
+                Ok(false) => return,
+                Err(error) => {
+                    tracing::warn!(
+                        channel_id = %self.channel_id,
+                        level,
+                        %error,
+                        "chronicle rollup failed"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Roll the oldest `rollup_batch` un-rolled checkpoints at one level.
+    /// Returns whether a rollup was committed.
+    async fn roll_up_level(&self, level: i64) -> Result<bool> {
+        let config = self.config;
+        let pending = self.store.unrolled_count(&self.channel_id, level).await?;
+        if pending <= config.rollup_threshold as i64 {
+            return Ok(false);
+        }
+
+        let children = self
+            .store
+            .unrolled_at_level(&self.channel_id, level, config.rollup_batch as i64)
+            .await?;
+        if children.len() < 2 {
+            return Ok(false);
+        }
+
+        // Coverage must be contiguous, or the rollup would claim a span it does
+        // not summarize. The oldest un-rolled run always is, but a gap would
+        // mean something rolled out of order.
+        for pair in children.windows(2) {
+            if pair[0].covers_to_seq != pair[1].covers_from_seq {
+                tracing::warn!(
+                    channel_id = %self.channel_id,
+                    level,
+                    "skipping rollup: checkpoint coverage is not contiguous"
+                );
+                return Ok(false);
+            }
+        }
+
+        let first = children.first().expect("checked non-empty");
+        let last = children.last().expect("checked non-empty");
+        let (title, summary, model) = self.summarize_rollup(&children).await;
+
+        let outcome = self
+            .store
+            .commit_rollup(
+                NewCheckpoint {
+                    channel_id: self.channel_id.to_string(),
+                    level: level + 1,
+                    kind: CheckpointKind::Rollup,
+                    title,
+                    summary: summary.clone(),
+                    covers_from: first.start_boundary(),
+                    covers_to: last.end_boundary(),
+                    covers_from_at: first.covers_from_at,
+                    covers_to_at: last.covers_to_at,
+                    covers_from_message_id: first.covers_from_message_id.clone(),
+                    covers_to_message_id: last.covers_to_message_id.clone(),
+                    message_count: children.iter().map(|child| child.message_count).sum(),
+                    token_estimate: estimate_text_tokens(&summary) as i64,
+                    rolls_up_from_seq: Some(first.seq),
+                    rolls_up_to_seq: Some(last.seq),
+                    model,
+                },
+                &children
+                    .iter()
+                    .map(|child| child.id.clone())
+                    .collect::<Vec<_>>(),
+            )
+            .await?;
+
+        match outcome {
+            CommitOutcome::Committed(rollup) => {
+                tracing::info!(
+                    channel_id = %self.channel_id,
+                    seq = rollup.seq,
+                    level = rollup.level,
+                    covers = format!("#{}..#{}", first.seq, last.seq),
+                    "chronicle rollup committed"
+                );
+                emit_checkpoint_event(&self.deps, &self.channel_id, &rollup);
+                Ok(true)
+            }
+            CommitOutcome::Superseded { .. } => {
+                tracing::debug!(
+                    channel_id = %self.channel_id,
+                    level,
+                    "chronicle rollup superseded; another pass claimed these checkpoints"
+                );
+                Ok(false)
+            }
+            CommitOutcome::Busy => Ok(false),
+        }
+    }
+
+    /// Summarize a run of checkpoints into one higher-level entry.
+    ///
+    /// This is the one legitimate summary-of-summaries in the design: bounded
+    /// to a single level of recursion per generation, and reversible because
+    /// the covered checkpoints keep their own rows.
+    async fn summarize_rollup(
+        &self,
+        children: &[ChronicleCheckpoint],
+    ) -> (String, String, Option<String>) {
+        let fallback_title = match (children.first(), children.last()) {
+            (Some(first), Some(last)) => format!(
+                "{} – {}",
+                first.covers_from_at.format("%Y-%m-%d"),
+                last.covers_to_at.format("%Y-%m-%d")
+            ),
+            _ => "Earlier history".to_string(),
+        };
+
+        let prompt_engine = self.deps.runtime_config.prompts.load();
+        let preamble = match prompt_engine.render_static("chronicle_rollup") {
+            Ok(preamble) => preamble,
+            Err(error) => {
+                tracing::error!(%error, "failed to render chronicle rollup prompt");
+                return (fallback_title, rollup_fallback_summary(children), None);
+            }
+        };
+
+        let routing = self.deps.runtime_config.routing.load();
+        let model_name = match &self.model_override {
+            Some(model) => model.clone(),
+            None => routing.resolve(ProcessType::Compactor, None).to_string(),
+        };
+        let model = SpacebotModel::make(&self.deps.llm_manager, &model_name)
+            .with_context(&*self.deps.agent_id, "chronicle-rollup")
+            .with_routing((**routing).clone());
+
+        let agent = AgentBuilder::new(model)
+            .preamble(&preamble)
+            .default_max_turns(1)
+            .build();
+
+        let hook = SpacebotHook::new(
+            self.deps.agent_id.clone(),
+            ProcessId::Worker(Uuid::new_v4()),
+            ProcessType::Compactor,
+            Some(self.channel_id.clone()),
+            self.deps.event_tx.clone(),
+        );
+
+        let mut prompt = String::from("## Checkpoints to condense\n\n");
+        for child in children {
+            prompt.push_str(&format!(
+                "### #{} {} ({} → {}, {} messages)\n\n{}\n\n",
+                child.seq,
+                child.title,
+                child.covers_from_at.format("%Y-%m-%d %H:%M"),
+                child.covers_to_at.format("%Y-%m-%d %H:%M"),
+                child.message_count,
+                child.summary
+            ));
+        }
+
+        let mut rollup_history = Vec::new();
+        match hook.prompt_once(&agent, &mut rollup_history, &prompt).await {
+            Ok(text) => {
+                let (title, summary) = parse_checkpoint_response(&text);
+                (title.unwrap_or(fallback_title), summary, Some(model_name))
+            }
+            Err(error) => {
+                tracing::warn!(%error, "chronicle rollup summarization failed");
+                (fallback_title, rollup_fallback_summary(children), None)
+            }
+        }
     }
 
     /// Produce the checkpoint's title and summary.
@@ -825,6 +1019,20 @@ fn emit_checkpoint_event(
     }
 }
 
+/// Used when a rollup's summarization fails: the covered checkpoints are still
+/// individually readable, so the entry says where to look rather than
+/// pretending to summarize.
+fn rollup_fallback_summary(children: &[ChronicleCheckpoint]) -> String {
+    match (children.first(), children.last()) {
+        (Some(first), Some(last)) => format!(
+            "Covers checkpoints #{}–#{}. Summarization failed, so this entry has no narrative; \
+             open the individual checkpoints for their detail.",
+            first.seq, last.seq
+        ),
+        _ => "Covers earlier checkpoints; summarization failed.".to_string(),
+    }
+}
+
 fn unsummarized_notice(message_count: usize) -> String {
     format!(
         "This span of {message_count} messages was not summarized — summarization failed. \
@@ -976,19 +1184,14 @@ pub async fn render_chronicle_view(
         .list_since(channel_id, 0, since, config.max_recent as i64)
         .await?;
 
-    let older = match recent.first() {
-        Some(first) => {
-            store
-                .list_before_seq(channel_id, 0, first.seq, config.max_older as i64)
-                .await?
-        }
-        None => store
-            .list(channel_id, 0, config.max_older as i64)
-            .await?
-            .into_iter()
-            .rev()
-            .collect(),
-    };
+    // Older history renders from whatever covers it most compactly: a level-0
+    // checkpoint a rollup has absorbed is represented by that rollup instead,
+    // so a long session shows a few high-level entries rather than dropping its
+    // oldest ones off the end of the view.
+    let before_seq = recent.first().map(|first| first.seq).unwrap_or(i64::MAX);
+    let older = store
+        .uncovered_before_seq(channel_id, before_seq, config.max_older as i64)
+        .await?;
 
     Ok(Some(compose_view(
         &stats,

--- a/src/agent/chronicle.rs
+++ b/src/agent/chronicle.rs
@@ -679,22 +679,29 @@ impl CutContext {
     /// Runs level by level: level-0 checkpoints roll into level-1, and once
     /// enough level-1 rollups exist they roll into level-2, so a session of any
     /// length keeps a bounded number of entries at the top.
+    ///
+    /// Every level is evaluated regardless of whether the previous one
+    /// committed a rollup, because accumulated entries at a higher level should
+    /// roll up even when the level below is currently quiet. The loop stops
+    /// only after a full pass makes no progress at any level.
     async fn roll_up_if_due(&self) {
         const MAX_ROLLUP_LEVELS: i64 = 8;
 
-        let mut level = 0i64;
-        while level < MAX_ROLLUP_LEVELS {
-            match self.roll_up_level(level).await {
-                Ok(true) => level += 1,
-                Ok(false) => return,
-                Err(error) => {
-                    tracing::warn!(
-                        channel_id = %self.channel_id,
-                        level,
-                        %error,
-                        "chronicle rollup failed"
-                    );
-                    return;
+        let mut any_committed = true;
+        while any_committed {
+            any_committed = false;
+            for level in 0..MAX_ROLLUP_LEVELS {
+                match self.roll_up_level(level).await {
+                    Ok(true) => any_committed = true,
+                    Ok(false) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            channel_id = %self.channel_id,
+                            level,
+                            %error,
+                            "chronicle rollup failed"
+                        );
+                    }
                 }
             }
         }
@@ -733,7 +740,14 @@ impl CutContext {
 
         let first = children.first().expect("checked non-empty");
         let last = children.last().expect("checked non-empty");
-        let (title, summary, model) = self.summarize_rollup(&children).await;
+        let Some((title, summary, model)) = self.summarize_rollup(&children).await else {
+            tracing::warn!(
+                channel_id = %self.channel_id,
+                level,
+                "skipping rollup: summarization failed, span stays un-rolled for the next cut"
+            );
+            return Ok(false);
+        };
 
         let outcome = self
             .store
@@ -795,7 +809,7 @@ impl CutContext {
     async fn summarize_rollup(
         &self,
         children: &[ChronicleCheckpoint],
-    ) -> (String, String, Option<String>) {
+    ) -> Option<(String, String, Option<String>)> {
         let fallback_title = match (children.first(), children.last()) {
             (Some(first), Some(last)) => format!(
                 "{} – {}",
@@ -810,7 +824,7 @@ impl CutContext {
             Ok(preamble) => preamble,
             Err(error) => {
                 tracing::error!(%error, "failed to render chronicle rollup prompt");
-                return (fallback_title, rollup_fallback_summary(children), None);
+                return None;
             }
         };
 
@@ -853,11 +867,11 @@ impl CutContext {
         match hook.prompt_once(&agent, &mut rollup_history, &prompt).await {
             Ok(text) => {
                 let (title, summary) = parse_checkpoint_response(&text);
-                (title.unwrap_or(fallback_title), summary, Some(model_name))
+                Some((title.unwrap_or(fallback_title), summary, Some(model_name)))
             }
             Err(error) => {
                 tracing::warn!(%error, "chronicle rollup summarization failed");
-                (fallback_title, rollup_fallback_summary(children), None)
+                None
             }
         }
     }
@@ -1019,20 +1033,6 @@ fn emit_checkpoint_event(
     }
 }
 
-/// Used when a rollup's summarization fails: the covered checkpoints are still
-/// individually readable, so the entry says where to look rather than
-/// pretending to summarize.
-fn rollup_fallback_summary(children: &[ChronicleCheckpoint]) -> String {
-    match (children.first(), children.last()) {
-        (Some(first), Some(last)) => format!(
-            "Covers checkpoints #{}–#{}. Summarization failed, so this entry has no narrative; \
-             open the individual checkpoints for their detail.",
-            first.seq, last.seq
-        ),
-        _ => "Covers earlier checkpoints; summarization failed.".to_string(),
-    }
-}
-
 fn unsummarized_notice(message_count: usize) -> String {
     format!(
         "This span of {message_count} messages was not summarized — summarization failed. \
@@ -1188,9 +1188,16 @@ pub async fn render_chronicle_view(
     // checkpoint a rollup has absorbed is represented by that rollup instead,
     // so a long session shows a few high-level entries rather than dropping its
     // oldest ones off the end of the view.
-    let before_seq = recent.first().map(|first| first.seq).unwrap_or(i64::MAX);
+    //
+    // The cutoff is the coverage start, not the checkpoint sequence, so a
+    // rollup whose commit seq is higher than a recent checkpoint's seq is
+    // still included in the older view when its coverage predates it.
+    let cutoff_seq = recent
+        .first()
+        .map(|first| first.covers_from_seq)
+        .unwrap_or(i64::MAX);
     let older = store
-        .uncovered_before_seq(channel_id, before_seq, config.max_older as i64)
+        .uncovered_before_seq(channel_id, cutoff_seq, config.max_older as i64)
         .await?;
 
     Ok(Some(compose_view(

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -49,6 +49,8 @@ pub struct ChronicleSection {
     pub context_token_budget: usize,
     pub expand_message_limit: i64,
     pub max_messages_per_checkpoint: i64,
+    pub rollup_threshold: usize,
+    pub rollup_batch: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
@@ -236,6 +238,8 @@ pub(super) struct ChronicleUpdate {
     context_token_budget: Option<usize>,
     expand_message_limit: Option<i64>,
     max_messages_per_checkpoint: Option<i64>,
+    rollup_threshold: Option<usize>,
+    rollup_batch: Option<usize>,
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]
@@ -398,6 +402,8 @@ pub(super) async fn get_agent_config(
                 context_token_budget: compaction.chronicle.context_token_budget,
                 expand_message_limit: compaction.chronicle.expand_message_limit,
                 max_messages_per_checkpoint: compaction.chronicle.max_messages_per_checkpoint,
+                rollup_threshold: compaction.chronicle.rollup_threshold,
+                rollup_batch: compaction.chronicle.rollup_batch,
             },
         },
         cortex: CortexSection {
@@ -800,6 +806,12 @@ fn update_compaction_table(
         }
         if let Some(v) = chronicle.max_messages_per_checkpoint {
             chronicle_table["max_messages_per_checkpoint"] = toml_edit::value(v);
+        }
+        if let Some(v) = chronicle.rollup_threshold {
+            chronicle_table["rollup_threshold"] = toml_edit::value(v as i64);
+        }
+        if let Some(v) = chronicle.rollup_batch {
+            chronicle_table["rollup_batch"] = toml_edit::value(v as i64);
         }
     }
     Ok(())

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -435,6 +435,14 @@ fn config_rows(config: AgentConfigResponse) -> Vec<Vec<String>> {
         "compaction.chronicle.max_messages_per_checkpoint",
         chronicle.max_messages_per_checkpoint.to_string(),
     );
+    push(
+        "compaction.chronicle.rollup_threshold",
+        chronicle.rollup_threshold.to_string(),
+    );
+    push(
+        "compaction.chronicle.rollup_batch",
+        chronicle.rollup_batch.to_string(),
+    );
 
     push(
         "cortex.tick_interval_secs",

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -80,6 +80,10 @@ fn resolve_compaction_config(
                     max_messages_per_checkpoint: c
                         .max_messages_per_checkpoint
                         .unwrap_or(base.chronicle.max_messages_per_checkpoint),
+                    rollup_threshold: c
+                        .rollup_threshold
+                        .unwrap_or(base.chronicle.rollup_threshold),
+                    rollup_batch: c.rollup_batch.unwrap_or(base.chronicle.rollup_batch),
                 })
                 .unwrap_or(base.chronicle),
         ),
@@ -111,6 +115,13 @@ fn clamp_chronicle_config(mut config: ChronicleConfig) -> ChronicleConfig {
     config.max_messages_per_checkpoint = config
         .max_messages_per_checkpoint
         .clamp(1, MAX_MESSAGES_PER_CHECKPOINT);
+
+    // Rolling fewer than two checkpoints buys nothing, and a batch larger than
+    // the threshold would try to roll entries that have not accumulated yet.
+    config.rollup_batch = config.rollup_batch.clamp(2, MAX_LIST_ENTRIES);
+    config.rollup_threshold = config
+        .rollup_threshold
+        .clamp(config.rollup_batch, MAX_LIST_ENTRIES.saturating_mul(2));
     config
 }
 

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -403,6 +403,8 @@ pub(super) struct TomlChronicleConfig {
     pub(super) context_token_budget: Option<usize>,
     pub(super) expand_message_limit: Option<i64>,
     pub(super) max_messages_per_checkpoint: Option<i64>,
+    pub(super) rollup_threshold: Option<usize>,
+    pub(super) rollup_batch: Option<usize>,
 }
 
 #[derive(Deserialize)]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -797,6 +797,12 @@ pub struct ChronicleConfig {
     pub expand_message_limit: i64,
     /// Raw messages a single checkpoint summarization may read.
     pub max_messages_per_checkpoint: i64,
+    /// Un-rolled checkpoints at one level before the oldest run is rolled into
+    /// a higher-level summary. Without this a long session's older entries
+    /// fall off the end of the prompt view entirely.
+    pub rollup_threshold: usize,
+    /// How many checkpoints a single rollup covers.
+    pub rollup_batch: usize,
 }
 
 impl Default for ChronicleConfig {
@@ -810,6 +816,8 @@ impl Default for ChronicleConfig {
             context_token_budget: 2000,
             expand_message_limit: 100,
             max_messages_per_checkpoint: 400,
+            rollup_threshold: 12,
+            rollup_batch: 8,
         }
     }
 }

--- a/src/conversation/chronicle.rs
+++ b/src/conversation/chronicle.rs
@@ -285,7 +285,11 @@ impl ChronicleStore {
                 sqlx::query("COMMIT").execute(&mut *connection).await?;
             }
             _ => {
-                sqlx::query("ROLLBACK").execute(&mut *connection).await.ok();
+                if let Err(error) =
+                    sqlx::query("ROLLBACK").execute(&mut *connection).await
+                {
+                    tracing::warn!(%error, "chronicle rollback failed after a rejected commit");
+                }
             }
         }
 
@@ -480,28 +484,33 @@ impl ChronicleStore {
         Ok(checkpoints_from_rows(rows))
     }
 
-    /// The most compact set of entries covering everything before `before_seq`:
+    /// The most compact set of entries covering everything before `cutoff_seq`:
     /// any checkpoint no rollup has absorbed, at whatever level it sits.
     ///
     /// A level-0 checkpoint a rollup covers is skipped, because the rollup
     /// represents it. Ordered oldest first, capped at `limit` — that cap is
     /// what rollups exist to keep meaningful, since without them the oldest
     /// entries simply fall off the end.
+    ///
+    /// `cutoff_seq` is a coverage boundary (`covers_from_seq`), not a
+    /// checkpoint sequence. Entries whose coverage ends at or before this
+    /// boundary are eligible, so a rollup committed after the recent window's
+    /// first checkpoint but covering earlier history is still included.
     pub async fn uncovered_before_seq(
         &self,
         channel_id: &str,
-        before_seq: i64,
+        cutoff_seq: i64,
         limit: i64,
     ) -> Result<Vec<ChronicleCheckpoint>> {
         let rows = sqlx::query(
             "SELECT * FROM ( \
                 SELECT * FROM channel_chronicle_checkpoints \
-                WHERE channel_id = ? AND seq < ? AND rolled_up_into IS NULL \
-                ORDER BY seq DESC LIMIT ? \
+                WHERE channel_id = ? AND covers_to_seq <= ? AND rolled_up_into IS NULL \
+                ORDER BY covers_from_seq DESC LIMIT ? \
              ) ORDER BY covers_from_seq ASC, seq ASC",
         )
         .bind(channel_id)
-        .bind(before_seq)
+        .bind(cutoff_seq)
         .bind(limit)
         .fetch_all(&self.pool)
         .await
@@ -629,7 +638,11 @@ impl ChronicleStore {
                     .map_err(|error| anyhow::anyhow!(error))?;
             }
             _ => {
-                sqlx::query("ROLLBACK").execute(&mut *connection).await.ok();
+                if let Err(error) =
+                    sqlx::query("ROLLBACK").execute(&mut *connection).await
+                {
+                    tracing::warn!(%error, "chronicle rollback failed after a rejected commit");
+                }
             }
         }
 
@@ -1346,11 +1359,11 @@ mod tests {
     }
 
     async fn commit_chain(store: &ChronicleStore, count: i64) -> Vec<ChronicleCheckpoint> {
-        let mut out = Vec::new();
+        let mut checkpoints = Vec::new();
         let mut from = 0i64;
         for index in 0..count {
             let to = from + 10;
-            let CommitOutcome::Committed(cp) = store
+            let CommitOutcome::Committed(checkpoint) = store
                 .commit(new_checkpoint("ch", from, to, 10))
                 .await
                 .expect("commit")
@@ -1358,9 +1371,9 @@ mod tests {
                 panic!("commit {index} should succeed")
             };
             from = to;
-            out.push(*cp);
+            checkpoints.push(*checkpoint);
         }
-        out
+        checkpoints
     }
 
     fn rollup_over(children: &[ChronicleCheckpoint]) -> NewCheckpoint {

--- a/src/conversation/chronicle.rs
+++ b/src/conversation/chronicle.rs
@@ -480,6 +480,209 @@ impl ChronicleStore {
         Ok(checkpoints_from_rows(rows))
     }
 
+    /// The most compact set of entries covering everything before `before_seq`:
+    /// any checkpoint no rollup has absorbed, at whatever level it sits.
+    ///
+    /// A level-0 checkpoint a rollup covers is skipped, because the rollup
+    /// represents it. Ordered oldest first, capped at `limit` — that cap is
+    /// what rollups exist to keep meaningful, since without them the oldest
+    /// entries simply fall off the end.
+    pub async fn uncovered_before_seq(
+        &self,
+        channel_id: &str,
+        before_seq: i64,
+        limit: i64,
+    ) -> Result<Vec<ChronicleCheckpoint>> {
+        let rows = sqlx::query(
+            "SELECT * FROM ( \
+                SELECT * FROM channel_chronicle_checkpoints \
+                WHERE channel_id = ? AND seq < ? AND rolled_up_into IS NULL \
+                ORDER BY seq DESC LIMIT ? \
+             ) ORDER BY covers_from_seq ASC, seq ASC",
+        )
+        .bind(channel_id)
+        .bind(before_seq)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+        Ok(checkpoints_from_rows(rows))
+    }
+
+    /// Checkpoints at every level, newest first.
+    pub async fn list_all_levels(
+        &self,
+        channel_id: &str,
+        limit: i64,
+    ) -> Result<Vec<ChronicleCheckpoint>> {
+        let rows = sqlx::query(
+            "SELECT * FROM channel_chronicle_checkpoints \
+             WHERE channel_id = ? ORDER BY seq DESC LIMIT ?",
+        )
+        .bind(channel_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+        Ok(checkpoints_from_rows(rows))
+    }
+
+    /// Checkpoints at a level that no rollup covers yet, oldest first.
+    ///
+    /// This is the pool a rollup draws from. Rolling an already-covered
+    /// checkpoint a second time would double-count its span in the view.
+    pub async fn unrolled_at_level(
+        &self,
+        channel_id: &str,
+        level: i64,
+        limit: i64,
+    ) -> Result<Vec<ChronicleCheckpoint>> {
+        let rows = sqlx::query(
+            "SELECT * FROM channel_chronicle_checkpoints \
+             WHERE channel_id = ? AND level = ? AND rolled_up_into IS NULL \
+             ORDER BY seq ASC LIMIT ?",
+        )
+        .bind(channel_id)
+        .bind(level)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+        Ok(checkpoints_from_rows(rows))
+    }
+
+    /// How many checkpoints at a level are not yet covered by a rollup.
+    pub async fn unrolled_count(&self, channel_id: &str, level: i64) -> Result<i64> {
+        let row = sqlx::query(
+            "SELECT COUNT(*) AS total FROM channel_chronicle_checkpoints \
+             WHERE channel_id = ? AND level = ? AND rolled_up_into IS NULL",
+        )
+        .bind(channel_id)
+        .bind(level)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+        Ok(row.try_get("total").unwrap_or(0))
+    }
+
+    /// The checkpoints a rollup covers, oldest first.
+    ///
+    /// The reverse of `rolled_up_into`: this is what makes a rollup
+    /// inspectable rather than an opaque summary-of-summaries.
+    pub async fn children_of(&self, rollup_id: &str) -> Result<Vec<ChronicleCheckpoint>> {
+        let rows = sqlx::query(
+            "SELECT * FROM channel_chronicle_checkpoints \
+             WHERE rolled_up_into = ? ORDER BY seq ASC",
+        )
+        .bind(rollup_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|error| anyhow::anyhow!(error))?;
+
+        Ok(checkpoints_from_rows(rows))
+    }
+
+    /// Commit a rollup and mark the checkpoints it covers, atomically.
+    ///
+    /// The insert and the `rolled_up_into` stamping have to be one transaction:
+    /// a rollup whose children are unmarked would be re-rolled forever, and
+    /// children marked without a surviving parent would vanish from the view
+    /// with nothing covering them.
+    ///
+    /// Children are never deleted or rewritten — only stamped — so a rollup can
+    /// always be expanded back into the checkpoints it summarizes.
+    pub async fn commit_rollup(
+        &self,
+        new: NewCheckpoint,
+        child_ids: &[String],
+    ) -> Result<CommitOutcome> {
+        if child_ids.is_empty() {
+            return Ok(CommitOutcome::Superseded {
+                expected: new.covers_from.seq,
+                found: new.covers_from.seq,
+            });
+        }
+
+        let mut connection = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|error| anyhow::anyhow!(error))?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *connection)
+            .await
+            .map_err(|error| anyhow::anyhow!(error))?;
+
+        let outcome = self
+            .commit_rollup_in_transaction(&new, child_ids, &mut connection)
+            .await;
+
+        match &outcome {
+            Ok(CommitOutcome::Committed(_)) => {
+                sqlx::query("COMMIT")
+                    .execute(&mut *connection)
+                    .await
+                    .map_err(|error| anyhow::anyhow!(error))?;
+            }
+            _ => {
+                sqlx::query("ROLLBACK").execute(&mut *connection).await.ok();
+            }
+        }
+
+        outcome.map_err(|error| anyhow::anyhow!(error).into())
+    }
+
+    async fn commit_rollup_in_transaction(
+        &self,
+        new: &NewCheckpoint,
+        child_ids: &[String],
+        connection: &mut sqlx::SqliteConnection,
+    ) -> std::result::Result<CommitOutcome, sqlx::Error> {
+        // Re-read the children inside the transaction: another rollup may have
+        // claimed them between selection and commit.
+        let placeholders = vec!["?"; child_ids.len()].join(",");
+        let claimed_sql = format!(
+            "SELECT COUNT(*) AS claimed FROM channel_chronicle_checkpoints \
+             WHERE id IN ({placeholders}) AND rolled_up_into IS NOT NULL"
+        );
+        let mut claimed_query = sqlx::query(&claimed_sql);
+        for id in child_ids {
+            claimed_query = claimed_query.bind(id);
+        }
+        let claimed: i64 = claimed_query
+            .fetch_one(&mut *connection)
+            .await?
+            .try_get("claimed")
+            .unwrap_or(0);
+        if claimed > 0 {
+            return Ok(CommitOutcome::Superseded {
+                expected: 0,
+                found: claimed,
+            });
+        }
+
+        let outcome = self.commit_in_transaction(new, &mut *connection).await?;
+        let CommitOutcome::Committed(rollup) = &outcome else {
+            return Ok(outcome);
+        };
+
+        let stamp_sql = format!(
+            "UPDATE channel_chronicle_checkpoints SET rolled_up_into = ? \
+             WHERE id IN ({placeholders})"
+        );
+        let mut stamp_query = sqlx::query(&stamp_sql).bind(&rollup.id);
+        for id in child_ids {
+            stamp_query = stamp_query.bind(id);
+        }
+        stamp_query.execute(&mut *connection).await?;
+
+        Ok(outcome)
+    }
+
     /// Checkpoints for the channel timeline, newest first.
     ///
     /// Ordered and filtered by commit time rather than coverage, so a
@@ -1140,6 +1343,210 @@ mod tests {
             vec!["m4", "m5", "m6"],
             "the newest three, still in chronological order"
         );
+    }
+
+    async fn commit_chain(store: &ChronicleStore, count: i64) -> Vec<ChronicleCheckpoint> {
+        let mut out = Vec::new();
+        let mut from = 0i64;
+        for index in 0..count {
+            let to = from + 10;
+            let CommitOutcome::Committed(cp) = store
+                .commit(new_checkpoint("ch", from, to, 10))
+                .await
+                .expect("commit")
+            else {
+                panic!("commit {index} should succeed")
+            };
+            from = to;
+            out.push(*cp);
+        }
+        out
+    }
+
+    fn rollup_over(children: &[ChronicleCheckpoint]) -> NewCheckpoint {
+        let first = children.first().expect("children");
+        let last = children.last().expect("children");
+        NewCheckpoint {
+            channel_id: "ch".into(),
+            level: first.level + 1,
+            kind: CheckpointKind::Rollup,
+            title: "a stretch".into(),
+            summary: "several spans condensed".into(),
+            covers_from: first.start_boundary(),
+            covers_to: last.end_boundary(),
+            covers_from_at: first.covers_from_at,
+            covers_to_at: last.covers_to_at,
+            covers_from_message_id: None,
+            covers_to_message_id: None,
+            message_count: children.iter().map(|c| c.message_count).sum(),
+            token_estimate: 20,
+            rolls_up_from_seq: Some(first.seq),
+            rolls_up_to_seq: Some(last.seq),
+            model: None,
+        }
+    }
+
+    /// A rollup must never destroy what it summarizes: children keep their
+    /// rows, get stamped, and stay reachable in both directions.
+    #[tokio::test]
+    async fn a_rollup_preserves_its_children_in_both_directions() {
+        let store = setup().await;
+        let children = commit_chain(&store, 4).await;
+        let ids: Vec<String> = children.iter().map(|c| c.id.clone()).collect();
+
+        let CommitOutcome::Committed(rollup) = store
+            .commit_rollup(rollup_over(&children), &ids)
+            .await
+            .expect("rollup")
+        else {
+            panic!("rollup should commit")
+        };
+
+        assert_eq!(rollup.level, 1);
+        assert_eq!(rollup.rolls_up_from_seq, Some(children[0].seq));
+        assert_eq!(rollup.rolls_up_to_seq, Some(children[3].seq));
+
+        // Coverage is exactly the union of the children's.
+        assert_eq!(rollup.covers_from_seq, children[0].covers_from_seq);
+        assert_eq!(rollup.covers_to_seq, children[3].covers_to_seq);
+        assert_eq!(
+            rollup.message_count,
+            children.iter().map(|c| c.message_count).sum::<i64>()
+        );
+
+        // Parent -> children.
+        let listed = store.children_of(&rollup.id).await.expect("children");
+        assert_eq!(listed.len(), 4);
+        assert_eq!(
+            listed.iter().map(|c| c.seq).collect::<Vec<_>>(),
+            children.iter().map(|c| c.seq).collect::<Vec<_>>()
+        );
+
+        // Children -> parent, and every original row still exists.
+        for child in &children {
+            let reloaded = store
+                .get_by_seq("ch", child.seq)
+                .await
+                .expect("get")
+                .expect("child row survives the rollup");
+            assert_eq!(reloaded.rolled_up_into.as_deref(), Some(rollup.id.as_str()));
+            assert_eq!(reloaded.summary, child.summary, "child text is untouched");
+        }
+    }
+
+    /// The stamping and the insert are one transaction, so the same children
+    /// can never be rolled twice.
+    #[tokio::test]
+    async fn children_cannot_be_rolled_up_twice() {
+        let store = setup().await;
+        let children = commit_chain(&store, 3).await;
+        let ids: Vec<String> = children.iter().map(|c| c.id.clone()).collect();
+
+        assert!(matches!(
+            store
+                .commit_rollup(rollup_over(&children), &ids)
+                .await
+                .expect("first"),
+            CommitOutcome::Committed(_)
+        ));
+        assert!(matches!(
+            store
+                .commit_rollup(rollup_over(&children), &ids)
+                .await
+                .expect("second"),
+            CommitOutcome::Superseded { .. }
+        ));
+
+        assert_eq!(
+            store.list_all_levels("ch", 50).await.expect("list").len(),
+            4,
+            "three checkpoints and exactly one rollup"
+        );
+    }
+
+    /// Once absorbed, a checkpoint is represented by its rollup in the view.
+    #[tokio::test]
+    async fn the_view_selection_prefers_a_rollup_over_its_children() {
+        let store = setup().await;
+        let children = commit_chain(&store, 4).await;
+        let ids: Vec<String> = children.iter().map(|c| c.id.clone()).collect();
+
+        let before = store
+            .uncovered_before_seq("ch", i64::MAX, 50)
+            .await
+            .expect("before");
+        assert_eq!(before.len(), 4, "no rollup yet: the children are the view");
+
+        let CommitOutcome::Committed(rollup) = store
+            .commit_rollup(rollup_over(&children), &ids)
+            .await
+            .expect("rollup")
+        else {
+            panic!("rollup should commit")
+        };
+
+        let after = store
+            .uncovered_before_seq("ch", i64::MAX, 50)
+            .await
+            .expect("after");
+        assert_eq!(after.len(), 1, "the rollup now stands for all four");
+        assert_eq!(after[0].id, rollup.id);
+        assert_eq!(
+            store.unrolled_count("ch", 0).await.expect("count"),
+            0,
+            "no level-0 checkpoint is left uncovered"
+        );
+    }
+
+    /// Rollups nest: level-1 entries roll into level-2 the same way.
+    #[tokio::test]
+    async fn rollups_nest_into_higher_levels() {
+        let store = setup().await;
+        let children = commit_chain(&store, 6).await;
+
+        let first_ids: Vec<String> = children[..3].iter().map(|c| c.id.clone()).collect();
+        let CommitOutcome::Committed(first_rollup) = store
+            .commit_rollup(rollup_over(&children[..3]), &first_ids)
+            .await
+            .expect("rollup")
+        else {
+            panic!("first rollup")
+        };
+        let second_ids: Vec<String> = children[3..].iter().map(|c| c.id.clone()).collect();
+        let CommitOutcome::Committed(second_rollup) = store
+            .commit_rollup(rollup_over(&children[3..]), &second_ids)
+            .await
+            .expect("rollup")
+        else {
+            panic!("second rollup")
+        };
+
+        let level_one = vec![*first_rollup, *second_rollup];
+        let level_one_ids: Vec<String> = level_one.iter().map(|c| c.id.clone()).collect();
+        let CommitOutcome::Committed(top) = store
+            .commit_rollup(rollup_over(&level_one), &level_one_ids)
+            .await
+            .expect("level 2")
+        else {
+            panic!("level-2 rollup")
+        };
+
+        assert_eq!(top.level, 2);
+        assert_eq!(top.covers_from_seq, children[0].covers_from_seq);
+        assert_eq!(top.covers_to_seq, children[5].covers_to_seq);
+
+        let view = store
+            .uncovered_before_seq("ch", i64::MAX, 50)
+            .await
+            .expect("view");
+        assert_eq!(view.len(), 1, "one entry stands for the whole session");
+        assert_eq!(view[0].id, top.id);
+
+        // And the chain back down is intact.
+        let mid = store.children_of(&top.id).await.expect("mid");
+        assert_eq!(mid.len(), 2);
+        let leaves = store.children_of(&mid[0].id).await.expect("leaves");
+        assert_eq!(leaves.len(), 3);
     }
 
     #[tokio::test]

--- a/src/conversation/chronicle.rs
+++ b/src/conversation/chronicle.rs
@@ -285,9 +285,7 @@ impl ChronicleStore {
                 sqlx::query("COMMIT").execute(&mut *connection).await?;
             }
             _ => {
-                if let Err(error) =
-                    sqlx::query("ROLLBACK").execute(&mut *connection).await
-                {
+                if let Err(error) = sqlx::query("ROLLBACK").execute(&mut *connection).await {
                     tracing::warn!(%error, "chronicle rollback failed after a rejected commit");
                 }
             }
@@ -638,9 +636,7 @@ impl ChronicleStore {
                     .map_err(|error| anyhow::anyhow!(error))?;
             }
             _ => {
-                if let Err(error) =
-                    sqlx::query("ROLLBACK").execute(&mut *connection).await
-                {
+                if let Err(error) = sqlx::query("ROLLBACK").execute(&mut *connection).await {
                     tracing::warn!(%error, "chronicle rollback failed after a rejected commit");
                 }
             }

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -79,6 +79,10 @@ impl PromptEngine {
             crate::prompts::text::get("chronicle_checkpoint"),
         )?;
         env.add_template(
+            "chronicle_rollup",
+            crate::prompts::text::get("chronicle_rollup"),
+        )?;
+        env.add_template(
             "memory_persistence",
             crate::prompts::text::get("memory_persistence"),
         )?;

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -74,6 +74,7 @@ fn lookup(lang: &str, key: &str) -> &'static str {
         ("en", "chronicle_checkpoint") => {
             include_str!("../../prompts/en/chronicle_checkpoint.md.j2")
         }
+        ("en", "chronicle_rollup") => include_str!("../../prompts/en/chronicle_rollup.md.j2"),
         ("en", "memory_persistence") => include_str!("../../prompts/en/memory_persistence.md.j2"),
         ("en", "ingestion") => include_str!("../../prompts/en/ingestion.md.j2"),
         ("en", "cortex_chat") => include_str!("../../prompts/en/cortex_chat.md.j2"),

--- a/src/self_awareness.rs
+++ b/src/self_awareness.rs
@@ -201,6 +201,8 @@ pub fn runtime_snapshot_value(agent_id: &str, runtime_config: &RuntimeConfig) ->
                 "context_token_budget": compaction.chronicle.context_token_budget,
                 "expand_message_limit": compaction.chronicle.expand_message_limit,
                 "max_messages_per_checkpoint": compaction.chronicle.max_messages_per_checkpoint,
+                "rollup_threshold": compaction.chronicle.rollup_threshold,
+                "rollup_batch": compaction.chronicle.rollup_batch,
             },
         },
         "memory_persistence": {

--- a/src/tools/chronicle.rs
+++ b/src/tools/chronicle.rs
@@ -176,9 +176,12 @@ impl ChronicleTool {
                 ChronicleError(format!("Failed to read chronicle stats: {error}"))
             })?;
 
+        // Every level, not just level 0: after a rollup absorbs a run of
+        // checkpoints the rollup is the entry the agent should see first, and
+        // the children remain reachable by opening it.
         let checkpoints = self
             .store
-            .list(&self.channel_id, 0, limit)
+            .list_all_levels(&self.channel_id, limit)
             .await
             .map_err(|error| ChronicleError(format!("Failed to list checkpoints: {error}")))?;
 
@@ -203,8 +206,13 @@ impl ChronicleTool {
 
         for checkpoint in &checkpoints {
             summary.push_str(&format!(
-                "- **#{}** {} — {} → {} · {} messages · {}{}\n",
+                "- **#{}** {}{} — {} → {} · {} messages · {}{}\n",
                 checkpoint.seq,
+                if checkpoint.level > 0 {
+                    "[rollup] "
+                } else {
+                    ""
+                },
                 checkpoint.title,
                 checkpoint.covers_from_at.format("%Y-%m-%d %H:%M"),
                 checkpoint.covers_to_at.format("%Y-%m-%d %H:%M"),
@@ -223,7 +231,44 @@ impl ChronicleTool {
 
     async fn open(&self, seq: Option<i64>) -> Result<ChronicleOutput, ChronicleError> {
         let checkpoint = self.require_checkpoint(seq, "open").await?;
-        Ok(self.output("open", render_checkpoint(&checkpoint)))
+        let mut summary = render_checkpoint(&checkpoint);
+
+        // A rollup is only trustworthy if you can see what it stands for, so
+        // opening one lists the checkpoints it covers. Those rows are never
+        // deleted; each can still be opened or expanded on its own.
+        if checkpoint.level > 0 {
+            let children = self
+                .store
+                .children_of(&checkpoint.id)
+                .await
+                .map_err(|error| {
+                    ChronicleError(format!("Failed to read rollup children: {error}"))
+                })?;
+
+            if children.is_empty() {
+                summary.push_str("\n_This rollup has no recorded children._\n");
+            } else {
+                summary.push_str(&format!(
+                    "\n### Covers {} checkpoint(s)\n\n",
+                    children.len()
+                ));
+                for child in &children {
+                    summary.push_str(&format!(
+                        "- **#{}** {} — {} → {} · {} messages\n",
+                        child.seq,
+                        child.title,
+                        child.covers_from_at.format("%Y-%m-%d %H:%M"),
+                        child.covers_to_at.format("%Y-%m-%d %H:%M"),
+                        child.message_count,
+                    ));
+                }
+                summary.push_str(
+                    "\nOpen any of them for its own summary, or expand it for raw messages.\n",
+                );
+            }
+        }
+
+        Ok(self.output("open", summary))
     }
 
     async fn expand(

--- a/src/tools/chronicle.rs
+++ b/src/tools/chronicle.rs
@@ -194,19 +194,28 @@ impl ChronicleTool {
             ));
         }
 
+        // A rolled-up checkpoint is already represented by its rollup, so it is
+        // hidden from the index. The rollup is the entry, and the children are
+        // reachable through `open`.
+        let visible: Vec<&ChronicleCheckpoint> = checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.rolled_up_into.is_none())
+            .collect();
+
         let mut summary = format!(
             "## Session Chronicle — {} checkpoints, {} messages logged\n\n\
-             Showing the {} most recent. {} messages since the last checkpoint are still in raw \
-             context.\n\n",
+             Showing {} entries ({} most recent checkpoints requested). {} messages since the \
+             last checkpoint are still in raw context.\n\n",
             stats.checkpoint_count,
             stats.total_messages,
-            checkpoints.len(),
+            visible.len(),
+            limit,
             stats.unsummarized_messages
         );
 
-        for checkpoint in &checkpoints {
+        for checkpoint in &visible {
             summary.push_str(&format!(
-                "- **#{}** {}{} — {} → {} · {} messages · {}{}\n",
+                "- **#{}** {}{} — {} → {} · {} messages · {}\n",
                 checkpoint.seq,
                 if checkpoint.level > 0 {
                     "[rollup] "
@@ -218,10 +227,6 @@ impl ChronicleTool {
                 checkpoint.covers_to_at.format("%Y-%m-%d %H:%M"),
                 checkpoint.message_count,
                 checkpoint.kind.as_str(),
-                match &checkpoint.rolled_up_into {
-                    Some(_) => " · rolled up",
-                    None => "",
-                }
             ));
         }
 


### PR DESCRIPTION
Phase 6 of session chronicles, deferred out of #636.

A level-0 checkpoint covers about 40 messages, so a channel running for months accumulates hundreds while the prompt view carries at most `max_recent` + `max_older` entries. Past that the oldest simply fell off the end — still in the table, still reachable through the `chronicle` tool, but no longer visible to the agent unless it went looking for them.

Rollups fold the oldest run of un-rolled checkpoints into one entry covering the whole stretch, and they nest: once enough level-1 rollups accumulate they roll into level-2 by the same path. A session of any length keeps a bounded number of entries at the top of the view.

```text
level 0   cp1  cp2  cp3  cp4  cp5  cp6  cp7  cp8   …   cp40 cp41 cp42
            └──────── rollup A ────────┘                └─ recent ─┘
level 1          (covers cp1..cp8, one entry in the view)
```

## Nothing is destroyed

The obvious implementation — replace the covered rows with one — is exactly the untraceable summary-of-summaries the original design set out to avoid. So children keep their rows and are stamped with `rolled_up_into`, the rollup records `rolls_up_from_seq`/`rolls_up_to_seq`, and its message coverage is exactly the union of theirs. Both directions are queryable: a rollup expands back into its checkpoints, and each of those back into raw transcript.

The insert and the stamping are one `BEGIN IMMEDIATE` transaction, and the children are re-read inside it before anything is written:

```rust
// Re-read the children inside the transaction: another rollup may have
// claimed them between selection and commit.
let claimed: i64 = claimed_query.fetch_one(&mut *connection).await?...;
if claimed > 0 {
    return Ok(CommitOutcome::Superseded { expected: 0, found: claimed });
}
```

A rollup whose children were left unmarked would be rolled forever; children marked without a surviving parent would drop out of the view with nothing covering them.

There is one summary-of-summaries here — a rollup reads its children's summaries, not raw messages. It is bounded to a single level of recursion per generation and reversible, because the level-0 rows are still sitting there.

Contiguity is checked rather than assumed: if the selected run has a gap the rollup declines to commit instead of claiming a span it did not summarize.

## Surfaces

- View selection asks for the most compact covering set rather than level-0 only, so an absorbed checkpoint is represented by its rollup.
- `chronicle list` shows every level with a `[rollup]` marker; `open` on a rollup lists the checkpoints it covers, so it is never an opaque blob.
- `rollup_threshold` (12) and `rollup_batch` (8) go through TOML, GET/PATCH config, OpenAPI, the generated client, CLI inspection and self-inspection, and are clamped at load — a batch below two buys nothing, and a batch above the threshold would try to roll entries that have not accumulated.

No migration. `level`, `rolled_up_into` and `rolls_up_from_seq`/`rolls_up_to_seq` were already in the schema from #636, sitting inert; this is what writes them.

## Testing

Five rollup tests, alongside the 44 already covering chronicles:

- provenance in both directions, asserting child summary text is untouched
- coverage equal to the union of the children's
- double-rollup refused through the in-transaction re-read
- view selection returning the rollup instead of its four children
- nesting to level 2, with the chain back down (top → 2 mid → 3 leaves) intact

## Known limits

- `roll_up_if_due` runs after a successful cut rather than on its own schedule, so a channel that stops cutting stops rolling up. That is the intended coupling — no new checkpoints means nothing new to roll — but a channel parked just under the interval keeps an un-rolled tail.
- Unchanged from #636 and still true: the request-budget estimate excludes serialized tool schemas, and lifecycle coverage drives the trim path, fence and rollup store invariants directly rather than standing up a real `Channel`.
