### PR TITLE
feat(autonomy): durable task comments and the enrichment loop

### DIFF
--- a/docs/design-docs/autonomy.md
+++ b/docs/design-docs/autonomy.md
@@ -40,7 +40,8 @@ The cortex assembles the autonomy channel's context before each wake. It gets:
 - **Memory bulletin** — the cortex's current knowledge synthesis.
 - **Working memory** — recent system events. What's been happening across all channels.
 - **Wake events** — what pulled this run forward, if anything: the wake's name, instructions, and payload for each pending event since the last run. Surfaced first, because they are usually why the run exists.
-- **Task state** — all active tasks: ready, in-progress, backlog, pending_approval. Full detail on each, including all comments.
+- **Task state** — all active tasks: ready, in-progress, backlog, pending_approval, each with its comment count and last enrichment time.
+- **Enrichment queue** — the ordered selection for this run, with the recent comments on each entry inlined. Full comment threads are rendered here rather than across the whole board, so context stays bounded as the board grows.
 - **Goals** — all active goals with descriptions and notes. Background context and direction, not a work queue. See [`goals.md`](goals.md).
 - **Active workers** — what's currently running so it doesn't duplicate work.
 - **Last few run summaries** — the `autonomy_complete` output from its previous runs, with timestamps. This is the primary continuity mechanism.
@@ -56,16 +57,23 @@ All tasks require human approval before execution. `pending_approval` tasks are 
 The autonomy channel reasons about which tasks to prioritise given goal context and current system state — it is not a FIFO queue.
 
 During a run it can:
-- **Enrich pending tasks** — spawn investigation workers, reason about their findings, and add comments to tasks with synthesised results. A task that arrived as a title becomes a fully researched brief before the user ever approves it.
+- **Enrich pending tasks** — spawn investigation workers, reason about their findings, and record synthesised results with `add_task_comment`. A task that arrived as a title becomes a fully researched brief before the user ever approves it.
 - **Execute ready tasks** — tasks the user has approved. Uses execution tools directly (shell, file, browser) with no forced delegation. Workers available for genuine parallelism.
 - **Create new tasks** — identifies follow-on work and adds it to `pending_approval`. The agent proposes; the user decides.
 - **Update task metadata** — priority, blockers, progress notes.
+- **Link work to goals** — set `goal_id` when creating a task toward a goal, and record where a goal now stands in its `notes`.
 
 What it **cannot** do:
 - Reply to users (no `reply` tool)
 - Execute tasks that are still in `pending_approval`
 - Create cron jobs
 - Spawn other autonomy channels
+- Change a goal's status. `goal_update` is registered without the `status`
+  field for autonomy runs, so completing or abandoning a goal is unreachable
+  rather than merely discouraged.
+
+At `observe` the task surface is not registered at all: the run reads and
+summarises, and has no tool with which to create, update, comment, or claim.
 
 ---
 
@@ -79,32 +87,54 @@ Both the agent and the user can comment on a task. This makes tasks a shared wor
 
 ```sql
 CREATE TABLE task_comments (
-    id          TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    id          TEXT NOT NULL UNIQUE,
     task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
     author_type TEXT NOT NULL,   -- 'agent' | 'user' | 'worker'
-    author_id   TEXT,            -- user_id for users, worker_id for workers, null for agent
+    author_id   TEXT,            -- agent id, user id, or worker id
     body        TEXT NOT NULL,   -- synthesised comment text (2-5 lines)
     worker_id   TEXT,            -- if this comment summarises a worker run, links to that worker
-    metadata    TEXT DEFAULT '{}',
+    metadata    TEXT NOT NULL DEFAULT '{}',
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
-CREATE INDEX task_comments_task ON task_comments(task_id, created_at);
+CREATE INDEX task_comments_task ON task_comments(task_id, seq);
+CREATE INDEX task_comments_author ON task_comments(task_id, author_type, created_at);
 ```
+
+`seq` is the ordering key, not `created_at`: two comments inside the same
+millisecond would otherwise have no defined order, and pagination cursors would
+skip or repeat rows. `seq` is also the cursor the list API returns.
+
+Deletion is explicit as well as declared. `ON DELETE CASCADE` only fires when
+the connection has `PRAGMA foreign_keys` on, so `TaskStore::delete` removes a
+task's comments in the same transaction as the task.
+
+Comment bodies are capped at 4000 bytes. A finding longer than that is a
+transcript, and transcripts belong behind the `worker_id` link.
 
 `worker_id` links a comment to a specific worker run. The UI renders it as a pill on the comment — click to expand the full worker output. The comment body is always the agent's synthesised 2-5 line summary; the worker output is available on demand, never inlined.
 
 ### `add_task_comment` tool
 
-Available to the autonomy channel and to workers (via the task tools toolset).
+Comments are append-only. There is no edit and no delete: the store exposes
+neither, and the UI offers no affordance for either.
 
 ```rust
-struct AddTaskCommentInput {
-    task_id: String,
+struct AddTaskCommentArgs {
+    task_number: i64,           // #N, matching every other task tool
     body: String,               // synthesised finding — 2-5 lines
     worker_id: Option<String>,  // tag the worker whose output this summarises
 }
 ```
+
+Registered for the autonomy channel (at `suggest` and above), for branches, for
+the cortex chat, and for task workers. A worker's registration drops the
+`worker_id` field and stamps its own id, so a worker cannot misattribute a
+finding to another run.
+
+Commenting is also where autonomous ownership is settled — see
+[Task Ownership](#task-ownership).
 
 ### Enrichment Pattern
 
@@ -122,7 +152,19 @@ The autonomy channel system prompt instructs: investigate and comment freely; ne
 
 ### Worker Briefing
 
-When a `ready` task is eventually executed, `WorkerContextMode::Briefed` pulls the task's comments as part of the briefing synthesis alongside memory recall and working memory events. The executing worker walks in knowing what was investigated, what solution was proposed, and what the user said — without re-doing any of the research.
+When a `ready` task is executed, its comments are appended to the worker's task
+prompt as a "Prior findings" block: oldest first, capped at 12 comments, 600
+bytes each, 4000 bytes total. The executing worker walks in knowing what was
+investigated, what solution was proposed, and what the user said — without
+re-doing any of the research.
+
+`WorkerContextMode::Briefed` does not exist in source. `WorkerContextMode` is a
+struct of `history` / `memory` / `wiki_write` modes, and the enum in
+[`worker-briefing.md`](worker-briefing.md) was never built. Comments are
+injected at the ready-task pickup path instead, which is where a worker is
+actually bound to a task — the only place the briefing has a task's comments to
+carry. Worker transcripts are never inlined; they stay behind the `worker_id`
+link on each comment.
 
 ---
 
@@ -140,7 +182,7 @@ ALTER TABLE tasks ADD COLUMN last_enriched_at TEXT;
 
 Tasks have an `assigned_agent_id` field. Once an agent claims a task, no other agent can work on it. Ownership is enforced at the query level and set atomically when a task is first enriched or executed.
 
-The global tasks table currently declares `assigned_agent_id TEXT NOT NULL` with assignment at creation time, so the unowned-task model requires making the column nullable. That migration touches the global database and every task consumer; it ships as its own change ahead of this system, not inside it.
+`assigned_agent_id` is nullable as of `20260809000001_tasks_nullable_assignment`, so tasks can exist unowned until an agent claims them.
 
 ```sql
 -- Atomic claim: only succeeds if still unassigned or already assigned to this agent
@@ -148,7 +190,14 @@ UPDATE tasks SET assigned_agent_id = ?1
 WHERE id = ?2 AND (assigned_agent_id IS NULL OR assigned_agent_id = ?1)
 ```
 
-If the UPDATE affects 0 rows, another agent claimed it first — skip and move on.
+If the UPDATE affects 0 rows, another agent claimed it first — the tool returns
+a skip ("task #N was claimed by <agent> first"), and the run moves on.
+
+The claim happens when the agent *acts* on a task, not when it lists one:
+`add_task_comment` claims before it writes, and `claim_next_ready` takes
+assignment and `in_progress` in one guarded UPDATE. Surveying the board claims
+nothing, and `observe` runs get no mutation tools at all, so they cannot claim
+by any path.
 
 `claim_unowned` is an agent-level config flag (default: `true`). Set to `false` for agents that should only work on tasks explicitly assigned to them — useful in multi-agent setups where task routing is intentional. Once claimed, ownership is permanent. Reassignment is user-initiated only.
 
@@ -163,7 +212,17 @@ On wake, tasks are ordered by:
 
 Rule 4 prevents just-worked-on tasks from floating to the top next wake. Rule 1 clears that exclusion when the user responds — natural gate, no separate flag needed.
 
-The channel selects up to `max_tasks_per_run` from this ordered list, reasoning about which are most valuable given goal context. Not a mechanical top-N pick. All queries filter to `assigned_agent_id = this_agent OR assigned_agent_id IS NULL` (when `claim_unowned = true`).
+This ordering is settled in SQL (`TaskStore::select_for_enrichment`) and
+rendered into the run briefing as an **Enrichment Queue**, so the channel opens
+with a list that already excludes last run's work. Visibility filters to
+`assigned_agent_id = this_agent OR assigned_agent_id IS NULL` (the latter only
+when `claim_unowned = true`).
+
+`max_tasks_per_run` is enforced, not requested: `add_task_comment` holds the
+run's allowance and refuses a task beyond it. The allowance is spent per task,
+so a run can keep commenting on work it already started. Within the allowance
+the channel still reasons about which tasks are most valuable given goal
+context — it is not a mechanical top-N pick.
 
 ### Run History as Context
 
@@ -269,18 +328,31 @@ Enforced at startup and on config reload — autonomy does not start if any rule
 - Task retry/failure handling (3 strikes → `failed`, working memory error event)
 - All config fields + validation
 
-**Phase 2 — Task Comments**
+**Phase 2 — Task Comments — shipped**
 - `task_comments` table migration
-- `add_task_comment` tool (autonomy channel + workers)
-- Task comments included in task state context on wake
-- Task comments pulled into `WorkerContextMode::Briefed` pipeline
+- `add_task_comment` tool (autonomy channel, branches, cortex chat, task workers)
+- Task comments in the wake briefing: counts on every surveyed task, full
+  recent comments on every enrichment-queue entry
+- Task comments injected into the executing worker's briefing at ready-task
+  pickup, bounded per comment and in total
+- `last_enriched_at` column, transactional with the comment that sets it
+- Atomic claim on first comment and on ready-task pickup
 - API endpoints: list and create comments per task
 - UI: chronological comments on task detail, worker pill with expandable full output
 
 **Phase 3 — Polish**
 - Autonomy UI surface: run history, last wake time, active enrichment progress
-- "Quiet while active" flag: suppress autonomy wakes when user channels have been recently active
 - Autonomy outcomes surfaced to relevant user channels via working memory synthesis
+
+**Rejected — "quiet while active"**
+
+Suppressing autonomy wakes while user channels have been recently active is
+rejected, not deferred. Enrichment is exactly the work that is most useful
+while the user is around to react to it, and the wake already carries the
+signals that matter: a user comment on a task pulls the next run forward
+rather than pushing it away. A global "someone is talking, stand down" flag
+would suppress the run for reasons unrelated to the task it was going to work
+on. Do not reintroduce it.
 
 ---
 

--- a/docs/design-docs/goals.md
+++ b/docs/design-docs/goals.md
@@ -114,7 +114,10 @@ No token budget — autonomy channels and goal review get the full picture.
 - `goal_create(title, description?, priority?, due_date?)` — create a new goal
 - `goal_update(id, status?, priority?, due_date?, notes?, metadata_patch?)` — update fields
 - `goal_list(status?)` — list goals, optionally filtered by status
-- `goal_note(id, notes)` — update the progress notes field (shorthand for `goal_update`)
+
+There is no separate `goal_note` tool: `goal_update(id, notes)` is the notes
+path, and a second tool for one field would be a synonym rather than a
+capability.
 
 ### Channel Tools (read-only)
 
@@ -124,7 +127,11 @@ Channels get `goal_list` only. They can read goals and reference them in convers
 
 Goals are not completed by tool — they're completed by the user via the API or UI. The agent can call `goal_update(status: "completed")` only with explicit user instruction. The goal review process does not call this automatically.
 
-What the goal review *can* do: set `notes` to "All linked tasks complete — ready for your review" when it detects all tasks are done. This surfaces the completion candidate to the user without presuming to close it.
+What the autonomy run *does* do: prepend "All linked tasks complete — ready for
+your review." to the goal's notes when every linked task is `done`. This
+surfaces the completion candidate to the user without presuming to close it.
+The write is programmatic, so a goal cannot be flagged by a model that
+miscounted, and cannot be closed by one that overreached.
 
 ---
 
@@ -192,15 +199,22 @@ A goal without tasks is a signal the autonomy channel acts on — it creates `pe
 **Phase 1 — Data Model + Tools**
 - `goals` table migration
 - `goal_id` FK on tasks migration
-- `goal_create`, `goal_update`, `goal_list`, `goal_note` tools
+- `goal_create`, `goal_update`, `goal_list` tools
 - Active goals injected into channel system prompt (short format)
 - API endpoints: CRUD for goals
 
-**Phase 2 — Autonomy Integration**
+**Phase 2 — Autonomy Integration — shipped**
 - Autonomy channel receives all active goals in extended format on wake
-- Autonomy channel uses `goal_id` when creating tasks from goals
-- Autonomy channel updates `notes` as progress is made
-- Autonomy channel sets `notes` when all linked tasks are complete
+- Autonomy channel uses `goal_id` when creating tasks from goals. `task_create`
+  resolves the id against the goal store before insert, so an unknown goal is a
+  tool error rather than a dangling link.
+- Autonomy channel updates `notes` as progress is made, through a `goal_update`
+  registration with the `status` field removed
+- The ready-for-review marker is written deterministically at the end of each
+  run, not left to the model: `mark_goals_ready_for_review` prepends the marker
+  to any active goal whose linked tasks are all `done`, keeping the agent's own
+  progress notes beneath it. It is idempotent, treats `failed` as work
+  remaining, and never touches goal status.
 
 **Phase 3 — UI**
 - Goals tab: list, create, detail panel, linked task counts

--- a/interface/src/api/client.ts
+++ b/interface/src/api/client.ts
@@ -1076,9 +1076,42 @@ export interface TaskItem {
 	created_by: string;
 	approved_at?: string;
 	approved_by?: string;
+	last_enriched_at?: string;
 	created_at: string;
 	updated_at: string;
 	completed_at?: string;
+}
+
+export type TaskCommentAuthor = "agent" | "user" | "worker";
+
+export interface TaskComment {
+	seq: number;
+	id: string;
+	task_id: string;
+	author_type: TaskCommentAuthor;
+	author_id?: string;
+	body: string;
+	worker_id?: string;
+	metadata: Record<string, unknown>;
+	created_at: string;
+}
+
+export interface TaskCommentListResponse {
+	comments: TaskComment[];
+	total: number;
+	next_cursor?: number;
+}
+
+export interface TaskCommentResponse {
+	comment: TaskComment;
+}
+
+export interface CreateTaskCommentRequest {
+	author_type?: TaskCommentAuthor;
+	author_id?: string;
+	body: string;
+	worker_id?: string;
+	metadata?: Record<string, unknown>;
 }
 
 export interface TaskListResponse {
@@ -1103,6 +1136,7 @@ export interface CreateTaskRequest {
 	priority?: TaskPriority;
 	subtasks?: TaskSubtask[];
 	metadata?: Record<string, unknown>;
+	goal_id?: string;
 	source_memory_id?: string;
 	created_by?: string;
 }
@@ -2574,6 +2608,27 @@ export const api = {
 		});
 		if (!response.ok) throw new Error(`API error: ${response.status}`);
 		return response.json() as Promise<TaskResponse>;
+	},
+	listTaskComments: (taskNumber: number, params?: { after?: number; limit?: number }) => {
+		const search = new URLSearchParams();
+		if (params?.after !== undefined) search.set("after", String(params.after));
+		if (params?.limit) search.set("limit", String(params.limit));
+		const query = search.toString();
+		return fetchJson<TaskCommentListResponse>(
+			query ? `/tasks/${taskNumber}/comments?${query}` : `/tasks/${taskNumber}/comments`,
+		);
+	},
+	createTaskComment: async (
+		taskNumber: number,
+		request: CreateTaskCommentRequest,
+	): Promise<TaskCommentResponse> => {
+		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}/comments`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(request),
+		});
+		if (!response.ok) throw new Error(`API error: ${response.status}`);
+		return response.json() as Promise<TaskCommentResponse>;
 	},
 	assignTask: async (taskNumber: number, assignedAgentId: string): Promise<TaskResponse> => {
 		const response = await fetch(`${getApiBase()}/tasks/${taskNumber}/assign`, {

--- a/interface/src/api/schema.d.ts
+++ b/interface/src/api/schema.d.ts
@@ -2487,6 +2487,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tasks/{number}/comments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** `GET /tasks/{number}/comments` — list a task's comments, oldest first. */
+        get: operations["list_task_comments"];
+        put?: never;
+        /** `POST /tasks/{number}/comments` — append a comment to a task. */
+        post: operations["create_task_comment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tasks/{number}/execute": {
         parameters: {
             query?: never;
@@ -3469,11 +3487,22 @@ export interface components {
             path: string;
             remote_url?: string | null;
         };
+        CreateTaskCommentRequest: {
+            author_id?: string | null;
+            /** @description Defaults to `user` — the interface is the human's comment surface. */
+            author_type?: string | null;
+            body: string;
+            metadata?: unknown;
+            /** @description Worker run this comment summarises, when applicable. */
+            worker_id?: string | null;
+        };
         CreateTaskRequest: {
             /** @description Agent assigned to execute. Defaults to `owner_agent_id`. */
             assigned_agent_id?: string | null;
             created_by?: string | null;
             description?: string | null;
+            /** @description Goal this task contributes to. */
+            goal_id?: string | null;
             metadata?: unknown;
             /** @description Agent that owns (created) this task. */
             owner_agent_id: string;
@@ -4569,6 +4598,8 @@ export interface components {
             /** @description Goal this task contributes to, when linked. */
             goal_id?: string | null;
             id: string;
+            /** @description Last time an autonomy run enriched this task. Drives selection order. */
+            last_enriched_at?: string | null;
             metadata: unknown;
             owner_agent_id: string;
             priority: components["schemas"]["TaskPriority"];
@@ -4584,6 +4615,43 @@ export interface components {
         TaskActionResponse: {
             message: string;
             success: boolean;
+        };
+        TaskComment: {
+            author_id?: string | null;
+            author_type: components["schemas"]["TaskCommentAuthor"];
+            body: string;
+            created_at: string;
+            id: string;
+            metadata: unknown;
+            /**
+             * Format: int64
+             * @description Monotonic sequence number. Stable pagination cursor.
+             */
+            seq: number;
+            task_id: string;
+            /** @description Worker run this comment summarises, when it summarises one. */
+            worker_id?: string | null;
+        };
+        /**
+         * @description Who wrote a comment.
+         * @enum {string}
+         */
+        TaskCommentAuthor: "agent" | "user" | "worker";
+        TaskCommentListResponse: {
+            comments: components["schemas"]["TaskComment"][];
+            /**
+             * Format: int64
+             * @description Cursor for the next page, absent when the page is the last one.
+             */
+            next_cursor?: number | null;
+            /**
+             * Format: int64
+             * @description Total comments on the task, independent of this page.
+             */
+            total: number;
+        };
+        TaskCommentResponse: {
+            comment: components["schemas"]["TaskComment"];
         };
         TaskListResponse: {
             tasks: components["schemas"]["Task"][];
@@ -11228,6 +11296,93 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["TaskResponse"];
                 };
+            };
+            /** @description Task not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Task store not initialized */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_task_comments: {
+        parameters: {
+            query?: {
+                /** @description Resume after this comment `seq`. Comments are returned oldest-first. */
+                after?: number | null;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Task number */
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskCommentListResponse"];
+                };
+            };
+            /** @description Task not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Task store not initialized */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    create_task_comment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Task number */
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTaskCommentRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskCommentResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Task not found */
             404: {

--- a/interface/src/components/TaskComments.tsx
+++ b/interface/src/components/TaskComments.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRobot, faUser, faGear, faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import { Badge, Button } from "@spacedrive/primitives";
+import { api, type TaskComment, type TaskCommentAuthor } from "@/api/client";
+import { useLiveContext } from "@/hooks/useLiveContext";
+
+const PAGE_SIZE = 50;
+
+/** Longest comment the backend accepts, in bytes. Mirrors MAX_COMMENT_BODY_BYTES. */
+const MAX_BODY_BYTES = 4000;
+
+const AUTHOR_ICON: Record<TaskCommentAuthor, typeof faUser> = {
+	user: faUser,
+	agent: faRobot,
+	worker: faGear,
+};
+
+const AUTHOR_VARIANT: Record<TaskCommentAuthor, "info" | "success" | "default"> = {
+	user: "info",
+	agent: "success",
+	worker: "default",
+};
+
+function formatTimestamp(value: string): string {
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
+}
+
+/**
+ * A worker-authored or worker-tagged comment links back to the run that
+ * produced it. The body stays the agent's summary; the full output is fetched
+ * only when the user asks for it.
+ */
+function WorkerOutput({ agentId, workerId }: { agentId: string; workerId: string }) {
+	const [expanded, setExpanded] = useState(false);
+
+	const { data, isLoading, error } = useQuery({
+		queryKey: ["worker-detail", agentId, workerId],
+		queryFn: () => api.workerDetail(agentId, workerId),
+		enabled: expanded,
+		staleTime: 60_000,
+	});
+
+	return (
+		<div className="mt-1.5">
+			<button
+				type="button"
+				onClick={() => setExpanded((open) => !open)}
+				className="inline-flex items-center gap-1.5 text-[11px] text-ink-dull hover:text-ink"
+			>
+				<FontAwesomeIcon
+					icon={expanded ? faChevronDown : faChevronRight}
+					className="text-[9px]"
+				/>
+				<Badge variant="default" size="sm">
+					<FontAwesomeIcon icon={faGear} className="text-[10px]" />
+					<span className="font-mono">{workerId.slice(0, 8)}</span>
+				</Badge>
+			</button>
+
+			{expanded && (
+				<div className="mt-1.5 rounded border border-app-line/60 bg-app-box/40 p-2">
+					{isLoading ? (
+						<span className="text-[11px] text-ink-faint">Loading worker output…</span>
+					) : error ? (
+						<span className="text-[11px] text-red-400">
+							Worker run is no longer available.
+						</span>
+					) : (
+						<pre className="max-h-60 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-ink-dull">
+							{data?.result?.trim() || "This worker recorded no output."}
+						</pre>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function CommentRow({
+	comment,
+	agentId,
+	resolveAgentName,
+}: {
+	comment: TaskComment;
+	agentId?: string;
+	resolveAgentName?: (agentId: string) => string;
+}) {
+	const author =
+		comment.author_type === "agent" && comment.author_id
+			? (resolveAgentName?.(comment.author_id) ?? comment.author_id)
+			: comment.author_type === "worker"
+				? "Worker"
+				: (comment.author_id ?? "You");
+
+	return (
+		<li className="border-b border-app-line/40 py-2.5 last:border-b-0">
+			<div className="mb-1 flex items-center gap-2">
+				<Badge variant={AUTHOR_VARIANT[comment.author_type]} size="sm">
+					<FontAwesomeIcon icon={AUTHOR_ICON[comment.author_type]} className="text-[10px]" />
+					<span>{author}</span>
+				</Badge>
+				<span className="text-[10px] text-ink-faint">
+					{formatTimestamp(comment.created_at)}
+				</span>
+			</div>
+			<p className="whitespace-pre-wrap break-words text-xs leading-relaxed text-ink-dull">
+				{comment.body}
+			</p>
+			{comment.worker_id && agentId && (
+				<WorkerOutput agentId={agentId} workerId={comment.worker_id} />
+			)}
+		</li>
+	);
+}
+
+/**
+ * Chronological comment thread for a task, with a composer.
+ *
+ * Comments are append-only: there is no edit or delete affordance because the
+ * store has no such operation. `agentId` enables the worker-output links; it is
+ * the agent the task is assigned to, which is the pool a worker run lives in.
+ */
+export function TaskComments({
+	taskNumber,
+	agentId,
+	resolveAgentName,
+}: {
+	taskNumber: number;
+	agentId?: string;
+	resolveAgentName?: (agentId: string) => string;
+}) {
+	const queryClient = useQueryClient();
+	const { taskEventVersion } = useLiveContext();
+	const queryKey = ["task-comments", taskNumber];
+
+	// A comment from an autonomy run arrives over SSE as a task event.
+	const previousVersion = useRef(taskEventVersion);
+	useEffect(() => {
+		if (taskEventVersion !== previousVersion.current) {
+			previousVersion.current = taskEventVersion;
+			void queryClient.invalidateQueries({ queryKey });
+		}
+	}, [taskEventVersion, queryClient, taskNumber]);
+
+	const { data, isLoading, error } = useQuery({
+		queryKey,
+		queryFn: () => api.listTaskComments(taskNumber, { limit: PAGE_SIZE }),
+	});
+
+	const [draft, setDraft] = useState("");
+
+	const createMutation = useMutation({
+		mutationFn: (body: string) => api.createTaskComment(taskNumber, { body }),
+		onSuccess: () => {
+			setDraft("");
+			void queryClient.invalidateQueries({ queryKey });
+		},
+	});
+
+	const handleSubmit = useCallback(() => {
+		const body = draft.trim();
+		if (body.length < 4 || body.length > MAX_BODY_BYTES) return;
+		createMutation.mutate(body);
+	}, [draft, createMutation]);
+
+	const comments = data?.comments ?? [];
+	const total = data?.total ?? 0;
+	const hasMore = data?.next_cursor !== undefined && data?.next_cursor !== null;
+
+	return (
+		<div className="border-t border-app-line/40 px-4 py-3">
+			<h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-ink-dull">
+				Comments{total > 0 ? ` (${total})` : ""}
+			</h3>
+
+			{isLoading ? (
+				<p className="text-xs text-ink-faint">Loading comments…</p>
+			) : error ? (
+				<p className="text-xs text-red-400">Failed to load comments.</p>
+			) : comments.length === 0 ? (
+				<p className="text-xs text-ink-faint">
+					No comments yet. Findings from autonomy runs land here.
+				</p>
+			) : (
+				<>
+					<ul className="mb-2">
+						{comments.map((comment) => (
+							<CommentRow
+								key={comment.id}
+								comment={comment}
+								agentId={agentId}
+								resolveAgentName={resolveAgentName}
+							/>
+						))}
+					</ul>
+					{hasMore && (
+						<p className="mb-2 text-[11px] text-ink-faint">
+							Showing the first {comments.length} of {total}.
+						</p>
+					)}
+				</>
+			)}
+
+			<div className="mt-2">
+				<textarea
+					value={draft}
+					onChange={(event) => setDraft(event.target.value)}
+					placeholder="Add a comment…"
+					rows={3}
+					maxLength={MAX_BODY_BYTES}
+					className="w-full resize-y rounded border border-app-line bg-app-input px-2 py-1.5 text-xs text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
+				/>
+				<div className="mt-1.5 flex items-center justify-between">
+					<span className="text-[10px] text-ink-faint">
+						{createMutation.isError ? "Failed to post comment." : "Comments are permanent."}
+					</span>
+					<Button
+						size="sm"
+						disabled={draft.trim().length < 4 || createMutation.isPending}
+						onClick={handleSubmit}
+					>
+						{createMutation.isPending ? "Posting…" : "Comment"}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/interface/src/routes/AgentTasks.tsx
+++ b/interface/src/routes/AgentTasks.tsx
@@ -20,6 +20,7 @@ import {
 	GithubMetadataBadges,
 	getGithubReferences,
 } from "@/components/TaskUtils";
+import {TaskComments} from "@/components/TaskComments";
 
 const TASK_LIMIT = 200;
 
@@ -225,6 +226,10 @@ export function AgentTasks({agentId}: {agentId: string}) {
 					{/* GitHub metadata (not part of the shared TaskDetail) */}
 					<GithubSection
 						metadata={(activeTask as unknown as TaskItem).metadata}
+					/>
+					<TaskComments
+						taskNumber={(activeTask as unknown as TaskItem).task_number}
+						agentId={agentId}
 					/>
 				</div>
 			)}

--- a/interface/src/routes/GlobalTasks.tsx
+++ b/interface/src/routes/GlobalTasks.tsx
@@ -26,6 +26,7 @@ import {
 	GithubMetadataBadges,
 	getGithubReferences,
 } from "@/components/TaskUtils";
+import {TaskComments} from "@/components/TaskComments";
 
 const TASK_LIMIT = 200;
 
@@ -313,6 +314,14 @@ export function GlobalTasks() {
 					/>
 					<GithubSection
 						metadata={(activeTask as unknown as TaskItem).metadata}
+					/>
+					<TaskComments
+						taskNumber={(activeTask as unknown as TaskItem).task_number}
+						agentId={
+							(activeTask as unknown as TaskItem).assigned_agent_id ??
+							(activeTask as unknown as TaskItem).owner_agent_id
+						}
+						resolveAgentName={resolveAgentName}
 					/>
 				</div>
 			)}

--- a/migrations/global/20260810000001_task_comments.sql
+++ b/migrations/global/20260810000001_task_comments.sql
@@ -1,0 +1,31 @@
+-- Append-only task comments plus the enrichment cadence timestamp.
+--
+-- Comments are the durable record of what has been investigated or decided on
+-- a task. The task description stays the stable statement of the work itself;
+-- everything learned since lands here, chronologically, never edited.
+
+CREATE TABLE task_comments (
+    -- Monotonic sequence: breaks ties inside a millisecond so chronological
+    -- ordering and cursor pagination are stable across reads.
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    id          TEXT NOT NULL UNIQUE,
+    task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    author_type TEXT NOT NULL,               -- 'agent' | 'user' | 'worker'
+    author_id   TEXT,                        -- agent id, user id, or worker id
+    body        TEXT NOT NULL,
+    worker_id   TEXT,                        -- worker run this comment summarises
+    metadata    TEXT NOT NULL DEFAULT '{}',  -- JSON object
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX task_comments_task ON task_comments(task_id, seq);
+CREATE INDEX task_comments_author ON task_comments(task_id, author_type, created_at);
+
+-- Set every time an autonomy run successfully enriches a task. Drives the
+-- selection ordering: never-enriched first, then stale, with tasks worked in
+-- the previous run held back unless a user has commented since.
+--
+-- Millisecond precision matches task_comments.created_at so the two compare
+-- lexicographically without a format mismatch.
+ALTER TABLE tasks ADD COLUMN last_enriched_at TEXT;
+CREATE INDEX tasks_last_enriched ON tasks(status, last_enriched_at);

--- a/prompts/en/autonomy_channel.md.j2
+++ b/prompts/en/autonomy_channel.md.j2
@@ -24,6 +24,14 @@ Your previous run summaries, newest first. Do not repeat work a recent run alrea
 ## Task State
 {{ task_state }}
 
+{% if enrichment_queue %}
+## Enrichment Queue
+Selected for this run and ordered for you: tasks a user has commented on since your last pass come first, then tasks never enriched, then stale ones. Tasks you worked in your previous run are already filtered out. Comments under each task are what has been found or decided so far — do not repeat that work.
+
+{{ enrichment_queue }}
+Work down this list. You may skip an entry if the goals make something else more valuable, but do not go looking for work that was deliberately held back.
+{% endif %}
+
 {% if active_goals %}
 ## Active Goals
 Background context and direction, not a work queue. Use goals to decide which tasks matter most and what new work is worth proposing.
@@ -45,14 +53,16 @@ Survey the task state above and decide what is most valuable, given the goals an
 Your autonomy level is **observe**: survey and summarize only. You may investigate and read anything, but you must NOT mutate anything — no creating tasks, no updating tasks, no executing work, no writing files. Your output is your `autonomy_complete` summary.
 {% elif level == "suggest" %}
 Your autonomy level is **suggest**: enrich and propose, never execute. You may:
-- **Enrich pending_approval tasks** — investigate (workers, web, files) and record findings in task metadata/updates so the user reviews a fully reasoned brief.
-- **Create new tasks** — propose follow-on work as `pending_approval` tasks{% if claim_unowned %} (you may also pick up unowned pending tasks for enrichment){% endif %}. You propose; the user decides.
+- **Enrich pending_approval tasks** — investigate (workers, web, files) and record each finding with `add_task_comment` so the user reviews a fully reasoned brief. Comments are permanent and append-only; the task description stays as written.
+- **Create new tasks** — propose follow-on work as `pending_approval` tasks with `task_create`, setting `goal_id` when the work serves a goal{% if claim_unowned %} (you may also pick up unowned pending tasks for enrichment){% endif %}. You propose; the user decides.
+- **Record goal progress** — update a goal's `notes` with where it now stands.
 You must NOT execute tasks or make changes beyond task enrichment and proposals.
 {% elif level == "act" %}
 Your autonomy level is **act**: the full loop. You may:
-- **Enrich pending_approval tasks** — investigate and record findings so the user reviews a fully reasoned brief.
+- **Enrich pending_approval tasks** — investigate and record each finding with `add_task_comment` so the user reviews a fully reasoned brief.
 - **Execute ready tasks** — tasks the user has approved. Use your tools directly; spawn workers for genuine parallelism.
-- **Create new tasks** — propose follow-on work as `pending_approval` tasks{% if claim_unowned %} (you may also claim unowned tasks){% endif %}.
+- **Create new tasks** — propose follow-on work as `pending_approval` tasks with `task_create`, setting `goal_id` when the work serves a goal{% if claim_unowned %} (you may also claim unowned tasks){% endif %}.
+- **Record goal progress** — update a goal's `notes` with where it now stands.
 {% else %}
 Treat this run as observe: survey and summarize only. Do not mutate anything — no creating tasks, no updating tasks, no executing work, no writing files.
 {% endif %}
@@ -60,7 +70,8 @@ Treat this run as observe: survey and summarize only. Do not mutate anything —
 Hard rules, regardless of level:
 - Tasks in `pending_approval` are NEVER executed. They are waiting for the user. Enrichment only.
 - Do not message users, create cron jobs, or modify identity/config.
-- You have up to {{ max_tasks_per_run }} task{% if max_tasks_per_run > 1 %}s{% endif %} this run. Depth beats breadth — leave the rest for the next run.
+- Never close or abandon a goal. Note that its linked work is done and leave the decision to the user.
+- You have up to {{ max_tasks_per_run }} task{% if max_tasks_per_run > 1 %}s{% endif %} this run, and `add_task_comment` enforces it — a further task is refused. Depth beats breadth; leave the rest for the next run.
 - Expect a wrap-up notice after about {{ warn_minutes }} minute{% if warn_minutes > 1 %}s{% endif %}. When it arrives, finish what you're doing and complete the run — do not start a new task.
 
 When you are done (or have nothing worth doing), call `autonomy_complete` with a 2-5 line summary and one actions entry per task you enriched, created, or executed. Every run must end with this call.

--- a/prompts/en/tools/add_task_comment_description.md.j2
+++ b/prompts/en/tools/add_task_comment_description.md.j2
@@ -1,0 +1,7 @@
+Append a finding to a task. Comments are permanent and chronological — they are the record of what has been investigated, found, or decided since the task was written.
+
+Write the synthesised conclusion, 2-5 lines. Not a transcript, not a log of what you tried. If a worker produced the finding, pass its `worker_id` and summarise; the full output stays available behind that link instead of being pasted here.
+
+The task description is not yours to rewrite. It states what needs to be done; comments carry everything learned since. Use `task_update` for status, priority, and subtasks.
+
+Commenting on an unassigned task takes ownership of it. If another agent got there first, you will be told — move on to something else.

--- a/src/agent/autonomy.rs
+++ b/src/agent/autonomy.rs
@@ -39,20 +39,71 @@ pub const AUTONOMY_CONTRACT_MAX_RETRIES: usize =
 /// Fallback summary recorded when a run ends without calling `autonomy_complete`.
 pub const AUTONOMY_FALLBACK_SUMMARY: &str = "run ended without summary";
 
+/// The run's allowance of distinct tasks, enforced at the tool boundary.
+///
+/// `max_tasks_per_run` used to live only in the system prompt, where it was a
+/// request rather than a limit. Spending the allowance per task — not per
+/// comment — lets a run keep working something it already started while still
+/// refusing to open a new one.
+#[derive(Debug, Clone)]
+pub struct EnrichmentBudget {
+    max_tasks: u32,
+    touched: Arc<std::sync::Mutex<std::collections::HashSet<i64>>>,
+}
+
+impl EnrichmentBudget {
+    pub fn new(max_tasks: u32) -> Self {
+        Self {
+            max_tasks: max_tasks.max(1),
+            touched: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        }
+    }
+
+    pub fn max_tasks(&self) -> u32 {
+        self.max_tasks
+    }
+
+    /// Reserve this run's allowance for `task_number`. Returns false only when
+    /// the allowance is spent and this is a task the run has not touched.
+    pub fn try_touch(&self, task_number: i64) -> bool {
+        let mut touched = self
+            .touched
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if touched.contains(&task_number) {
+            return true;
+        }
+        if touched.len() >= self.max_tasks as usize {
+            return false;
+        }
+        touched.insert(task_number);
+        true
+    }
+
+    pub fn touched_count(&self) -> usize {
+        self.touched
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+}
+
 /// Shared state between the run driver, the channel, and the
 /// `autonomy_complete` tool for a single autonomy run.
 #[derive(Debug, Clone)]
 pub struct AutonomyRunHandle {
     pub run_id: String,
     pub store: Arc<AutonomyRunStore>,
+    pub budget: EnrichmentBudget,
     completed: Arc<AtomicBool>,
 }
 
 impl AutonomyRunHandle {
-    pub fn new(run_id: String, store: Arc<AutonomyRunStore>) -> Self {
+    pub fn new(run_id: String, store: Arc<AutonomyRunStore>, max_tasks_per_run: u32) -> Self {
         Self {
             run_id,
             store,
+            budget: EnrichmentBudget::new(max_tasks_per_run),
             completed: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -274,7 +325,11 @@ pub async fn run_autonomy_channel(
         ..ResolvedConversationSettings::default()
     };
 
-    let handle = AutonomyRunHandle::new(run_id.clone(), deps.autonomy_run_store.clone());
+    let handle = AutonomyRunHandle::new(
+        run_id.clone(),
+        deps.autonomy_run_store.clone(),
+        config.max_tasks_per_run,
+    );
 
     let screenshot_dir = deps
         .runtime_config
@@ -412,6 +467,42 @@ pub async fn run_autonomy_channel(
         }
     }
 
+    // Goals whose linked work all landed during this run get flagged for the
+    // user. The marker is deterministic rather than prompt-driven, and it
+    // never changes goal status — closing a goal stays the user's call.
+    match crate::goals::mark_goals_ready_for_review(&deps.goal_store).await {
+        Ok(marked) => {
+            for goal in marked {
+                tracing::info!(goal_id = %goal.id, title = %goal.title, "goal flagged ready for review");
+                deps.working_memory
+                    .emit(
+                        crate::memory::WorkingMemoryEventType::Outcome,
+                        format!(
+                            "Goal ready for review: {} — all linked tasks complete",
+                            goal.title
+                        ),
+                    )
+                    .importance(0.6)
+                    .record();
+                crate::wakes::emit_system_event(
+                    deps,
+                    crate::wakes::SystemEvent::GoalUpdated,
+                    &format!("goal:{}", goal.id),
+                    &serde_json::json!({
+                        "goal_id": goal.id,
+                        "title": goal.title,
+                        "status": goal.status.to_string(),
+                        "ready_for_review": true,
+                    }),
+                )
+                .await;
+            }
+        }
+        Err(error) => {
+            tracing::warn!(%error, "failed to flag goals ready for review");
+        }
+    }
+
     // Wake the ready-task pickup so side-effect tasks created during the run
     // (delegations, follow-ups) are noticed promptly. Fired after the channel
     // exits so the one-shot wake actually finds the rows.
@@ -497,12 +588,21 @@ async fn build_run_briefing(
         })
         .collect();
 
-    let run_history_views: Vec<AutonomyRunHistoryView> = deps
+    // This run's own row already exists, so "the previous run" is the newest
+    // one that is no longer running.
+    let previous_runs: Vec<crate::wakes::AutonomyRun> = deps
         .autonomy_run_store
         .recent(config.run_history_count.max(1))
         .await?
         .into_iter()
         .filter(|run| run.status != AutonomyRunStatus::Running)
+        .collect();
+    let last_run_started_at = previous_runs
+        .first()
+        .and_then(|run| crate::wakes::parse_run_timestamp(&run.started_at));
+
+    let run_history_views: Vec<AutonomyRunHistoryView> = previous_runs
+        .into_iter()
         .map(|run| AutonomyRunHistoryView {
             started_at: run.started_at,
             status: run.status.as_str().to_string(),
@@ -514,6 +614,7 @@ async fn build_run_briefing(
         .collect();
 
     let task_state = render_task_state(deps, config.claim_unowned).await?;
+    let enrichment_queue = render_enrichment_queue(deps, config, last_run_started_at).await?;
     let active_goals = crate::goals::render_active_goals_extended(&deps.goal_store).await?;
     let active_workers = render_active_workers(deps).await?;
 
@@ -525,6 +626,7 @@ async fn build_run_briefing(
             wake_event_views,
             run_history_views,
             &task_state,
+            enrichment_queue.as_deref(),
             (!active_goals.is_empty()).then_some(active_goals.as_str()),
             active_workers.as_deref(),
             config.max_tasks_per_run,
@@ -532,6 +634,92 @@ async fn build_run_briefing(
             config.claim_unowned,
         )
         .map_err(|error| anyhow::anyhow!("failed to render autonomy channel prompt: {error}"))
+}
+
+/// Statuses the enrichment loop reasons about. `ready` and `in_progress` are
+/// execution states, handled by the ready-task pickup rather than enrichment.
+const ENRICHABLE_STATUSES: [TaskStatus; 2] = [TaskStatus::PendingApproval, TaskStatus::Backlog];
+
+/// Comments rendered per task in the enrichment queue.
+const QUEUE_COMMENT_LIMIT: i64 = 6;
+
+/// Byte cap on a single rendered comment body.
+const QUEUE_COMMENT_BYTES: usize = 400;
+
+/// Staleness horizon: tasks untouched for this many intervals are back in play.
+const STALE_INTERVAL_MULTIPLIER: i64 = 3;
+
+/// Render the ordered enrichment selection for this run.
+///
+/// This is the deterministic half of task selection — the channel still
+/// reasons about which of these are worth its time, but the ordering, the
+/// staleness horizon, and the previous-run exclusion are settled in SQL
+/// before the model ever sees them.
+async fn render_enrichment_queue(
+    deps: &AgentDeps,
+    config: &AutonomyConfig,
+    last_run_started_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> anyhow::Result<Option<String>> {
+    let now = chrono::Utc::now();
+    let stale_after = chrono::Duration::seconds(
+        (config.interval_secs as i64).saturating_mul(STALE_INTERVAL_MULTIPLIER),
+    );
+    let candidates = deps
+        .task_store
+        .select_for_enrichment(crate::tasks::EnrichmentSelection {
+            agent_id: &deps.agent_id,
+            claim_unowned: config.claim_unowned,
+            statuses: &ENRICHABLE_STATUSES,
+            last_run_started_at: last_run_started_at.map(crate::tasks::sqlite_timestamp),
+            stale_before: crate::tasks::sqlite_timestamp(now - stale_after),
+            // One extra so the channel can see there was more to choose from
+            // than it is allowed to take.
+            limit: i64::from(config.max_tasks_per_run) + 1,
+        })
+        .await?;
+
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let mut output = String::new();
+    for (index, candidate) in candidates.iter().enumerate() {
+        let task = &candidate.task;
+        output.push_str(&format!(
+            "{}. #{} [{}] {} — {}\n",
+            index + 1,
+            task.task_number,
+            task.priority.as_str(),
+            task.title,
+            candidate.reason
+        ));
+
+        let comments = deps
+            .task_store
+            .recent_comments(task.task_number, QUEUE_COMMENT_LIMIT)
+            .await?;
+        for comment in comments {
+            let author = match comment.author_id.as_deref() {
+                Some(author_id) => format!("{} {}", comment.author_type, author_id),
+                None => comment.author_type.to_string(),
+            };
+            output.push_str(&format!(
+                "   - [{} {}] {}\n",
+                author,
+                comment.created_at,
+                crate::tools::truncate_utf8_ellipsis(
+                    &comment
+                        .body
+                        .split_whitespace()
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                    QUEUE_COMMENT_BYTES,
+                )
+            ));
+        }
+    }
+
+    Ok(Some(output))
 }
 
 /// One-line JSON payload preview, truncated for prompt hygiene.
@@ -553,6 +741,8 @@ async fn render_task_state(deps: &AgentDeps, claim_unowned: bool) -> anyhow::Res
         (TaskStatus::InProgress, "In progress"),
         (TaskStatus::Backlog, "Backlog"),
     ];
+
+    let comment_counts = deps.task_store.comment_counts().await?;
 
     let mut output = String::new();
     let mut any = false;
@@ -576,7 +766,8 @@ async fn render_task_state(deps: &AgentDeps, claim_unowned: bool) -> anyhow::Res
         any = true;
         output.push_str(&format!("### {label}\n"));
         for task in visible {
-            output.push_str(&render_task_line(&task, &deps.agent_id));
+            let comments = comment_counts.get(&task.id).copied().unwrap_or(0);
+            output.push_str(&render_task_line(&task, &deps.agent_id, comments));
         }
         output.push('\n');
     }
@@ -587,7 +778,7 @@ async fn render_task_state(deps: &AgentDeps, claim_unowned: bool) -> anyhow::Res
     Ok(output)
 }
 
-fn render_task_line(task: &Task, agent_id: &str) -> String {
+fn render_task_line(task: &Task, agent_id: &str, comment_count: i64) -> String {
     let ownership = match task.assigned_agent_id.as_deref() {
         Some(assigned) if assigned == agent_id => String::new(),
         Some(assigned) => format!(" (assigned to {assigned})"),
@@ -600,6 +791,15 @@ fn render_task_line(task: &Task, agent_id: &str) -> String {
         task.title,
         ownership
     );
+    if comment_count > 0 {
+        line.push_str(&format!(
+            " ({comment_count} comment{})",
+            if comment_count == 1 { "" } else { "s" }
+        ));
+    }
+    if let Some(enriched_at) = &task.last_enriched_at {
+        line.push_str(&format!(" (last enriched {enriched_at})"));
+    }
     if let Some(description) = task
         .description
         .as_deref()
@@ -784,6 +984,7 @@ mod tests {
             created_by: "user".to_string(),
             approved_at: None,
             approved_by: None,
+            last_enriched_at: None,
             created_at: String::new(),
             updated_at: String::new(),
             completed_at: None,

--- a/src/agent/cortex.rs
+++ b/src/agent/cortex.rs
@@ -3911,17 +3911,77 @@ async fn run_ready_task_loop(deps: &AgentDeps, logger: &CortexLogger) -> anyhow:
     }
 }
 
+/// Comments carried into a task worker's briefing.
+const BRIEFING_COMMENT_LIMIT: i64 = 12;
+
+/// Byte cap per comment in the briefing.
+const BRIEFING_COMMENT_BYTES: usize = 600;
+
+/// Total byte cap on the briefing block.
+const BRIEFING_TOTAL_BYTES: usize = 4000;
+
+/// Render a task's accumulated comments as a briefing block for the worker
+/// about to execute it.
+///
+/// This is the continuity the enrichment loop exists to produce: the worker
+/// walks in knowing what was investigated and what the user decided, instead
+/// of re-doing the research. Bounded on both axes — worker transcripts stay
+/// behind their own links and never land here.
+async fn render_task_comment_briefing(deps: &AgentDeps, task_number: i64) -> Option<String> {
+    let comments = match deps
+        .task_store
+        .recent_comments(task_number, BRIEFING_COMMENT_LIMIT)
+        .await
+    {
+        Ok(comments) if !comments.is_empty() => comments,
+        Ok(_) => return None,
+        Err(error) => {
+            tracing::warn!(%error, task_number, "failed to load task comments for worker briefing");
+            return None;
+        }
+    };
+
+    let mut block = String::from(
+        "\n\nPrior findings on this task, oldest first. This is what has already been \
+         investigated or decided — do not redo it.\n",
+    );
+    for comment in comments {
+        let author = match comment.author_id.as_deref() {
+            Some(author_id) => format!("{} {}", comment.author_type, author_id),
+            None => comment.author_type.to_string(),
+        };
+        let line = format!(
+            "- [{} {}] {}\n",
+            author,
+            comment.created_at,
+            crate::tools::truncate_utf8_ellipsis(
+                &comment
+                    .body
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                BRIEFING_COMMENT_BYTES,
+            )
+        );
+        if block.len() + line.len() > BRIEFING_TOTAL_BYTES {
+            block.push_str(
+                "- (earlier comments omitted — read the task board for the full thread)\n",
+            );
+            break;
+        }
+        block.push_str(&line);
+    }
+
+    Some(block)
+}
+
 async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyhow::Result<()> {
     // Ready-task execution is Act-only. Observe and Suggest agents survey and
     // propose but never execute approved work without a user present, and Off
     // disables autonomous pickup entirely. The instance ceiling caps the
     // per-agent dial. See docs/design-docs/autonomy.md.
-    let autonomy_level = deps
-        .runtime_config
-        .autonomy
-        .load()
-        .level
-        .min(**deps.autonomy_ceiling.load());
+    let autonomy = **deps.runtime_config.autonomy.load();
+    let autonomy_level = autonomy.level.min(**deps.autonomy_ceiling.load());
     if !crate::agent::autonomy::ready_pickup_allowed(autonomy_level) {
         tracing::debug!(
             agent_id = %deps.agent_id,
@@ -3931,7 +3991,13 @@ async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyho
         return Ok(());
     }
 
-    let Some(task) = deps.task_store.claim_next_ready(&deps.agent_id).await? else {
+    // Claiming and starting are one guarded UPDATE, so two agents racing for
+    // the same unowned ready task leave one winner and one empty result.
+    let Some(task) = deps
+        .task_store
+        .claim_next_ready(&deps.agent_id, autonomy.claim_unowned)
+        .await?
+    else {
         return Ok(());
     };
 
@@ -4023,6 +4089,9 @@ async fn pickup_one_ready_task(deps: &AgentDeps, logger: &CortexLogger) -> anyho
             let marker = if subtask.completed { "[x]" } else { "[ ]" };
             task_prompt.push_str(&format!("{}. {} {}\n", index + 1, marker, subtask.title));
         }
+    }
+    if let Some(prior_findings) = render_task_comment_briefing(deps, task.task_number).await {
+        task_prompt.push_str(&prior_findings);
     }
 
     let screenshot_dir = deps
@@ -4693,10 +4762,8 @@ mod tests {
     use crate::agent::process_control::ControlActionResult;
     use crate::memory::MemoryType;
     use crate::tasks::TaskStatus;
-    use crate::tasks::TaskStore;
     use futures::FutureExt;
     use futures::future;
-    use sqlx::sqlite::SqlitePoolOptions;
     use std::collections::VecDeque;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
@@ -5557,67 +5624,30 @@ mod tests {
 
     #[tokio::test]
     async fn register_detached_worker_for_pickup_registers_entry_and_updates_task_record() {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .expect("failed to create sqlite memory pool");
-
-        sqlx::query(
-            "CREATE TABLE tasks (
-                id TEXT PRIMARY KEY,
-                task_number INTEGER NOT NULL UNIQUE,
-                title TEXT NOT NULL,
-                description TEXT,
-                status TEXT NOT NULL DEFAULT 'backlog',
-                priority TEXT NOT NULL DEFAULT 'medium',
-                owner_agent_id TEXT NOT NULL,
-                assigned_agent_id TEXT NOT NULL,
-                subtasks TEXT,
-                metadata TEXT,
-                goal_id TEXT,
-                source_memory_id TEXT,
-                worker_id TEXT,
-                created_by TEXT NOT NULL,
-                approved_at TEXT,
-                approved_by TEXT,
-                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                completed_at TEXT
-            )",
-        )
-        .execute(&pool)
-        .await
-        .expect("failed to create tasks table");
-
-        let task_store = TaskStore::new(pool.clone());
+        // The real instance migrations back this fixture so the schema cannot
+        // drift away from what the store queries.
+        let task_store = crate::tasks::store::setup_test_store().await;
         let registry = crate::agent::process_control::ProcessControlRegistry::new();
         let agent_id: crate::AgentId = Arc::from("agent-1");
-        let task_number = 2_i64;
         let worker_id = uuid::Uuid::new_v4();
 
-        sqlx::query(
-            "INSERT INTO tasks (
-                id, task_number, title, description, status, priority,
-                owner_agent_id, assigned_agent_id,
-                subtasks, metadata, source_memory_id, created_by
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(uuid::Uuid::new_v4().to_string())
-        .bind(task_number)
-        .bind("test task")
-        .bind(Some("description".to_string()))
-        .bind("ready")
-        .bind("medium")
-        .bind(&*agent_id)
-        .bind(&*agent_id)
-        .bind("[]")
-        .bind("{}")
-        .bind(Option::<String>::None)
-        .bind("system")
-        .execute(&pool)
-        .await
-        .expect("failed to insert task fixture");
+        let task = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: agent_id.to_string(),
+                assigned_agent_id: Some(agent_id.to_string()),
+                title: "test task".to_string(),
+                description: Some("description".to_string()),
+                status: crate::tasks::TaskStatus::Ready,
+                priority: crate::tasks::TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                goal_id: None,
+                source_memory_id: None,
+                created_by: "system".to_string(),
+            })
+            .await
+            .expect("failed to insert task fixture");
+        let task_number = task.task_number;
 
         let (lifecycle, _cancel_rx) = super::register_detached_worker_for_pickup(
             &registry,
@@ -5642,70 +5672,32 @@ mod tests {
 
     #[tokio::test]
     async fn register_detached_worker_for_pickup_unregisters_control_on_task_update_error() {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect("sqlite::memory:")
-            .await
-            .expect("failed to create sqlite memory pool");
-
-        sqlx::query(
-            "CREATE TABLE tasks (
-                id TEXT PRIMARY KEY,
-                task_number INTEGER NOT NULL UNIQUE,
-                title TEXT NOT NULL,
-                description TEXT,
-                status TEXT NOT NULL DEFAULT 'backlog',
-                priority TEXT NOT NULL DEFAULT 'medium',
-                owner_agent_id TEXT NOT NULL,
-                assigned_agent_id TEXT NOT NULL,
-                subtasks TEXT,
-                metadata TEXT,
-                goal_id TEXT,
-                source_memory_id TEXT,
-                worker_id TEXT,
-                created_by TEXT NOT NULL,
-                approved_at TEXT,
-                approved_by TEXT,
-                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                completed_at TEXT
-            )",
-        )
-        .execute(&pool)
-        .await
-        .expect("failed to create tasks table");
-
-        let task_store = TaskStore::new(pool.clone());
+        let task_store = crate::tasks::store::setup_test_store().await;
         let registry = crate::agent::process_control::ProcessControlRegistry::new();
         let agent_id: crate::AgentId = Arc::from("agent-1");
-        let task_number = 1_i64;
         let worker_id = uuid::Uuid::new_v4();
 
-        sqlx::query(
-            "INSERT INTO tasks (
-                id, task_number, title, description, status, priority,
-                owner_agent_id, assigned_agent_id,
-                subtasks, metadata, source_memory_id, created_by
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(uuid::Uuid::new_v4().to_string())
-        .bind(task_number)
-        .bind("test task")
-        .bind(Some("description".to_string()))
-        .bind("ready")
-        .bind("medium")
-        .bind(&*agent_id)
-        .bind(&*agent_id)
-        .bind("[]")
-        .bind("{}")
-        .bind(Option::<String>::None)
-        .bind("system")
-        .execute(&pool)
-        .await
-        .expect("failed to insert task fixture");
+        let task = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: agent_id.to_string(),
+                assigned_agent_id: Some(agent_id.to_string()),
+                title: "test task".to_string(),
+                description: Some("description".to_string()),
+                status: crate::tasks::TaskStatus::Ready,
+                priority: crate::tasks::TaskPriority::Medium,
+                subtasks: Vec::new(),
+                metadata: serde_json::json!({}),
+                goal_id: None,
+                source_memory_id: None,
+                created_by: "system".to_string(),
+            })
+            .await
+            .expect("failed to insert task fixture");
+        let task_number = task.task_number;
 
+        // Force the task update to fail after the control entry is registered.
         sqlx::query("DROP TABLE tasks")
-            .execute(&pool)
+            .execute(task_store.pool())
             .await
             .expect("failed to drop tasks table");
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -156,6 +156,10 @@ pub fn api_router() -> OpenApiRouter<Arc<ApiState>> {
         .routes(routes!(tasks::approve_task))
         .routes(routes!(tasks::execute_task))
         .routes(routes!(tasks::assign_task))
+        .routes(routes!(
+            tasks::list_task_comments,
+            tasks::create_task_comment
+        ))
         // Wiki routes
         .routes(routes!(wiki::list_pages, wiki::create_page))
         .routes(routes!(wiki::search_pages))

--- a/src/api/tasks.rs
+++ b/src/api/tasks.rs
@@ -48,6 +48,9 @@ pub(super) struct CreateTaskRequest {
     subtasks: Vec<crate::tasks::TaskSubtask>,
     #[serde(default)]
     metadata: Option<serde_json::Value>,
+    /// Goal this task contributes to.
+    #[serde(default)]
+    goal_id: Option<String>,
     #[serde(default)]
     source_memory_id: Option<String>,
     #[serde(default)]
@@ -89,6 +92,44 @@ pub(super) struct AssignRequest {
     assigned_agent_id: String,
 }
 
+#[derive(Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
+pub(super) struct TaskCommentListQuery {
+    /// Resume after this comment `seq`. Comments are returned oldest-first.
+    #[serde(default)]
+    after: Option<i64>,
+    #[serde(default = "default_comment_limit")]
+    limit: i64,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub(super) struct CreateTaskCommentRequest {
+    /// Defaults to `user` — the interface is the human's comment surface.
+    #[serde(default)]
+    author_type: Option<String>,
+    #[serde(default)]
+    author_id: Option<String>,
+    body: String,
+    /// Worker run this comment summarises, when applicable.
+    #[serde(default)]
+    worker_id: Option<String>,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TaskCommentListResponse {
+    pub comments: Vec<crate::tasks::TaskComment>,
+    /// Total comments on the task, independent of this page.
+    pub total: i64,
+    /// Cursor for the next page, absent when the page is the last one.
+    pub next_cursor: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TaskCommentResponse {
+    pub comment: crate::tasks::TaskComment,
+}
+
 #[derive(Serialize, Deserialize, utoipa::ToSchema)]
 pub struct TaskListResponse {
     pub tasks: Vec<crate::tasks::Task>,
@@ -111,6 +152,10 @@ pub struct TaskActionResponse {
 
 fn default_task_limit() -> i64 {
     100
+}
+
+fn default_comment_limit() -> i64 {
+    50
 }
 
 /// Extract the global task store, returning 503 if not yet initialized.
@@ -208,6 +253,38 @@ async fn finish_task_mutation(
         crate::wakes::SystemEvent::TaskApproved,
         &format!("task:{}", task.task_number),
         &payload,
+    )
+    .await;
+}
+
+/// Post-comment fan-out: SSE for the dashboard, plus a `task.commented` wake
+/// routed to the task's agent so a user weighing in pulls the next autonomy
+/// run forward instead of waiting out the interval.
+///
+/// Shared with the `add_task_comment` tool so agent and user comments travel
+/// the same path.
+pub async fn fan_out_task_comment(
+    state: &ApiState,
+    task: &crate::tasks::Task,
+    author_type: crate::tasks::TaskCommentAuthor,
+) {
+    emit_task_event(state, task, "commented");
+
+    let key: crate::AgentId = Arc::from(task.effective_agent_id());
+    let deps = state.wake_registry.read().await.get(&key).cloned();
+    let Some(deps) = deps else {
+        return;
+    };
+
+    crate::wakes::emit_system_event(
+        &deps,
+        crate::wakes::SystemEvent::TaskCommented,
+        &format!("task:{}", task.task_number),
+        &serde_json::json!({
+            "task_number": task.task_number,
+            "title": task.title,
+            "author_type": author_type.as_str(),
+        }),
     )
     .await;
 }
@@ -323,6 +400,7 @@ pub(super) async fn create_task(
             priority,
             subtasks: request.subtasks,
             metadata: request.metadata.unwrap_or_else(|| serde_json::json!({})),
+            goal_id: request.goal_id,
             source_memory_id: request.source_memory_id,
             created_by: request.created_by.unwrap_or_else(|| "human".to_string()),
         })
@@ -576,6 +654,125 @@ pub(super) async fn execute_task(
     )
     .await;
     Ok(Json(TaskResponse { task: update.task }))
+}
+
+/// `GET /tasks/{number}/comments` — list a task's comments, oldest first.
+#[utoipa::path(
+    get,
+    path = "/tasks/{number}/comments",
+    params(
+        ("number" = i64, Path, description = "Task number"),
+        TaskCommentListQuery,
+    ),
+    responses(
+        (status = 200, body = TaskCommentListResponse),
+        (status = 404, description = "Task not found"),
+        (status = 503, description = "Task store not initialized"),
+    ),
+    tag = "tasks",
+)]
+pub(super) async fn list_task_comments(
+    State(state): State<Arc<ApiState>>,
+    Path(number): Path<i64>,
+    Query(query): Query<TaskCommentListQuery>,
+) -> Result<Json<TaskCommentListResponse>, StatusCode> {
+    let store = get_task_store(&state)?;
+
+    // Distinguish "no comments" from "no task" before reading the page.
+    store
+        .get_by_number(number)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, task_number = number, "failed to load task for comments");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let limit = query.limit.clamp(1, crate::tasks::MAX_COMMENT_PAGE);
+    let comments = store
+        .list_comments(number, limit, query.after)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, task_number = number, "failed to list task comments");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let total = store.count_comments(number).await.map_err(|error| {
+        tracing::warn!(%error, task_number = number, "failed to count task comments");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let next_cursor = (comments.len() as i64 == limit)
+        .then(|| comments.last().map(|comment| comment.seq))
+        .flatten();
+
+    Ok(Json(TaskCommentListResponse {
+        comments,
+        total,
+        next_cursor,
+    }))
+}
+
+/// `POST /tasks/{number}/comments` — append a comment to a task.
+#[utoipa::path(
+    post,
+    path = "/tasks/{number}/comments",
+    params(
+        ("number" = i64, Path, description = "Task number"),
+    ),
+    request_body = CreateTaskCommentRequest,
+    responses(
+        (status = 200, body = TaskCommentResponse),
+        (status = 400, description = "Invalid request"),
+        (status = 404, description = "Task not found"),
+        (status = 503, description = "Task store not initialized"),
+    ),
+    tag = "tasks",
+)]
+pub(super) async fn create_task_comment(
+    State(state): State<Arc<ApiState>>,
+    Path(number): Path<i64>,
+    Json(request): Json<CreateTaskCommentRequest>,
+) -> Result<Json<TaskCommentResponse>, StatusCode> {
+    let store = get_task_store(&state)?;
+
+    let author_type = match request.author_type.as_deref() {
+        None => crate::tasks::TaskCommentAuthor::User,
+        Some(value) => {
+            crate::tasks::TaskCommentAuthor::parse(value).ok_or(StatusCode::BAD_REQUEST)?
+        }
+    };
+    crate::tasks::normalize_comment_body(&request.body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let task = store
+        .get_by_number(number)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, task_number = number, "failed to load task for comment");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let comment = store
+        .add_comment(crate::tasks::CreateTaskCommentInput {
+            task_number: number,
+            author_type,
+            author_id: request.author_id,
+            body: request.body,
+            worker_id: request.worker_id,
+            metadata: request.metadata.unwrap_or_else(|| serde_json::json!({})),
+            // A comment arriving through the API is human input. It must not
+            // move the enrichment clock — being commented on is exactly what
+            // pulls a task back to the front of the next run's queue.
+            mark_enriched: false,
+        })
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, task_number = number, "failed to create task comment");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    fan_out_task_comment(&state, &task, author_type).await;
+    Ok(Json(TaskCommentResponse { comment }))
 }
 
 /// `POST /tasks/{number}/assign` — reassign a task to a different agent.

--- a/src/goals.rs
+++ b/src/goals.rs
@@ -60,6 +60,69 @@ fn first_non_empty_line(text: &str) -> Option<&str> {
     text.lines().map(str::trim).find(|line| !line.is_empty())
 }
 
+/// Marker the agent writes onto a goal whose linked work is all done.
+///
+/// It is a signal, not a decision: the goal stays `active` and only the user
+/// closes it. See `docs/design-docs/goals.md`.
+pub const GOAL_READY_FOR_REVIEW_NOTE: &str = "All linked tasks complete — ready for your review.";
+
+/// Flag active goals whose linked tasks have all finished.
+///
+/// Prepends [`GOAL_READY_FOR_REVIEW_NOTE`] to the goal's notes, keeping the
+/// agent's own progress assessment underneath it. Idempotent: a goal already
+/// carrying the marker is left alone, so repeated runs do not churn the row.
+/// Goal status is never touched.
+pub async fn mark_goals_ready_for_review(store: &GoalStore) -> Result<Vec<Goal>> {
+    let goals = store
+        .list(GoalListFilter {
+            status: Some(GoalStatus::Active),
+            limit: None,
+        })
+        .await?;
+
+    let mut marked = Vec::new();
+    for goal in goals {
+        if goal
+            .notes
+            .as_deref()
+            .is_some_and(|notes| notes.trim_start().starts_with(GOAL_READY_FOR_REVIEW_NOTE))
+        {
+            continue;
+        }
+
+        let counts = store.linked_task_counts(&goal.id).await?;
+        // A goal with no tasks has nothing to be done with, and any task that
+        // is not `done` — including `failed` — means work remains.
+        if counts.total() == 0 || counts.done != counts.total() {
+            continue;
+        }
+
+        let notes = match goal
+            .notes
+            .as_deref()
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+        {
+            Some(existing) => format!("{GOAL_READY_FOR_REVIEW_NOTE}\n\n{existing}"),
+            None => GOAL_READY_FOR_REVIEW_NOTE.to_string(),
+        };
+        if let Some(updated) = store
+            .update(
+                &goal.id,
+                UpdateGoalInput {
+                    notes: Some(notes),
+                    ..Default::default()
+                },
+            )
+            .await?
+        {
+            marked.push(updated);
+        }
+    }
+
+    Ok(marked)
+}
+
 /// Render the extended active-goals block for the autonomy channel briefing.
 ///
 /// Unlike the short channel format, this includes each goal's full

--- a/src/goals/store.rs
+++ b/src/goals/store.rs
@@ -778,6 +778,85 @@ mod tests {
         assert!(!rendered.contains("More detail below"));
     }
 
+    /// Insert a task linked to `goal_id` with the given status.
+    async fn linked_task(store: &GoalStore, goal_id: &str, number: i64, status: &str) {
+        sqlx::query(
+            "INSERT INTO tasks (id, task_number, title, status, owner_agent_id, created_by, goal_id) \
+             VALUES (?, ?, ?, ?, 'agent-test', 'autonomy', ?)",
+        )
+        .bind(format!("task-{number}"))
+        .bind(number)
+        .bind(format!("linked task {number}"))
+        .bind(status)
+        .bind(goal_id)
+        .execute(&store.pool)
+        .await
+        .expect("linked task should insert");
+    }
+
+    #[tokio::test]
+    async fn goals_are_flagged_for_review_only_when_every_linked_task_is_done() {
+        let store = setup_test_store().await;
+        let complete = store.create(basic_input("all done")).await.expect("create");
+        let partial = store
+            .create(basic_input("still going"))
+            .await
+            .expect("create");
+        let untouched = store.create(basic_input("no tasks")).await.expect("create");
+        let failing = store
+            .create(basic_input("has a failure"))
+            .await
+            .expect("create");
+
+        linked_task(&store, &complete.id, 1, "done").await;
+        linked_task(&store, &complete.id, 2, "done").await;
+        linked_task(&store, &partial.id, 3, "done").await;
+        linked_task(&store, &partial.id, 4, "in_progress").await;
+        linked_task(&store, &failing.id, 5, "done").await;
+        linked_task(&store, &failing.id, 6, "failed").await;
+
+        store
+            .update(
+                &complete.id,
+                UpdateGoalInput {
+                    notes: Some("Migration finished, docs updated.".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("notes should set");
+
+        let marked = crate::goals::mark_goals_ready_for_review(&store)
+            .await
+            .expect("review pass should succeed");
+        assert_eq!(marked.len(), 1);
+        assert_eq!(marked[0].id, complete.id);
+
+        let notes = marked[0].notes.as_deref().expect("notes should be set");
+        assert!(notes.starts_with(crate::goals::GOAL_READY_FOR_REVIEW_NOTE));
+        assert!(
+            notes.contains("Migration finished, docs updated."),
+            "the agent's own assessment must survive the marker"
+        );
+        // The signal never closes the goal.
+        assert_eq!(marked[0].status, GoalStatus::Active);
+
+        for untouched_goal in [&partial.id, &untouched.id, &failing.id] {
+            let goal = store
+                .get(untouched_goal)
+                .await
+                .expect("get")
+                .expect("goal exists");
+            assert!(goal.notes.is_none(), "only completed goals are flagged");
+        }
+
+        // Running again is a no-op rather than stacking markers.
+        let repeat = crate::goals::mark_goals_ready_for_review(&store)
+            .await
+            .expect("review pass should succeed");
+        assert!(repeat.is_empty());
+    }
+
     #[tokio::test]
     async fn render_active_goals_is_empty_without_active_goals() {
         let store = setup_test_store().await;

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -682,6 +682,7 @@ impl PromptEngine {
         wake_events: Vec<AutonomyWakeEventView>,
         run_history: Vec<AutonomyRunHistoryView>,
         task_state: &str,
+        enrichment_queue: Option<&str>,
         active_goals: Option<&str>,
         active_workers: Option<&str>,
         max_tasks_per_run: u32,
@@ -696,6 +697,7 @@ impl PromptEngine {
                 wake_events => wake_events,
                 run_history => run_history,
                 task_state => task_state,
+                enrichment_queue => enrichment_queue,
                 active_goals => active_goals,
                 active_workers => active_workers,
                 max_tasks_per_run => max_tasks_per_run,
@@ -1126,6 +1128,7 @@ mod tests {
                 wake_events.clone(),
                 run_history.clone(),
                 "### Pending approval\n- #4 [high] Investigate flaky test\n",
+                Some("1. #4 [high] Investigate flaky test — user_engaged\n"),
                 Some("### [HIGH] Ship v2"),
                 None,
                 2,
@@ -1143,6 +1146,8 @@ mod tests {
         assert!(observe.contains("up to 2 tasks this run"));
         assert!(observe.contains("about 8 minutes"));
         assert!(observe.contains("`pending_approval` are NEVER executed"));
+        assert!(observe.contains("## Enrichment Queue"));
+        assert!(observe.contains("user_engaged"));
 
         let act = engine
             .render_autonomy_channel_prompt(
@@ -1153,12 +1158,14 @@ mod tests {
                 "No active tasks.\n",
                 None,
                 None,
+                None,
                 1,
                 1,
                 false,
             )
             .expect("act prompt should render");
         assert!(act.contains("Scheduled interval — no wake events pending."));
+        assert!(!act.contains("## Enrichment Queue"));
         assert!(act.contains("Execute ready tasks"));
         assert!(act.contains("up to 1 task this run"));
         assert!(!act.contains("claim unowned tasks"));
@@ -1171,6 +1178,7 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
                 "No active tasks.\n",
+                None,
                 None,
                 None,
                 1,

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -282,6 +282,9 @@ fn lookup(lang: &str, key: &str) -> &'static str {
         ("en", "tools/task_update") => {
             include_str!("../../prompts/en/tools/task_update_description.md.j2")
         }
+        ("en", "tools/add_task_comment") => {
+            include_str!("../../prompts/en/tools/add_task_comment_description.md.j2")
+        }
         ("en", "tools/goal_create") => {
             include_str!("../../prompts/en/tools/goal_create_description.md.j2")
         }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,8 +1,14 @@
 //! Task tracking data model and storage.
 
+pub mod comments;
 pub mod migration;
 pub mod store;
 
+pub use comments::{
+    CreateTaskCommentInput, EnrichmentCandidate, EnrichmentReason, EnrichmentSelection,
+    MAX_COMMENT_BODY_BYTES, MAX_COMMENT_PAGE, TaskClaim, TaskComment, TaskCommentAuthor,
+    normalize_comment_body, sqlite_timestamp,
+};
 pub use store::{
     CreateTaskInput, Task, TaskListFilter, TaskPriority, TaskStatus, TaskStore, TaskSubtask,
     TaskUpdateResult, UpdateTaskInput, WorkerTaskUpdateResult,

--- a/src/tasks/comments.rs
+++ b/src/tasks/comments.rs
@@ -400,6 +400,12 @@ impl TaskStore {
     /// then never enriched, then stale. Tasks worked during the previous run
     /// are excluded unless a user has commented since — that is what stops a
     /// run from repeating the one before it.
+    ///
+    /// The user-comment comparison is inclusive of the enrichment timestamp.
+    /// Both are millisecond-precision, so a comment landing in the same
+    /// millisecond as the enrichment that preceded it would otherwise be
+    /// swallowed. Erring toward one extra look at the task is the safe
+    /// direction; erring toward dropping a user's input is not.
     pub async fn select_for_enrichment(
         &self,
         selection: EnrichmentSelection<'_>,
@@ -416,7 +422,7 @@ impl TaskStore {
                      SELECT 1 FROM task_comments c \
                      WHERE c.task_id = tasks.id AND c.author_type = 'user' \
                        AND (tasks.last_enriched_at IS NULL \
-                            OR c.created_at > tasks.last_enriched_at) \
+                            OR c.created_at >= tasks.last_enriched_at) \
                  ) AS user_engaged \
                  FROM tasks \
                  WHERE status IN ({status_placeholders}) \

--- a/src/tasks/comments.rs
+++ b/src/tasks/comments.rs
@@ -1,0 +1,1028 @@
+//! Append-only task comments, enrichment cadence, and autonomous claiming.
+//!
+//! Comments live in the same instance database as tasks, so every write that
+//! has to move together — insert a comment and stamp `last_enriched_at`,
+//! delete a task and its comments — happens in one transaction.
+
+use crate::error::Result;
+use crate::tasks::store::{SELECT_COLUMNS, Task, TaskStatus, TaskStore, task_from_row};
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::{Row as _, sqlite::SqliteRow};
+
+/// Longest comment body accepted, in bytes. Comments are synthesised findings,
+/// not transcripts — worker output stays behind the `worker_id` link.
+pub const MAX_COMMENT_BODY_BYTES: usize = 4000;
+
+/// Shortest comment body accepted, in characters after trimming.
+pub const MIN_COMMENT_BODY_CHARS: usize = 4;
+
+/// Hard ceiling on rows returned by a single comment list call.
+pub const MAX_COMMENT_PAGE: i64 = 200;
+
+/// How many enrichment candidates a single selection query scans.
+const ENRICHMENT_SCAN_LIMIT: i64 = 500;
+
+/// Who wrote a comment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskCommentAuthor {
+    /// An agent process — the autonomy channel or a branch.
+    Agent,
+    /// A human, via the API or interface.
+    User,
+    /// A worker reporting on its own run.
+    Worker,
+}
+
+impl TaskCommentAuthor {
+    pub const ALL: [TaskCommentAuthor; 3] = [
+        TaskCommentAuthor::Agent,
+        TaskCommentAuthor::User,
+        TaskCommentAuthor::Worker,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskCommentAuthor::Agent => "agent",
+            TaskCommentAuthor::User => "user",
+            TaskCommentAuthor::Worker => "worker",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "agent" => Some(TaskCommentAuthor::Agent),
+            "user" => Some(TaskCommentAuthor::User),
+            "worker" => Some(TaskCommentAuthor::Worker),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for TaskCommentAuthor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TaskComment {
+    /// Monotonic sequence number. Stable pagination cursor.
+    pub seq: i64,
+    pub id: String,
+    pub task_id: String,
+    pub author_type: TaskCommentAuthor,
+    pub author_id: Option<String>,
+    pub body: String,
+    /// Worker run this comment summarises, when it summarises one.
+    pub worker_id: Option<String>,
+    pub metadata: Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateTaskCommentInput {
+    pub task_number: i64,
+    pub author_type: TaskCommentAuthor,
+    pub author_id: Option<String>,
+    pub body: String,
+    pub worker_id: Option<String>,
+    pub metadata: Value,
+    /// Stamp `tasks.last_enriched_at` in the same transaction. Set for agent
+    /// and worker enrichment; user comments never move the cadence clock,
+    /// because a user weighing in is what pulls a task back into selection.
+    pub mark_enriched: bool,
+}
+
+/// Why a task surfaced in the enrichment selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EnrichmentReason {
+    /// A user commented after the last enrichment pass.
+    UserEngaged,
+    /// Never enriched.
+    NeverEnriched,
+    /// Enriched, but not recently.
+    Stale,
+}
+
+impl EnrichmentReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EnrichmentReason::UserEngaged => "user_engaged",
+            EnrichmentReason::NeverEnriched => "never_enriched",
+            EnrichmentReason::Stale => "stale",
+        }
+    }
+}
+
+impl std::fmt::Display for EnrichmentReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EnrichmentCandidate {
+    pub task: Task,
+    pub reason: EnrichmentReason,
+}
+
+/// Inputs to the enrichment selection query.
+#[derive(Debug, Clone)]
+pub struct EnrichmentSelection<'a> {
+    pub agent_id: &'a str,
+    /// Whether unassigned tasks are visible to this agent.
+    pub claim_unowned: bool,
+    pub statuses: &'a [TaskStatus],
+    /// Start of the most recent autonomy run. Tasks enriched at or after this
+    /// point are held back unless a user has commented since.
+    pub last_run_started_at: Option<String>,
+    /// Tasks enriched before this timestamp count as stale.
+    pub stale_before: String,
+    pub limit: i64,
+}
+
+/// Outcome of an atomic claim attempt.
+#[derive(Debug, Clone)]
+pub enum TaskClaim {
+    /// This call moved the task from unassigned to the requesting agent.
+    Claimed(Box<Task>),
+    /// The task was already assigned to the requesting agent.
+    AlreadyOwned(Box<Task>),
+    /// Another agent holds the task. The caller skips it.
+    OwnedByOther {
+        agent_id: String,
+    },
+    NotFound,
+}
+
+/// Format a UTC instant the way the SQLite stores write timestamps, so
+/// Rust-computed bounds compare lexicographically against stored values.
+pub fn sqlite_timestamp(value: chrono::DateTime<chrono::Utc>) -> String {
+    value.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+}
+
+/// Validate and normalise a comment body.
+pub fn normalize_comment_body(body: &str) -> std::result::Result<String, String> {
+    let trimmed = body.trim();
+    if trimmed.chars().count() < MIN_COMMENT_BODY_CHARS {
+        return Err(format!(
+            "comment body must be at least {MIN_COMMENT_BODY_CHARS} characters"
+        ));
+    }
+    if trimmed.len() > MAX_COMMENT_BODY_BYTES {
+        return Err(format!(
+            "comment body is {} bytes; the limit is {MAX_COMMENT_BODY_BYTES}. Summarise the finding and link the worker instead",
+            trimmed.len()
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+impl TaskStore {
+    /// Append a comment to a task, optionally stamping the enrichment clock.
+    ///
+    /// Fails when the task does not exist. The insert and the
+    /// `last_enriched_at` update share one transaction so a crash can never
+    /// leave a task marked enriched without the comment that enriched it.
+    pub async fn add_comment(&self, input: CreateTaskCommentInput) -> Result<TaskComment> {
+        let body = normalize_comment_body(&input.body).map_err(|message| {
+            crate::error::Error::Other(anyhow::anyhow!("invalid comment: {message}"))
+        })?;
+        let metadata = match input.metadata {
+            Value::Object(_) => input.metadata,
+            _ => Value::Object(serde_json::Map::new()),
+        };
+
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open task comment transaction")?;
+
+        let task_id: Option<String> =
+            sqlx::query_scalar("SELECT id FROM tasks WHERE task_number = ?")
+                .bind(input.task_number)
+                .fetch_optional(&mut *tx)
+                .await
+                .context("failed to resolve task for comment")?;
+        let Some(task_id) = task_id else {
+            return Err(anyhow::anyhow!("task #{} not found", input.task_number).into());
+        };
+
+        let comment_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO task_comments (id, task_id, author_type, author_id, body, worker_id, metadata) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&comment_id)
+        .bind(&task_id)
+        .bind(input.author_type.as_str())
+        .bind(&input.author_id)
+        .bind(&body)
+        .bind(&input.worker_id)
+        .bind(metadata.to_string())
+        .execute(&mut *tx)
+        .await
+        .context("failed to insert task comment")?;
+
+        if input.mark_enriched {
+            sqlx::query(
+                "UPDATE tasks SET last_enriched_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') \
+                 WHERE id = ?",
+            )
+            .bind(&task_id)
+            .execute(&mut *tx)
+            .await
+            .context("failed to stamp task enrichment time")?;
+        }
+
+        let row = sqlx::query(&format!(
+            "{COMMENT_SELECT_COLUMNS} FROM task_comments WHERE id = ?"
+        ))
+        .bind(&comment_id)
+        .fetch_one(&mut *tx)
+        .await
+        .context("failed to read inserted task comment")?;
+
+        tx.commit()
+            .await
+            .context("failed to commit task comment transaction")?;
+
+        comment_from_row(row)
+    }
+
+    /// List a task's comments oldest-first. `after_seq` resumes after a
+    /// previously returned cursor.
+    pub async fn list_comments(
+        &self,
+        task_number: i64,
+        limit: i64,
+        after_seq: Option<i64>,
+    ) -> Result<Vec<TaskComment>> {
+        let mut query = format!(
+            "{COMMENT_SELECT_COLUMNS} FROM task_comments \
+             WHERE task_id = (SELECT id FROM tasks WHERE task_number = ?)"
+        );
+        if after_seq.is_some() {
+            query.push_str(" AND seq > ?");
+        }
+        query.push_str(" ORDER BY seq ASC LIMIT ?");
+
+        let mut sql = sqlx::query(&query).bind(task_number);
+        if let Some(cursor) = after_seq {
+            sql = sql.bind(cursor);
+        }
+        let rows = sql
+            .bind(limit.clamp(1, MAX_COMMENT_PAGE))
+            .fetch_all(self.pool())
+            .await
+            .context("failed to list task comments")?;
+
+        rows.into_iter().map(comment_from_row).collect()
+    }
+
+    /// The most recent `limit` comments on a task, returned oldest-first.
+    ///
+    /// Used by briefing paths that want the tail of the conversation on a
+    /// task rather than the head.
+    pub async fn recent_comments(&self, task_number: i64, limit: i64) -> Result<Vec<TaskComment>> {
+        let rows = sqlx::query(&format!(
+            "SELECT * FROM ({COMMENT_SELECT_COLUMNS} FROM task_comments \
+             WHERE task_id = (SELECT id FROM tasks WHERE task_number = ?) \
+             ORDER BY seq DESC LIMIT ?) ORDER BY seq ASC"
+        ))
+        .bind(task_number)
+        .bind(limit.clamp(1, MAX_COMMENT_PAGE))
+        .fetch_all(self.pool())
+        .await
+        .context("failed to list recent task comments")?;
+
+        rows.into_iter().map(comment_from_row).collect()
+    }
+
+    /// Comment counts for every commented task, keyed by task id. One query,
+    /// so a survey of many tasks does not fan out into one call per task.
+    pub async fn comment_counts(&self) -> Result<std::collections::HashMap<String, i64>> {
+        let rows =
+            sqlx::query("SELECT task_id, COUNT(*) AS count FROM task_comments GROUP BY task_id")
+                .fetch_all(self.pool())
+                .await
+                .context("failed to count comments per task")?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok((
+                    row.try_get("task_id")
+                        .context("failed to read comment count task_id")?,
+                    row.try_get("count")
+                        .context("failed to read comment count")?,
+                ))
+            })
+            .collect()
+    }
+
+    pub async fn count_comments(&self, task_number: i64) -> Result<i64> {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM task_comments \
+             WHERE task_id = (SELECT id FROM tasks WHERE task_number = ?)",
+        )
+        .bind(task_number)
+        .fetch_one(self.pool())
+        .await
+        .context("failed to count task comments")
+        .map_err(Into::into)
+    }
+
+    /// Atomically claim an unassigned task for `agent_id`.
+    ///
+    /// The guarded UPDATE is the whole race: exactly one caller sees a row
+    /// affected, every other caller reads back the winner and skips.
+    pub async fn claim_for_agent(&self, task_number: i64, agent_id: &str) -> Result<TaskClaim> {
+        let mut tx = self
+            .pool()
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open task claim transaction")?;
+
+        let claimed = sqlx::query(
+            "UPDATE tasks SET assigned_agent_id = ?, \
+             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') \
+             WHERE task_number = ? AND assigned_agent_id IS NULL",
+        )
+        .bind(agent_id)
+        .bind(task_number)
+        .execute(&mut *tx)
+        .await
+        .context("failed to claim task")?
+        .rows_affected()
+            > 0;
+
+        let row = sqlx::query(&format!(
+            "{SELECT_COLUMNS} FROM tasks WHERE task_number = ?"
+        ))
+        .bind(task_number)
+        .fetch_optional(&mut *tx)
+        .await
+        .context("failed to read claimed task")?;
+
+        tx.commit()
+            .await
+            .context("failed to commit task claim transaction")?;
+
+        let Some(row) = row else {
+            return Ok(TaskClaim::NotFound);
+        };
+        let task = task_from_row(row)?;
+
+        if claimed {
+            return Ok(TaskClaim::Claimed(Box::new(task)));
+        }
+        match task.assigned_agent_id.as_deref() {
+            Some(owner) if owner == agent_id => Ok(TaskClaim::AlreadyOwned(Box::new(task))),
+            Some(owner) => Ok(TaskClaim::OwnedByOther {
+                agent_id: owner.to_string(),
+            }),
+            // The guarded UPDATE only misses an unassigned row when another
+            // writer assigned and unassigned it between the two statements,
+            // which the IMMEDIATE transaction rules out.
+            None => Ok(TaskClaim::AlreadyOwned(Box::new(task))),
+        }
+    }
+
+    /// Ordered enrichment candidates for an autonomy run.
+    ///
+    /// Priority, highest first: a user commented since the last enrichment,
+    /// then never enriched, then stale. Tasks worked during the previous run
+    /// are excluded unless a user has commented since — that is what stops a
+    /// run from repeating the one before it.
+    pub async fn select_for_enrichment(
+        &self,
+        selection: EnrichmentSelection<'_>,
+    ) -> Result<Vec<EnrichmentCandidate>> {
+        if selection.statuses.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let status_placeholders = vec!["?"; selection.statuses.len()].join(", ");
+        let query = format!(
+            "SELECT * FROM ( \
+                 {SELECT_COLUMNS}, \
+                 EXISTS ( \
+                     SELECT 1 FROM task_comments c \
+                     WHERE c.task_id = tasks.id AND c.author_type = 'user' \
+                       AND (tasks.last_enriched_at IS NULL \
+                            OR c.created_at > tasks.last_enriched_at) \
+                 ) AS user_engaged \
+                 FROM tasks \
+                 WHERE status IN ({status_placeholders}) \
+                   AND (assigned_agent_id = ? OR (assigned_agent_id IS NULL AND ?)) \
+                 LIMIT {ENRICHMENT_SCAN_LIMIT} \
+             ) \
+             WHERE user_engaged = 1 \
+                OR last_enriched_at IS NULL \
+                OR (last_enriched_at < ? AND (? IS NULL OR last_enriched_at <= ?)) \
+             ORDER BY \
+                 CASE WHEN user_engaged = 1 THEN 0 \
+                      WHEN last_enriched_at IS NULL THEN 1 \
+                      ELSE 2 END ASC, \
+                 CASE priority \
+                     WHEN 'critical' THEN 0 \
+                     WHEN 'high' THEN 1 \
+                     WHEN 'medium' THEN 2 \
+                     WHEN 'low' THEN 3 \
+                     ELSE 4 END ASC, \
+                 COALESCE(last_enriched_at, '') ASC, \
+                 task_number ASC \
+             LIMIT ?"
+        );
+
+        let mut sql = sqlx::query(&query);
+        for status in selection.statuses {
+            sql = sql.bind(status.as_str());
+        }
+        let rows = sql
+            .bind(selection.agent_id)
+            .bind(selection.claim_unowned)
+            .bind(&selection.stale_before)
+            .bind(&selection.last_run_started_at)
+            .bind(&selection.last_run_started_at)
+            .bind(selection.limit.clamp(1, ENRICHMENT_SCAN_LIMIT))
+            .fetch_all(self.pool())
+            .await
+            .context("failed to select enrichment candidates")?;
+
+        rows.into_iter()
+            .map(|row| {
+                let user_engaged: bool = row
+                    .try_get("user_engaged")
+                    .context("failed to read enrichment engagement flag")?;
+                let task = task_from_row(row)?;
+                let reason = if user_engaged {
+                    EnrichmentReason::UserEngaged
+                } else if task.last_enriched_at.is_none() {
+                    EnrichmentReason::NeverEnriched
+                } else {
+                    EnrichmentReason::Stale
+                };
+                Ok(EnrichmentCandidate { task, reason })
+            })
+            .collect()
+    }
+}
+
+/// Column list used by all comment SELECT queries. Kept in sync with
+/// [`comment_from_row`].
+const COMMENT_SELECT_COLUMNS: &str =
+    "SELECT seq, id, task_id, author_type, author_id, body, worker_id, metadata, created_at";
+
+fn comment_from_row(row: SqliteRow) -> Result<TaskComment> {
+    let author_value: String = row
+        .try_get("author_type")
+        .context("failed to read comment author_type")?;
+    let author_type = TaskCommentAuthor::parse(&author_value)
+        .with_context(|| format!("invalid comment author type in database: {author_value}"))?;
+    let metadata_value: String = row.try_get("metadata").unwrap_or_else(|_| "{}".to_string());
+
+    Ok(TaskComment {
+        seq: row.try_get("seq").context("failed to read comment seq")?,
+        id: row.try_get("id").context("failed to read comment id")?,
+        task_id: row
+            .try_get("task_id")
+            .context("failed to read comment task_id")?,
+        author_type,
+        author_id: row
+            .try_get::<Option<String>, _>("author_id")
+            .ok()
+            .flatten()
+            .filter(|value| !value.is_empty()),
+        body: row.try_get("body").context("failed to read comment body")?,
+        worker_id: row
+            .try_get::<Option<String>, _>("worker_id")
+            .ok()
+            .flatten()
+            .filter(|value| !value.is_empty()),
+        metadata: serde_json::from_str(&metadata_value)
+            .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+        created_at: row
+            .try_get("created_at")
+            .context("failed to read comment created_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::store::{
+        CreateTaskInput, TaskListFilter, TaskPriority, UpdateTaskInput, setup_test_store,
+    };
+
+    fn agent_comment(task_number: i64, body: &str) -> CreateTaskCommentInput {
+        CreateTaskCommentInput {
+            task_number,
+            author_type: TaskCommentAuthor::Agent,
+            author_id: Some("agent-test".to_string()),
+            body: body.to_string(),
+            worker_id: None,
+            metadata: serde_json::json!({}),
+            mark_enriched: true,
+        }
+    }
+
+    fn user_comment(task_number: i64, body: &str) -> CreateTaskCommentInput {
+        CreateTaskCommentInput {
+            author_type: TaskCommentAuthor::User,
+            author_id: Some("jamie".to_string()),
+            mark_enriched: false,
+            ..agent_comment(task_number, body)
+        }
+    }
+
+    fn task_input(title: &str, assigned: Option<&str>, status: TaskStatus) -> CreateTaskInput {
+        CreateTaskInput {
+            owner_agent_id: "agent-test".to_string(),
+            assigned_agent_id: assigned.map(str::to_string),
+            title: title.to_string(),
+            description: None,
+            status,
+            priority: TaskPriority::Medium,
+            subtasks: Vec::new(),
+            metadata: serde_json::json!({}),
+            goal_id: None,
+            source_memory_id: None,
+            created_by: "autonomy".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn comments_are_chronological_and_paginate_by_seq() {
+        let store = setup_test_store().await;
+        let task = store
+            .create(task_input(
+                "commented",
+                Some("agent-test"),
+                TaskStatus::Ready,
+            ))
+            .await
+            .expect("task should be created");
+
+        for index in 0..5 {
+            store
+                .add_comment(agent_comment(
+                    task.task_number,
+                    &format!("finding number {index}"),
+                ))
+                .await
+                .expect("comment should insert");
+        }
+
+        let first_page = store
+            .list_comments(task.task_number, 2, None)
+            .await
+            .expect("list should succeed");
+        assert_eq!(first_page.len(), 2);
+        assert_eq!(first_page[0].body, "finding number 0");
+        assert_eq!(first_page[1].body, "finding number 1");
+
+        let second_page = store
+            .list_comments(task.task_number, 2, Some(first_page[1].seq))
+            .await
+            .expect("list should succeed");
+        assert_eq!(second_page.len(), 2);
+        assert_eq!(second_page[0].body, "finding number 2");
+        assert!(second_page[0].seq > first_page[1].seq);
+
+        let tail = store
+            .recent_comments(task.task_number, 2)
+            .await
+            .expect("recent should succeed");
+        assert_eq!(tail.len(), 2);
+        assert_eq!(tail[0].body, "finding number 3");
+        assert_eq!(tail[1].body, "finding number 4");
+
+        assert_eq!(
+            store
+                .count_comments(task.task_number)
+                .await
+                .expect("count should succeed"),
+            5
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_comment_stamps_enrichment_and_user_comment_does_not() {
+        let store = setup_test_store().await;
+        let task = store
+            .create(task_input("cadence", Some("agent-test"), TaskStatus::Ready))
+            .await
+            .expect("task should be created");
+        assert!(task.last_enriched_at.is_none());
+
+        store
+            .add_comment(user_comment(task.task_number, "please look at the retries"))
+            .await
+            .expect("user comment should insert");
+        let after_user = store
+            .get_by_number(task.task_number)
+            .await
+            .expect("load")
+            .expect("task exists");
+        assert!(
+            after_user.last_enriched_at.is_none(),
+            "user comments must not move the enrichment clock"
+        );
+
+        store
+            .add_comment(agent_comment(task.task_number, "retries are exponential"))
+            .await
+            .expect("agent comment should insert");
+        let after_agent = store
+            .get_by_number(task.task_number)
+            .await
+            .expect("load")
+            .expect("task exists");
+        assert!(after_agent.last_enriched_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_task_and_out_of_bounds_bodies() {
+        let store = setup_test_store().await;
+        let task = store
+            .create(task_input("bounds", Some("agent-test"), TaskStatus::Ready))
+            .await
+            .expect("task should be created");
+
+        let missing = store
+            .add_comment(agent_comment(9999, "a finding on a ghost"))
+            .await
+            .expect_err("missing task must fail");
+        assert!(missing.to_string().contains("not found"));
+
+        let too_short = store
+            .add_comment(agent_comment(task.task_number, "  x "))
+            .await
+            .expect_err("short body must fail");
+        assert!(too_short.to_string().contains("at least"));
+
+        let too_long = store
+            .add_comment(agent_comment(
+                task.task_number,
+                &"x".repeat(MAX_COMMENT_BODY_BYTES + 1),
+            ))
+            .await
+            .expect_err("oversized body must fail");
+        assert!(too_long.to_string().contains("limit is"));
+    }
+
+    #[tokio::test]
+    async fn deleting_a_task_removes_its_comments() {
+        let store = setup_test_store().await;
+        let task = store
+            .create(task_input("doomed", Some("agent-test"), TaskStatus::Ready))
+            .await
+            .expect("task should be created");
+        store
+            .add_comment(agent_comment(task.task_number, "about to be orphaned"))
+            .await
+            .expect("comment should insert");
+
+        assert!(
+            store
+                .delete(task.task_number)
+                .await
+                .expect("delete should succeed")
+        );
+
+        let orphans: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM task_comments")
+            .fetch_one(store.pool())
+            .await
+            .expect("count should succeed");
+        assert_eq!(orphans, 0, "task deletion must cascade to comments");
+    }
+
+    #[tokio::test]
+    async fn concurrent_claims_produce_one_winner() {
+        let store = setup_test_store().await;
+        let task = store
+            .create(task_input("unowned", None, TaskStatus::PendingApproval))
+            .await
+            .expect("task should be created");
+
+        let first = store.clone();
+        let second = store.clone();
+        let number = task.task_number;
+        let (left, right) = tokio::join!(
+            tokio::spawn(async move { first.claim_for_agent(number, "agent-a").await }),
+            tokio::spawn(async move { second.claim_for_agent(number, "agent-b").await }),
+        );
+
+        let outcomes = [
+            left.expect("join").expect("claim should succeed"),
+            right.expect("join").expect("claim should succeed"),
+        ];
+        let winners = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, TaskClaim::Claimed(_)))
+            .count();
+        let losers = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, TaskClaim::OwnedByOther { .. }))
+            .count();
+        assert_eq!(winners, 1, "exactly one claimant may win");
+        assert_eq!(losers, 1, "the loser must get a clean skip");
+
+        let claimed = store
+            .get_by_number(number)
+            .await
+            .expect("load")
+            .expect("task exists");
+        assert!(claimed.assigned_agent_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn claim_is_idempotent_and_respects_existing_assignment() {
+        let store = setup_test_store().await;
+        let mine = store
+            .create(task_input("mine", Some("agent-a"), TaskStatus::Ready))
+            .await
+            .expect("task should be created");
+        let theirs = store
+            .create(task_input("theirs", Some("agent-b"), TaskStatus::Ready))
+            .await
+            .expect("task should be created");
+
+        assert!(matches!(
+            store
+                .claim_for_agent(mine.task_number, "agent-a")
+                .await
+                .expect("claim should succeed"),
+            TaskClaim::AlreadyOwned(_)
+        ));
+        assert!(matches!(
+            store
+                .claim_for_agent(theirs.task_number, "agent-a")
+                .await
+                .expect("claim should succeed"),
+            TaskClaim::OwnedByOther { .. }
+        ));
+        assert!(matches!(
+            store
+                .claim_for_agent(9999, "agent-a")
+                .await
+                .expect("claim should succeed"),
+            TaskClaim::NotFound
+        ));
+    }
+
+    fn selection<'a>(
+        statuses: &'a [TaskStatus],
+        last_run_started_at: Option<String>,
+        stale_before: String,
+    ) -> EnrichmentSelection<'a> {
+        EnrichmentSelection {
+            agent_id: "agent-test",
+            claim_unowned: true,
+            statuses,
+            last_run_started_at,
+            stale_before,
+            limit: 10,
+        }
+    }
+
+    #[tokio::test]
+    async fn selection_orders_user_engaged_then_never_enriched_then_stale() {
+        let store = setup_test_store().await;
+        let statuses = [TaskStatus::PendingApproval];
+
+        let engaged = store
+            .create(task_input(
+                "engaged",
+                Some("agent-test"),
+                TaskStatus::PendingApproval,
+            ))
+            .await
+            .expect("create");
+        let fresh = store
+            .create(task_input(
+                "never enriched",
+                Some("agent-test"),
+                TaskStatus::PendingApproval,
+            ))
+            .await
+            .expect("create");
+        let stale = store
+            .create(task_input(
+                "stale",
+                Some("agent-test"),
+                TaskStatus::PendingApproval,
+            ))
+            .await
+            .expect("create");
+
+        // Enrich two tasks in the distant past, then have a user comment on
+        // one of them afterwards.
+        for number in [engaged.task_number, stale.task_number] {
+            sqlx::query("UPDATE tasks SET last_enriched_at = ? WHERE task_number = ?")
+                .bind("2020-01-01T00:00:00.000Z")
+                .bind(number)
+                .execute(store.pool())
+                .await
+                .expect("backdate enrichment");
+        }
+        store
+            .add_comment(user_comment(engaged.task_number, "one more thing"))
+            .await
+            .expect("user comment");
+
+        let candidates = store
+            .select_for_enrichment(selection(
+                &statuses,
+                Some("2026-01-01T00:00:00.000Z".to_string()),
+                "2025-01-01T00:00:00.000Z".to_string(),
+            ))
+            .await
+            .expect("selection should succeed");
+
+        let ordered: Vec<(i64, EnrichmentReason)> = candidates
+            .iter()
+            .map(|candidate| (candidate.task.task_number, candidate.reason))
+            .collect();
+        assert_eq!(
+            ordered,
+            vec![
+                (engaged.task_number, EnrichmentReason::UserEngaged),
+                (fresh.task_number, EnrichmentReason::NeverEnriched),
+                (stale.task_number, EnrichmentReason::Stale),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn selection_excludes_work_from_the_previous_run() {
+        let store = setup_test_store().await;
+        let statuses = [TaskStatus::PendingApproval];
+        let task = store
+            .create(task_input(
+                "just worked",
+                Some("agent-test"),
+                TaskStatus::PendingApproval,
+            ))
+            .await
+            .expect("create");
+
+        store
+            .add_comment(agent_comment(task.task_number, "enriched during this run"))
+            .await
+            .expect("agent comment");
+
+        let last_run = Some("2020-01-01T00:00:00.000Z".to_string());
+        let stale_before = "2020-01-01T00:00:00.000Z".to_string();
+        let candidates = store
+            .select_for_enrichment(selection(&statuses, last_run.clone(), stale_before.clone()))
+            .await
+            .expect("selection should succeed");
+        assert!(
+            candidates.is_empty(),
+            "a task enriched after the last run start must not resurface"
+        );
+
+        // A user weighing in clears the exclusion.
+        store
+            .add_comment(user_comment(task.task_number, "actually, reconsider this"))
+            .await
+            .expect("user comment");
+        let candidates = store
+            .select_for_enrichment(selection(&statuses, last_run, stale_before))
+            .await
+            .expect("selection should succeed");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].reason, EnrichmentReason::UserEngaged);
+    }
+
+    #[tokio::test]
+    async fn selection_respects_assignment_and_claim_unowned() {
+        let store = setup_test_store().await;
+        let statuses = [TaskStatus::PendingApproval];
+        store
+            .create(task_input(
+                "someone else's",
+                Some("agent-other"),
+                TaskStatus::PendingApproval,
+            ))
+            .await
+            .expect("create");
+        let unowned = store
+            .create(task_input("unowned", None, TaskStatus::PendingApproval))
+            .await
+            .expect("create");
+
+        let stale_before = "2020-01-01T00:00:00.000Z".to_string();
+        let with_claim = store
+            .select_for_enrichment(selection(&statuses, None, stale_before.clone()))
+            .await
+            .expect("selection should succeed");
+        assert_eq!(with_claim.len(), 1);
+        assert_eq!(with_claim[0].task.task_number, unowned.task_number);
+
+        let without_claim = store
+            .select_for_enrichment(EnrichmentSelection {
+                claim_unowned: false,
+                ..selection(&statuses, None, stale_before)
+            })
+            .await
+            .expect("selection should succeed");
+        assert!(
+            without_claim.is_empty(),
+            "unowned tasks are invisible when claim_unowned is off"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_next_ready_can_take_unowned_work() {
+        let store = setup_test_store().await;
+        store
+            .create(task_input("unowned ready", None, TaskStatus::Ready))
+            .await
+            .expect("create");
+
+        assert!(
+            store
+                .claim_next_ready("agent-test", false)
+                .await
+                .expect("claim should succeed")
+                .is_none(),
+            "unowned work stays untouched when claim_unowned is off"
+        );
+
+        let claimed = store
+            .claim_next_ready("agent-test", true)
+            .await
+            .expect("claim should succeed")
+            .expect("unowned ready task should be claimed");
+        assert_eq!(claimed.status, TaskStatus::InProgress);
+        assert_eq!(claimed.assigned_agent_id.as_deref(), Some("agent-test"));
+
+        let remaining = store
+            .list(TaskListFilter {
+                status: Some(TaskStatus::Ready),
+                ..Default::default()
+            })
+            .await
+            .expect("list should succeed");
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn goal_id_survives_create_and_reassignment() {
+        let store = setup_test_store().await;
+        let goal_id = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO goals (id, title) VALUES (?, 'Ship the enrichment loop')")
+            .bind(&goal_id)
+            .execute(store.pool())
+            .await
+            .expect("goal should insert");
+
+        let task = store
+            .create(CreateTaskInput {
+                goal_id: Some(goal_id.clone()),
+                ..task_input(
+                    "goal linked",
+                    Some("agent-test"),
+                    TaskStatus::PendingApproval,
+                )
+            })
+            .await
+            .expect("create");
+        assert_eq!(task.goal_id.as_deref(), Some(goal_id.as_str()));
+
+        let updated = store
+            .update(
+                task.task_number,
+                UpdateTaskInput {
+                    assigned_agent_id: Some("agent-other".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("update should succeed")
+            .expect("task exists");
+        assert_eq!(updated.goal_id.as_deref(), Some(goal_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_an_unknown_goal_link() {
+        let store = setup_test_store().await;
+        let error = store
+            .create(CreateTaskInput {
+                goal_id: Some("no-such-goal".to_string()),
+                ..task_input("dangling", Some("agent-test"), TaskStatus::PendingApproval)
+            })
+            .await
+            .expect_err("a task cannot link to a goal that does not exist");
+        assert!(error.to_string().contains("FOREIGN KEY"));
+    }
+}

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -868,19 +868,28 @@ fn read_optional_timestamp(row: &sqlx::sqlite::SqliteRow, column: &str) -> Optio
 
 #[cfg(test)]
 pub(crate) async fn setup_test_store() -> TaskStore {
-    // A uniquely named shared-cache in-memory database: isolated per test, but
-    // reachable from several pool connections so concurrency tests are real.
-    let url = format!(
-        "sqlite:file:tasks-test-{}?mode=memory&cache=shared",
-        uuid::Uuid::new_v4()
-    );
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
+
+    // A file-backed database in a temp directory, matching how the instance
+    // store actually runs. An in-memory database would need `cache=shared` to
+    // be reachable from more than one connection, and shared-cache SQLite
+    // raises SQLITE_LOCKED on contention — which `busy_timeout` does not
+    // retry — so the concurrency tests would flake on an artifact that no
+    // deployment can hit.
+    let directory = tempfile::tempdir().expect("temp dir should be created");
+    let options = SqliteConnectOptions::new()
+        .filename(directory.path().join("tasks.db"))
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Off)
+        .busy_timeout(std::time::Duration::from_secs(10));
+
     let pool = sqlx::sqlite::SqlitePoolOptions::new()
         .min_connections(1)
         .max_connections(4)
-        .idle_timeout(None)
-        .connect(&url)
+        .connect_with(options)
         .await
-        .expect("in-memory sqlite should connect");
+        .expect("test sqlite should connect");
 
     // Run the real instance migrations so the test schema can never drift from
     // what ships — including task_comments and last_enriched_at.
@@ -888,6 +897,11 @@ pub(crate) async fn setup_test_store() -> TaskStore {
         .run(&pool)
         .await
         .expect("global migrations should run");
+
+    // The directory has to outlive the pool, and the store owns no place to
+    // put it. Tests are short-lived processes and each database is a few
+    // hundred kilobytes, so the handle is released to the OS temp sweeper.
+    std::mem::forget(directory);
 
     TaskStore::new(pool)
 }

--- a/src/tasks/store.rs
+++ b/src/tasks/store.rs
@@ -9,8 +9,6 @@ use anyhow::Context as _;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-#[cfg(test)]
-use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Row as _, SqlitePool};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -132,6 +130,8 @@ pub struct Task {
     pub created_by: String,
     pub approved_at: Option<String>,
     pub approved_by: Option<String>,
+    /// Last time an autonomy run enriched this task. Drives selection order.
+    pub last_enriched_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub completed_at: Option<String>,
@@ -157,6 +157,8 @@ pub struct CreateTaskInput {
     pub priority: TaskPriority,
     pub subtasks: Vec<TaskSubtask>,
     pub metadata: Value,
+    /// Goal this task contributes to, when created from one.
+    pub goal_id: Option<String>,
     pub source_memory_id: Option<String>,
     pub created_by: String,
 }
@@ -214,7 +216,6 @@ impl TaskStore {
         Self { pool }
     }
 
-    #[cfg(test)]
     pub(crate) fn pool(&self) -> &SqlitePool {
         &self.pool
     }
@@ -252,9 +253,9 @@ impl TaskStore {
                 INSERT INTO tasks (
                     id, task_number, title, description, status, priority,
                     owner_agent_id, assigned_agent_id,
-                    subtasks, metadata, source_memory_id, created_by
+                    subtasks, metadata, goal_id, source_memory_id, created_by
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
             )
             .bind(&task_id)
@@ -267,6 +268,7 @@ impl TaskStore {
             .bind(&input.assigned_agent_id)
             .bind(&subtasks_json)
             .bind(&metadata_json)
+            .bind(&input.goal_id)
             .bind(&input.source_memory_id)
             .bind(&input.created_by)
             .execute(&mut *tx)
@@ -605,21 +607,54 @@ impl TaskStore {
         task_from_row(updated)
     }
 
+    /// Delete a task and everything hanging off it.
+    ///
+    /// The comment delete is explicit as well as declared `ON DELETE CASCADE`,
+    /// because the cascade only fires when the connection has
+    /// `PRAGMA foreign_keys` on — a connection setting this store does not own.
     pub async fn delete(&self, task_number: i64) -> Result<bool> {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open task delete transaction")?;
+
+        sqlx::query(
+            "DELETE FROM task_comments \
+             WHERE task_id = (SELECT id FROM tasks WHERE task_number = ?)",
+        )
+        .bind(task_number)
+        .execute(&mut *tx)
+        .await
+        .context("failed to delete task comments")?;
+
         let result = sqlx::query("DELETE FROM tasks WHERE task_number = ?")
             .bind(task_number)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await
             .context("failed to delete task")?;
+
+        tx.commit()
+            .await
+            .context("failed to commit task delete transaction")?;
 
         Ok(result.rows_affected() > 0)
     }
 
-    /// Atomically claim the highest-priority ready task assigned to the given
-    /// agent. Moves it to `in_progress` and returns it.
-    pub async fn claim_next_ready(&self, assigned_agent_id: &str) -> Result<Option<Task>> {
+    /// Atomically claim the highest-priority ready task this agent may run.
+    ///
+    /// With `claim_unowned` set, unassigned ready work is in scope and the
+    /// guarded UPDATE takes assignment and `in_progress` together, so a race
+    /// between agents leaves exactly one winner.
+    pub async fn claim_next_ready(
+        &self,
+        agent_id: &str,
+        claim_unowned: bool,
+    ) -> Result<Option<Task>> {
         let row = sqlx::query(
-            "SELECT task_number FROM tasks WHERE assigned_agent_id = ? AND status = 'ready' \
+            "SELECT task_number FROM tasks \
+             WHERE status = 'ready' \
+               AND (assigned_agent_id = ? OR (assigned_agent_id IS NULL AND ?)) \
              ORDER BY CASE priority \
                WHEN 'critical' THEN 0 \
                WHEN 'high' THEN 1 \
@@ -629,7 +664,8 @@ impl TaskStore {
              task_number ASC \
              LIMIT 1",
         )
-        .bind(assigned_agent_id)
+        .bind(agent_id)
+        .bind(claim_unowned)
         .fetch_optional(&self.pool)
         .await
         .context("failed to find ready task")?;
@@ -642,11 +678,15 @@ impl TaskStore {
             .try_get("task_number")
             .context("failed to read task_number from ready task row")?;
         let result = sqlx::query(
-            "UPDATE tasks SET status = 'in_progress', \
+            "UPDATE tasks SET status = 'in_progress', assigned_agent_id = ?, \
              updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') \
-             WHERE task_number = ? AND status = 'ready'",
+             WHERE task_number = ? AND status = 'ready' \
+               AND (assigned_agent_id = ? OR (assigned_agent_id IS NULL AND ?))",
         )
+        .bind(agent_id)
         .bind(task_number)
+        .bind(agent_id)
+        .bind(claim_unowned)
         .execute(&self.pool)
         .await
         .context("failed to claim ready task")?;
@@ -672,9 +712,9 @@ impl TaskStore {
 }
 
 /// Column list used by all SELECT queries. Kept in sync with `task_from_row`.
-const SELECT_COLUMNS: &str = "SELECT id, task_number, title, description, status, priority, \
+pub(crate) const SELECT_COLUMNS: &str = "SELECT id, task_number, title, description, status, priority, \
      owner_agent_id, assigned_agent_id, subtasks, metadata, goal_id, source_memory_id, worker_id, \
-     created_by, approved_at, approved_by, created_at, updated_at, completed_at";
+     created_by, approved_at, approved_by, last_enriched_at, created_at, updated_at, completed_at";
 
 pub fn can_transition(current: TaskStatus, next: TaskStatus) -> bool {
     if current == next {
@@ -744,7 +784,7 @@ fn parse_metadata(value: &str) -> Value {
     serde_json::from_str(value).unwrap_or_else(|_| Value::Object(serde_json::Map::new()))
 }
 
-fn task_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Task> {
+pub(crate) fn task_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Task> {
     let status_value: String = row
         .try_get("status")
         .context("failed to read task status")?;
@@ -794,6 +834,7 @@ fn task_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Task> {
             .context("failed to read task created_by")?,
         approved_at: read_optional_timestamp(&row, "approved_at"),
         approved_by: row.try_get("approved_by").ok(),
+        last_enriched_at: read_optional_timestamp(&row, "last_enriched_at"),
         created_at,
         updated_at,
         completed_at: read_optional_timestamp(&row, "completed_at"),
@@ -827,55 +868,26 @@ fn read_optional_timestamp(row: &sqlx::sqlite::SqliteRow, column: &str) -> Optio
 
 #[cfg(test)]
 pub(crate) async fn setup_test_store() -> TaskStore {
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect("sqlite::memory:")
+    // A uniquely named shared-cache in-memory database: isolated per test, but
+    // reachable from several pool connections so concurrency tests are real.
+    let url = format!(
+        "sqlite:file:tasks-test-{}?mode=memory&cache=shared",
+        uuid::Uuid::new_v4()
+    );
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .min_connections(1)
+        .max_connections(4)
+        .idle_timeout(None)
+        .connect(&url)
         .await
         .expect("in-memory sqlite should connect");
 
-    sqlx::query(
-        r#"
-        CREATE TABLE tasks (
-            id TEXT PRIMARY KEY,
-            task_number INTEGER NOT NULL UNIQUE,
-            title TEXT NOT NULL,
-            description TEXT,
-            status TEXT NOT NULL DEFAULT 'backlog',
-            priority TEXT NOT NULL DEFAULT 'medium',
-            owner_agent_id TEXT NOT NULL,
-            assigned_agent_id TEXT,
-            subtasks TEXT,
-            metadata TEXT,
-            goal_id TEXT,
-            source_memory_id TEXT,
-            worker_id TEXT,
-            created_by TEXT NOT NULL,
-            approved_at TEXT,
-            approved_by TEXT,
-            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-            completed_at TEXT
-        )
-        "#,
-    )
-    .execute(&pool)
-    .await
-    .expect("tasks schema should be created");
-
-    sqlx::query(
-        "CREATE TABLE task_number_seq (
-            id INTEGER PRIMARY KEY CHECK (id = 1),
-            next_number INTEGER NOT NULL DEFAULT 1
-        )",
-    )
-    .execute(&pool)
-    .await
-    .expect("task_number_seq should be created");
-
-    sqlx::query("INSERT INTO task_number_seq (id, next_number) VALUES (1, 1)")
-        .execute(&pool)
+    // Run the real instance migrations so the test schema can never drift from
+    // what ships — including task_comments and last_enriched_at.
+    sqlx::migrate!("./migrations/global")
+        .run(&pool)
         .await
-        .expect("sequence seed should be inserted");
+        .expect("global migrations should run");
 
     TaskStore::new(pool)
 }
@@ -898,6 +910,7 @@ mod tests {
             priority: TaskPriority::Medium,
             subtasks: Vec::new(),
             metadata: serde_json::json!({}),
+            goal_id: None,
             source_memory_id: None,
             created_by: "branch".to_string(),
         }
@@ -1227,15 +1240,16 @@ mod tests {
                 priority: TaskPriority::High,
                 subtasks: Vec::new(),
                 metadata: serde_json::json!({}),
+                goal_id: None,
                 source_memory_id: None,
                 created_by: "branch".to_string(),
             })
             .await
             .expect("should create");
 
-        // agent-test should not be able to claim it
+        // agent-test should not be able to claim it, even with claim_unowned on
         let claimed = store
-            .claim_next_ready("agent-test")
+            .claim_next_ready("agent-test", true)
             .await
             .expect("claim should succeed");
         assert!(
@@ -1245,7 +1259,7 @@ mod tests {
 
         // agent-other should be able to claim it
         let claimed = store
-            .claim_next_ready("agent-other")
+            .claim_next_ready("agent-other", false)
             .await
             .expect("claim should succeed");
         assert!(claimed.is_some());

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -31,6 +31,7 @@
 //! - branch + worker tool superset plus `spacebot_docs`, `config_inspect`, `spawn_worker`,
 //!   and `restart`
 
+pub mod add_task_comment;
 pub mod attachment_recall;
 pub mod autonomy_complete;
 pub mod branch_tool;
@@ -90,6 +91,9 @@ pub mod factory_search_context;
 pub mod factory_update_config;
 pub mod factory_update_identity;
 
+pub use add_task_comment::{
+    AddTaskCommentArgs, AddTaskCommentError, AddTaskCommentOutput, AddTaskCommentTool,
+};
 pub use attachment_recall::{
     AttachmentRecallArgs, AttachmentRecallError, AttachmentRecallOutput, AttachmentRecallTool,
 };
@@ -487,6 +491,7 @@ pub async fn add_channel_tools(
     let chronicle_pool = state.deps.sqlite_pool.clone();
     let compaction = **state.deps.runtime_config.compaction.load();
     let autonomy_run = state.autonomy_run.clone();
+    let autonomy_deps = state.deps.clone();
 
     if allow_direct_reply {
         let agent_display_name = state
@@ -608,10 +613,11 @@ pub async fn add_channel_tools(
             .add_tool(SetOutcomeTool::new(outcome, conversation_id.clone()))
             .await?;
     }
-    if channel_kind == crate::agent::channel::ChannelKind::Autonomy
-        && let Some(run) = autonomy_run
-    {
-        handle.add_tool(AutonomyCompleteTool::new(run)).await?;
+    if channel_kind == crate::agent::channel::ChannelKind::Autonomy {
+        if let Some(run) = autonomy_run.clone() {
+            handle.add_tool(AutonomyCompleteTool::new(run)).await?;
+        }
+        add_autonomy_task_tools(handle, &autonomy_deps, autonomy_run.as_ref()).await?;
     }
 
     // Chronicle index. The channel gets metadata access only — expanding a
@@ -627,6 +633,62 @@ pub async fn add_channel_tools(
             ))
             .await?;
     }
+
+    Ok(())
+}
+
+/// Add the task-board surface the autonomy channel works through.
+///
+/// Gated on the effective autonomy level. At `observe` the run surveys and
+/// summarises, so it gets no mutation tools at all — nothing to claim a task
+/// with, nothing to comment through. `suggest` and `act` get the enrichment
+/// surface; execution of approved work is gated separately, at pickup.
+///
+/// `goal_update` is registered without status changes: a run records progress
+/// in a goal's notes, but closing one stays the user's decision.
+async fn add_autonomy_task_tools(
+    handle: &ToolServerHandle,
+    deps: &crate::AgentDeps,
+    autonomy_run: Option<&crate::agent::autonomy::AutonomyRunHandle>,
+) -> Result<(), rig::tool::server::ToolServerError> {
+    let autonomy = **deps.runtime_config.autonomy.load();
+    let level = autonomy.level.min(**deps.autonomy_ceiling.load());
+    if level < crate::config::AutonomyLevel::Suggest {
+        return Ok(());
+    }
+
+    let agent_id = deps.agent_id.to_string();
+    let mut task_create =
+        TaskCreateTool::new(deps.task_store.clone(), agent_id.clone(), "autonomy")
+            .with_goal_store(deps.goal_store.clone())
+            .with_working_memory(deps.working_memory.clone());
+    let mut add_comment = AddTaskCommentTool::for_agent(deps.task_store.clone(), agent_id.clone())
+        .with_claim_unowned(autonomy.claim_unowned)
+        .with_working_memory(deps.working_memory.clone());
+    if let Some(run) = autonomy_run {
+        add_comment = add_comment.with_budget(run.budget.clone());
+    }
+    let mut goal_update = GoalUpdateTool::new(deps.goal_store.clone())
+        .without_status_changes()
+        .with_working_memory(deps.working_memory.clone());
+    if let Some(api_state) = &deps.api_state {
+        task_create = task_create.with_api_state(api_state.clone());
+        add_comment = add_comment.with_api_state(api_state.clone());
+        goal_update = goal_update.with_api_state(api_state.clone());
+    }
+
+    handle.add_tool(task_create).await?;
+    handle
+        .add_tool(TaskListTool::new(deps.task_store.clone(), agent_id))
+        .await?;
+    handle
+        .add_tool(
+            TaskUpdateTool::for_branch(deps.task_store.clone(), deps.agent_id.clone())
+                .with_working_memory(deps.working_memory.clone()),
+        )
+        .await?;
+    handle.add_tool(add_comment).await?;
+    handle.add_tool(goal_update).await?;
 
     Ok(())
 }
@@ -870,6 +932,12 @@ pub async fn remove_channel_tools(
     remove_optional_tool(handle, AttachmentRecallTool::NAME).await;
     remove_optional_tool(handle, SetOutcomeTool::NAME).await;
     remove_optional_tool(handle, AutonomyCompleteTool::NAME).await;
+    // The autonomy task surface is registered per run and per level.
+    remove_optional_tool(handle, TaskCreateTool::NAME).await;
+    remove_optional_tool(handle, TaskListTool::NAME).await;
+    remove_optional_tool(handle, TaskUpdateTool::NAME).await;
+    remove_optional_tool(handle, AddTaskCommentTool::NAME).await;
+    remove_optional_tool(handle, GoalUpdateTool::NAME).await;
     remove_optional_tool(handle, SkillsSearchTool::NAME).await;
     remove_optional_tool(handle, InstallSkillTool::NAME).await;
     remove_optional_tool(handle, RestartTool::NAME).await;
@@ -970,9 +1038,13 @@ pub fn create_branch_tool_server(
         memory_save = memory_save.with_contract_state(contract_state.clone());
     }
 
-    let mut task_create = TaskCreateTool::new(task_store.clone(), agent_id.to_string(), "branch");
+    let mut task_create = TaskCreateTool::new(task_store.clone(), agent_id.to_string(), "branch")
+        .with_goal_store(goal_store.clone());
+    let mut add_task_comment =
+        AddTaskCommentTool::for_agent(task_store.clone(), agent_id.to_string());
     if let Some(ref api) = api_state {
         task_create = task_create.with_api_state(api.clone());
+        add_task_comment = add_task_comment.with_api_state(api.clone());
     }
 
     // Reflection passes read transcripts for error text and recovery steps,
@@ -998,7 +1070,13 @@ pub fn create_branch_tool_server(
         .tool(worker_inspect)
         .tool(task_create)
         .tool(TaskListTool::new(task_store.clone(), agent_id.to_string()))
-        .tool(TaskUpdateTool::for_branch(task_store, agent_id.clone()))
+        .tool(TaskUpdateTool::for_branch(
+            task_store.clone(),
+            agent_id.clone(),
+        ))
+        // A branch runs on a live user turn, so it records findings without
+        // taking ownership — claiming is the autonomy channel's business.
+        .tool(add_task_comment)
         .tool(GoalListTool::new(goal_store.clone()))
         .tool(FileReadTool::new(
             runtime_config.workspace_dir.clone(),
@@ -1155,8 +1233,15 @@ pub fn create_worker_tool_server(
             ),
         )
         .tool(TaskUpdateTool::for_worker(
-            task_store,
+            task_store.clone(),
             agent_id.clone(),
+            worker_id,
+        ))
+        // Findings go on the task, attributed to this run. The full transcript
+        // stays behind the worker link rather than in the comment body.
+        .tool(AddTaskCommentTool::for_worker(
+            task_store,
+            agent_id.to_string(),
             worker_id,
         ))
         .tool({
@@ -1329,10 +1414,18 @@ pub fn create_cortex_chat_tool_server(
         .tool(spawn_tool)
         .tool(
             TaskCreateTool::new(task_store.clone(), agent_id.to_string(), "cortex")
+                .with_goal_store(goal_store.clone())
                 .with_api_state(api_state.clone()),
         )
         .tool(TaskListTool::new(task_store.clone(), agent_id.to_string()))
-        .tool(TaskUpdateTool::for_branch(task_store, agent_id.clone()))
+        .tool(TaskUpdateTool::for_branch(
+            task_store.clone(),
+            agent_id.clone(),
+        ))
+        .tool(
+            AddTaskCommentTool::for_agent(task_store, agent_id.to_string())
+                .with_api_state(api_state.clone()),
+        )
         .tool(GoalCreateTool::new(goal_store.clone()).with_api_state(api_state.clone()))
         .tool(GoalListTool::new(goal_store.clone()))
         .tool(GoalUpdateTool::new(goal_store).with_api_state(api_state))

--- a/src/tools/add_task_comment.rs
+++ b/src/tools/add_task_comment.rs
@@ -1,0 +1,472 @@
+//! Append a durable finding to a task.
+//!
+//! Comments are the enrichment loop's output: what was investigated, what was
+//! found, what was decided. They are append-only and never touch the task
+//! description, which stays the stable statement of the work itself.
+//!
+//! The tool is also where autonomous ownership is settled. When the agent
+//! comments on an unassigned task and `claim_unowned` is on, the claim happens
+//! first and atomically — one winner, a clean skip for everyone else.
+
+use crate::agent::autonomy::EnrichmentBudget;
+use crate::tasks::{
+    CreateTaskCommentInput, TaskClaim, TaskCommentAuthor, TaskStore, normalize_comment_body,
+};
+
+use rig::completion::ToolDefinition;
+use rig::tool::Tool;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct AddTaskCommentTool {
+    task_store: Arc<TaskStore>,
+    agent_id: String,
+    author_type: TaskCommentAuthor,
+    author_id: Option<String>,
+    /// Worker id stamped on every comment this tool writes. Set for the worker
+    /// toolset so a worker's findings link back to its own run without the
+    /// model having to know its id.
+    bound_worker_id: Option<String>,
+    claim_unowned: bool,
+    budget: Option<EnrichmentBudget>,
+    working_memory: Option<Arc<crate::memory::WorkingMemoryStore>>,
+    api_state: Option<Arc<crate::api::ApiState>>,
+}
+
+impl std::fmt::Debug for AddTaskCommentTool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddTaskCommentTool")
+            .field("agent_id", &self.agent_id)
+            .field("author_type", &self.author_type)
+            .field("claim_unowned", &self.claim_unowned)
+            .finish()
+    }
+}
+
+impl AddTaskCommentTool {
+    /// Comments authored by an agent process — the autonomy channel or a branch.
+    pub fn for_agent(task_store: Arc<TaskStore>, agent_id: impl Into<String>) -> Self {
+        let agent_id = agent_id.into();
+        Self {
+            task_store,
+            author_id: Some(agent_id.clone()),
+            agent_id,
+            author_type: TaskCommentAuthor::Agent,
+            bound_worker_id: None,
+            claim_unowned: false,
+            budget: None,
+            working_memory: None,
+            api_state: None,
+        }
+    }
+
+    /// Comments authored by a worker, attributed to its own run.
+    pub fn for_worker(
+        task_store: Arc<TaskStore>,
+        agent_id: impl Into<String>,
+        worker_id: crate::WorkerId,
+    ) -> Self {
+        let worker_id = worker_id.to_string();
+        Self {
+            author_type: TaskCommentAuthor::Worker,
+            author_id: Some(worker_id.clone()),
+            bound_worker_id: Some(worker_id),
+            ..Self::for_agent(task_store, agent_id)
+        }
+    }
+
+    /// Whether commenting on an unassigned task claims it for this agent.
+    pub fn with_claim_unowned(mut self, claim_unowned: bool) -> Self {
+        self.claim_unowned = claim_unowned;
+        self
+    }
+
+    /// Cap on how many distinct tasks this run may enrich.
+    pub fn with_budget(mut self, budget: EnrichmentBudget) -> Self {
+        self.budget = Some(budget);
+        self
+    }
+
+    pub fn with_working_memory(mut self, store: Arc<crate::memory::WorkingMemoryStore>) -> Self {
+        self.working_memory = Some(store);
+        self
+    }
+
+    pub fn with_api_state(mut self, api_state: Arc<crate::api::ApiState>) -> Self {
+        self.api_state = Some(api_state);
+        self
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("add_task_comment failed: {0}")]
+pub struct AddTaskCommentError(String);
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddTaskCommentArgs {
+    /// Task number reference (#N).
+    pub task_number: i64,
+    /// The synthesised finding — a few lines, not a transcript.
+    pub body: String,
+    /// Worker run this comment summarises, when it summarises one.
+    #[serde(default)]
+    pub worker_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AddTaskCommentOutput {
+    pub success: bool,
+    pub comment_id: String,
+    pub task_number: i64,
+    /// Set when this call took ownership of a previously unassigned task.
+    pub claimed: bool,
+    pub message: String,
+}
+
+impl Tool for AddTaskCommentTool {
+    const NAME: &'static str = "add_task_comment";
+
+    type Error = AddTaskCommentError;
+    type Args = AddTaskCommentArgs;
+    type Output = AddTaskCommentOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        let mut properties = serde_json::json!({
+            "task_number": { "type": "integer", "description": "Task number reference (#N)" },
+            "body": {
+                "type": "string",
+                "description": format!(
+                    "The synthesised finding, 2-5 lines. Maximum {} characters.",
+                    crate::tasks::MAX_COMMENT_BODY_BYTES
+                ),
+            },
+        });
+        // A worker's comments are attributed to its own run automatically, so
+        // the field would only ever let it misattribute.
+        if self.bound_worker_id.is_none() {
+            properties["worker_id"] = serde_json::json!({
+                "type": "string",
+                "description": "Worker whose output this comment summarises, when applicable",
+            });
+        }
+
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: crate::prompts::text::get("tools/add_task_comment").to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": properties,
+                "required": ["task_number", "body"],
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let body = normalize_comment_body(&args.body).map_err(AddTaskCommentError)?;
+        let task_number = args.task_number;
+
+        let task = self
+            .task_store
+            .get_by_number(task_number)
+            .await
+            .map_err(|error| AddTaskCommentError(error.to_string()))?
+            .ok_or_else(|| AddTaskCommentError(format!("task #{task_number} not found")))?;
+
+        // Assignment is the ownership boundary: another agent's task is out of
+        // reach regardless of who owns the task record.
+        if let Some(assigned) = task.assigned_agent_id.as_deref()
+            && assigned != self.agent_id
+        {
+            return Err(AddTaskCommentError(format!(
+                "task #{task_number} is assigned to {assigned} — skip it"
+            )));
+        }
+
+        let mut claimed = false;
+        if task.assigned_agent_id.is_none() && self.claim_unowned {
+            match self
+                .task_store
+                .claim_for_agent(task_number, &self.agent_id)
+                .await
+                .map_err(|error| AddTaskCommentError(error.to_string()))?
+            {
+                TaskClaim::Claimed(_) => claimed = true,
+                TaskClaim::AlreadyOwned(_) => {}
+                TaskClaim::OwnedByOther { agent_id } => {
+                    return Err(AddTaskCommentError(format!(
+                        "task #{task_number} was claimed by {agent_id} first — skip it"
+                    )));
+                }
+                TaskClaim::NotFound => {
+                    return Err(AddTaskCommentError(format!(
+                        "task #{task_number} not found"
+                    )));
+                }
+            }
+        }
+
+        // The run's task allowance is spent on the task, not per comment, so a
+        // run can keep commenting on work it has already started.
+        if let Some(budget) = &self.budget
+            && !budget.try_touch(task_number)
+        {
+            return Err(AddTaskCommentError(format!(
+                "this run's allowance of {} task{} is spent — record what you have and call autonomy_complete",
+                budget.max_tasks(),
+                if budget.max_tasks() == 1 { "" } else { "s" }
+            )));
+        }
+
+        let worker_id = self.bound_worker_id.clone().or(args.worker_id);
+        let comment = self
+            .task_store
+            .add_comment(CreateTaskCommentInput {
+                task_number,
+                author_type: self.author_type,
+                author_id: self.author_id.clone(),
+                body,
+                worker_id,
+                metadata: serde_json::json!({}),
+                // Agent and worker comments are enrichment; the cadence clock
+                // moves with them so the next run picks up somewhere new.
+                mark_enriched: true,
+            })
+            .await
+            .map_err(|error| AddTaskCommentError(error.to_string()))?;
+
+        if let Some(api_state) = &self.api_state {
+            crate::api::tasks::fan_out_task_comment(api_state, &task, self.author_type).await;
+        }
+
+        if let Some(working_memory) = &self.working_memory {
+            working_memory
+                .emit(
+                    crate::memory::WorkingMemoryEventType::TaskUpdate,
+                    format!(
+                        "Task #{} enriched: {}",
+                        task_number,
+                        crate::summarize_first_non_empty_line(&comment.body, 160)
+                    ),
+                )
+                .importance(0.5)
+                .record();
+        }
+
+        let message = if claimed {
+            format!("Claimed and commented on task #{task_number}")
+        } else {
+            format!("Commented on task #{task_number}")
+        };
+
+        Ok(AddTaskCommentOutput {
+            success: true,
+            comment_id: comment.id,
+            task_number,
+            claimed,
+            message,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::store::{CreateTaskInput, TaskPriority, TaskStatus, setup_test_store};
+
+    fn task_input(title: &str, assigned: Option<&str>) -> CreateTaskInput {
+        CreateTaskInput {
+            owner_agent_id: "agent-a".to_string(),
+            assigned_agent_id: assigned.map(str::to_string),
+            title: title.to_string(),
+            description: None,
+            status: TaskStatus::PendingApproval,
+            priority: TaskPriority::Medium,
+            subtasks: Vec::new(),
+            metadata: serde_json::json!({}),
+            goal_id: None,
+            source_memory_id: None,
+            created_by: "autonomy".to_string(),
+        }
+    }
+
+    fn args(task_number: i64, body: &str) -> AddTaskCommentArgs {
+        AddTaskCommentArgs {
+            task_number,
+            body: body.to_string(),
+            worker_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn comment_claims_an_unowned_task_once() {
+        let store = Arc::new(setup_test_store().await);
+        let task = store
+            .create(task_input("unowned", None))
+            .await
+            .expect("create");
+        let tool = AddTaskCommentTool::for_agent(store.clone(), "agent-a").with_claim_unowned(true);
+
+        let first = tool
+            .call(args(task.task_number, "Investigated the retry path."))
+            .await
+            .expect("comment should succeed");
+        assert!(first.claimed);
+
+        let second = tool
+            .call(args(task.task_number, "Follow-up: the backoff is capped."))
+            .await
+            .expect("comment should succeed");
+        assert!(!second.claimed, "ownership is taken once, not per comment");
+
+        let loaded = store
+            .get_by_number(task.task_number)
+            .await
+            .expect("load")
+            .expect("task exists");
+        assert_eq!(loaded.assigned_agent_id.as_deref(), Some("agent-a"));
+        assert!(loaded.last_enriched_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn comment_leaves_unowned_tasks_unclaimed_when_disabled() {
+        let store = Arc::new(setup_test_store().await);
+        let task = store
+            .create(task_input("unowned", None))
+            .await
+            .expect("create");
+        let tool = AddTaskCommentTool::for_agent(store.clone(), "agent-a");
+
+        let output = tool
+            .call(args(task.task_number, "Read the issue thread."))
+            .await
+            .expect("comment should succeed");
+        assert!(!output.claimed);
+
+        let loaded = store
+            .get_by_number(task.task_number)
+            .await
+            .expect("load")
+            .expect("task exists");
+        assert!(loaded.assigned_agent_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn comment_rejects_another_agents_task() {
+        let store = Arc::new(setup_test_store().await);
+        let task = store
+            .create(task_input("theirs", Some("agent-b")))
+            .await
+            .expect("create");
+        let tool = AddTaskCommentTool::for_agent(store.clone(), "agent-a").with_claim_unowned(true);
+
+        let error = tool
+            .call(args(
+                task.task_number,
+                "Trying to touch someone else's work.",
+            ))
+            .await
+            .expect_err("wrong-agent access must fail");
+        assert!(error.to_string().contains("assigned to agent-b"));
+        assert_eq!(
+            store.count_comments(task.task_number).await.expect("count"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_comments_leave_one_winner() {
+        let store = Arc::new(setup_test_store().await);
+        let task = store
+            .create(task_input("contested", None))
+            .await
+            .expect("create");
+        let number = task.task_number;
+
+        let left = AddTaskCommentTool::for_agent(store.clone(), "agent-a").with_claim_unowned(true);
+        let right =
+            AddTaskCommentTool::for_agent(store.clone(), "agent-b").with_claim_unowned(true);
+        let (first, second) = tokio::join!(
+            tokio::spawn(async move { left.call(args(number, "Agent A investigated.")).await }),
+            tokio::spawn(async move { right.call(args(number, "Agent B investigated.")).await }),
+        );
+
+        let results = [first.expect("join"), second.expect("join")];
+        let winners = results.iter().filter(|result| result.is_ok()).count();
+        assert_eq!(winners, 1, "exactly one agent may take the task");
+        let skip = results
+            .iter()
+            .find_map(|result| result.as_ref().err())
+            .expect("the loser reports a skip");
+        assert!(skip.to_string().contains("claimed by"));
+        assert_eq!(store.count_comments(number).await.expect("count"), 1);
+    }
+
+    #[tokio::test]
+    async fn budget_caps_distinct_tasks_per_run() {
+        let store = Arc::new(setup_test_store().await);
+        let first = store
+            .create(task_input("first", Some("agent-a")))
+            .await
+            .expect("create");
+        let second = store
+            .create(task_input("second", Some("agent-a")))
+            .await
+            .expect("create");
+        let third = store
+            .create(task_input("third", Some("agent-a")))
+            .await
+            .expect("create");
+
+        let tool = AddTaskCommentTool::for_agent(store.clone(), "agent-a")
+            .with_budget(EnrichmentBudget::new(2));
+
+        tool.call(args(first.task_number, "First finding."))
+            .await
+            .expect("first task is within budget");
+        tool.call(args(second.task_number, "Second finding."))
+            .await
+            .expect("second task is within budget");
+        tool.call(args(first.task_number, "More on the first task."))
+            .await
+            .expect("a task already worked stays in budget");
+
+        let error = tool
+            .call(args(third.task_number, "One task too many."))
+            .await
+            .expect_err("the third distinct task must be refused");
+        assert!(error.to_string().contains("allowance"));
+    }
+
+    #[tokio::test]
+    async fn worker_comments_are_attributed_to_their_run() {
+        let store = Arc::new(setup_test_store().await);
+        let task = store
+            .create(task_input("worker owned", Some("agent-a")))
+            .await
+            .expect("create");
+        let worker_id = crate::WorkerId::new_v4();
+        let tool = AddTaskCommentTool::for_worker(store.clone(), "agent-a", worker_id);
+
+        tool.call(AddTaskCommentArgs {
+            task_number: task.task_number,
+            body: "Reproduced the failure on the second attempt.".to_string(),
+            // A worker cannot misattribute: the bound id wins.
+            worker_id: Some("some-other-worker".to_string()),
+        })
+        .await
+        .expect("worker comment should succeed");
+
+        let comments = store
+            .list_comments(task.task_number, 10, None)
+            .await
+            .expect("list");
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].author_type, TaskCommentAuthor::Worker);
+        assert_eq!(
+            comments[0].worker_id.as_deref(),
+            Some(worker_id.to_string()).as_deref()
+        );
+    }
+}

--- a/src/tools/add_task_comment.rs
+++ b/src/tools/add_task_comment.rs
@@ -395,11 +395,20 @@ mod tests {
         let results = [first.expect("join"), second.expect("join")];
         let winners = results.iter().filter(|result| result.is_ok()).count();
         assert_eq!(winners, 1, "exactly one agent may take the task");
+
+        // The loser can lose at either gate depending on interleaving: it reads
+        // the assignment the winner already committed, or it reads an unowned
+        // task and loses the guarded UPDATE. Both end the same way — told to
+        // skip, having written nothing.
         let skip = results
             .iter()
             .find_map(|result| result.as_ref().err())
-            .expect("the loser reports a skip");
-        assert!(skip.to_string().contains("claimed by"));
+            .expect("the loser reports a skip")
+            .to_string();
+        assert!(
+            skip.contains("skip it"),
+            "the loser must be told to skip, got: {skip}"
+        );
         assert_eq!(store.count_comments(number).await.expect("count"), 1);
     }
 

--- a/src/tools/autonomy_complete.rs
+++ b/src/tools/autonomy_complete.rs
@@ -177,7 +177,7 @@ mod tests {
     async fn records_summary_and_actions() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id.clone(), Arc::new(store.clone()));
+        let handle = AutonomyRunHandle::new(run_id.clone(), Arc::new(store.clone()), 2);
         let tool = AutonomyCompleteTool::new(handle.clone());
 
         let output = tool
@@ -205,7 +205,7 @@ mod tests {
     async fn rejects_invalid_action_kind() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id, Arc::new(store));
+        let handle = AutonomyRunHandle::new(run_id, Arc::new(store), 2);
         let tool = AutonomyCompleteTool::new(handle.clone());
 
         let error = tool
@@ -228,7 +228,7 @@ mod tests {
     async fn rejects_trivial_summary() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id, Arc::new(store));
+        let handle = AutonomyRunHandle::new(run_id, Arc::new(store), 2);
         let tool = AutonomyCompleteTool::new(handle);
 
         let error = tool

--- a/src/tools/goal_update.rs
+++ b/src/tools/goal_update.rs
@@ -11,6 +11,11 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct GoalUpdateTool {
     goal_store: Arc<GoalStore>,
+    /// Whether this registration may move a goal between statuses. Cleared for
+    /// processes that run without a user present: closing or abandoning a goal
+    /// is the user's decision, so the field is removed from the schema and
+    /// rejected if it arrives anyway.
+    allow_status_change: bool,
     working_memory: Option<Arc<crate::memory::WorkingMemoryStore>>,
     api_state: Option<Arc<crate::api::ApiState>>,
 }
@@ -25,9 +30,16 @@ impl GoalUpdateTool {
     pub fn new(goal_store: Arc<GoalStore>) -> Self {
         Self {
             goal_store,
+            allow_status_change: true,
             working_memory: None,
             api_state: None,
         }
+    }
+
+    /// Restrict this registration to notes, priority, due date, and metadata.
+    pub fn without_status_changes(mut self) -> Self {
+        self.allow_status_change = false;
+        self
     }
 
     pub fn with_working_memory(mut self, store: Arc<crate::memory::WorkingMemoryStore>) -> Self {
@@ -72,18 +84,8 @@ impl Tool for GoalUpdateTool {
     type Output = GoalUpdateOutput;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: crate::prompts::text::get("tools/goal_update").to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
+        let mut properties = serde_json::json!({
                     "id": { "type": "string", "description": "Goal id" },
-                    "status": {
-                        "type": "string",
-                        "enum": GoalStatus::ALL.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
-                        "description": "Optional new status — only change on explicit user instruction"
-                    },
                     "priority": {
                         "type": "string",
                         "enum": TaskPriority::ALL.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
@@ -92,7 +94,21 @@ impl Tool for GoalUpdateTool {
                     "due_date": { "type": "string", "description": "New deadline as YYYY-MM-DD, or empty string to clear" },
                     "notes": { "type": "string", "description": "Replacement progress notes — the goal's current standing, not an append" },
                     "metadata_patch": { "type": "object", "description": "Metadata object deep-merged with current metadata" }
-                },
+        });
+        if self.allow_status_change {
+            properties["status"] = serde_json::json!({
+                "type": "string",
+                "enum": GoalStatus::ALL.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                "description": "Optional new status — only change on explicit user instruction",
+            });
+        }
+
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: crate::prompts::text::get("tools/goal_update").to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": properties,
                 "required": ["id"]
             }),
         }
@@ -101,10 +117,18 @@ impl Tool for GoalUpdateTool {
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let status = match args.status.as_deref() {
             None => None,
-            Some(value) => Some(
-                GoalStatus::parse(value)
-                    .ok_or_else(|| GoalUpdateError(format!("invalid status: {value}")))?,
-            ),
+            Some(value) => {
+                if !self.allow_status_change {
+                    return Err(GoalUpdateError(
+                        "goal status is the user's call — record progress in notes instead"
+                            .to_string(),
+                    ));
+                }
+                Some(
+                    GoalStatus::parse(value)
+                        .ok_or_else(|| GoalUpdateError(format!("invalid status: {value}")))?,
+                )
+            }
         };
         let priority = match args.priority.as_deref() {
             None => None,

--- a/src/tools/send_agent_message.rs
+++ b/src/tools/send_agent_message.rs
@@ -245,6 +245,7 @@ impl Tool for SendAgentMessageTool {
                 priority: crate::tasks::TaskPriority::Medium,
                 subtasks: Vec::new(),
                 metadata,
+                goal_id: None,
                 source_memory_id: None,
                 created_by: format!("agent:{}", sending_agent_id),
             })

--- a/src/tools/task_create.rs
+++ b/src/tools/task_create.rs
@@ -13,6 +13,9 @@ pub struct TaskCreateTool {
     task_store: Arc<TaskStore>,
     agent_id: String,
     created_by: String,
+    /// Present when the caller may link new tasks to a goal. The store is used
+    /// to reject unknown ids, since SQLite foreign keys are not enforced here.
+    goal_store: Option<Arc<crate::goals::GoalStore>>,
     working_memory: Option<Arc<crate::memory::WorkingMemoryStore>>,
     api_state: Option<Arc<crate::api::ApiState>>,
 }
@@ -36,9 +39,16 @@ impl TaskCreateTool {
             task_store,
             agent_id: agent_id.into(),
             created_by: created_by.into(),
+            goal_store: None,
             working_memory: None,
             api_state: None,
         }
+    }
+
+    /// Allow this tool to link new tasks to an existing goal.
+    pub fn with_goal_store(mut self, store: Arc<crate::goals::GoalStore>) -> Self {
+        self.goal_store = Some(store);
+        self
     }
 
     pub fn with_working_memory(mut self, store: Arc<crate::memory::WorkingMemoryStore>) -> Self {
@@ -66,6 +76,9 @@ pub struct TaskCreateArgs {
     pub subtasks: Vec<String>,
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
+    /// Goal this task contributes to.
+    #[serde(default)]
+    pub goal_id: Option<String>,
 }
 
 fn default_priority() -> String {
@@ -88,29 +101,37 @@ impl Tool for TaskCreateTool {
     type Output = TaskCreateOutput;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
+        let mut properties = serde_json::json!({
+            "title": { "type": "string", "description": "Short task title" },
+            "description": { "type": "string", "description": "Optional detailed description" },
+            "priority": {
+                "type": "string",
+                "enum": crate::tasks::TaskPriority::ALL.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+                "description": "Task priority"
+            },
+            "subtasks": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional checklist items"
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional metadata object"
+            }
+        });
+        if self.goal_store.is_some() {
+            properties["goal_id"] = serde_json::json!({
+                "type": "string",
+                "description": "Id of the goal this task contributes to, as returned by goal_list",
+            });
+        }
+
         ToolDefinition {
             name: Self::NAME.to_string(),
             description: crate::prompts::text::get("tools/task_create").to_string(),
             parameters: serde_json::json!({
                 "type": "object",
-                "properties": {
-                    "title": { "type": "string", "description": "Short task title" },
-                    "description": { "type": "string", "description": "Optional detailed description" },
-                    "priority": {
-                        "type": "string",
-                        "enum": crate::tasks::TaskPriority::ALL.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
-                        "description": "Task priority"
-                    },
-                    "subtasks": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Optional checklist items"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "description": "Optional metadata object"
-                    }
-                },
+                "properties": properties,
                 "required": ["title"]
             }),
         }
@@ -130,6 +151,25 @@ impl Tool for TaskCreateTool {
             })
             .collect::<Vec<_>>();
 
+        // Resolve the goal before creating: an unknown id would otherwise
+        // persist as a dangling link that no linked-task count ever finds.
+        let goal_id = match (args.goal_id.as_deref(), &self.goal_store) {
+            (None, _) | (Some(""), _) => None,
+            (Some(goal_id), Some(store)) => {
+                let goal = store
+                    .get(goal_id)
+                    .await
+                    .map_err(|error| TaskCreateError(format!("{error}")))?
+                    .ok_or_else(|| TaskCreateError(format!("goal {goal_id} not found")))?;
+                Some(goal.id)
+            }
+            (Some(_), None) => {
+                return Err(TaskCreateError(
+                    "this process cannot link tasks to goals".to_string(),
+                ));
+            }
+        };
+
         let task = self
             .task_store
             .create(CreateTaskInput {
@@ -141,6 +181,7 @@ impl Tool for TaskCreateTool {
                 priority,
                 subtasks,
                 metadata: args.metadata.unwrap_or_else(|| serde_json::json!({})),
+                goal_id,
                 source_memory_id: None,
                 created_by: self.created_by.clone(),
             })
@@ -257,6 +298,7 @@ mod tests {
                 priority: "medium".to_string(),
                 subtasks: Vec::new(),
                 metadata: None,
+                goal_id: None,
             })
             .await
             .expect("task create should succeed");

--- a/src/tools/task_update.rs
+++ b/src/tools/task_update.rs
@@ -328,6 +328,7 @@ mod tests {
                 priority: TaskPriority::Medium,
                 subtasks: Vec::new(),
                 metadata: serde_json::json!({}),
+                goal_id: None,
                 source_memory_id: None,
                 created_by: "branch".to_string(),
             })
@@ -378,6 +379,7 @@ mod tests {
                 priority: TaskPriority::Medium,
                 subtasks: Vec::new(),
                 metadata: serde_json::json!({}),
+                goal_id: None,
                 source_memory_id: None,
                 created_by: "branch".to_string(),
             })
@@ -426,6 +428,7 @@ mod tests {
                 priority: TaskPriority::Medium,
                 subtasks: Vec::new(),
                 metadata: serde_json::json!({}),
+                goal_id: None,
                 source_memory_id: None,
                 created_by: "branch".to_string(),
             })
@@ -441,6 +444,7 @@ mod tests {
                 priority: TaskPriority::Medium,
                 subtasks: Vec::new(),
                 metadata: serde_json::json!({}),
+                goal_id: None,
                 source_memory_id: None,
                 created_by: "branch".to_string(),
             })


### PR DESCRIPTION
Builds on #631 (autonomy channel/goals/wakes/run-history shell). The channel had a survey and a run summary but nothing to write findings into — and no task tools registered at all. The enrichment loop in `autonomy.md` was prose. This lands the code.

## Task comments

New `task_comments` table, append-only. `seq INTEGER PRIMARY KEY AUTOINCREMENT` is the ordering key rather than `created_at`: two comments in the same millisecond would otherwise have no defined order and pagination cursors would skip or repeat rows. `seq` is also the cursor the list endpoint returns.

`TaskStore::delete` clears a task's comments in the same transaction as the task. `ON DELETE CASCADE` is declared too, but it only fires when the connection has `PRAGMA foreign_keys` on — a setting the store doesn't own.

`GET`/`POST /tasks/{n}/comments`, regenerated OpenAPI + TS client, and a comment thread on task detail in both task routes. A worker-linked comment renders a pill that fetches that worker's output on expand — the body stays the agent's summary, transcripts never inline.

## Enrichment cadence

`last_enriched_at` on tasks, stamped in the same transaction as the comment that earned it, so a crash can't mark a task enriched without the finding that enriched it. User comments deliberately don't move it — being commented on is what pulls a task back to the front.

`TaskStore::select_for_enrichment` does the ordering in SQL: user-engaged since last enrichment, then never enriched, then stale, with last run's work excluded unless a user has since commented. It renders into the wake briefing as an **Enrichment Queue** with each entry's recent comments inlined, so the run opens on a list that already excludes what it just did.

`max_tasks_per_run` is enforced at the tool boundary now instead of being a request in the prompt:

```rust
// Spent per task, not per comment — a run can keep working something it started.
if let Some(budget) = &self.budget
    && !budget.try_touch(task_number)
{
    return Err(AddTaskCommentError(format!(
        "this run's allowance of {} task{} is spent — record what you have and call autonomy_complete",
        budget.max_tasks(), if budget.max_tasks() == 1 { "" } else { "s" }
    )));
}
```

## Claiming

`add_task_comment` claims an unassigned task atomically before writing when `claim_unowned` is set. Listing claims nothing. `observe` gets no mutation tools registered at all, so it can't claim by any path.

```rust
UPDATE tasks SET assigned_agent_id = ?, updated_at = ...
WHERE task_number = ? AND assigned_agent_id IS NULL
```

`claim_next_ready` now takes assignment and `in_progress` in one guarded UPDATE and can pick up unowned ready work.

## Worker continuity

Ready-task pickup appends the task's comments to the worker prompt — oldest first, 12 comments, 600 bytes each, 4000 total.

`WorkerContextMode::Briefed` **does not exist in source**. `WorkerContextMode` is a struct of `history`/`memory`/`wiki_write`; the enum in `worker-briefing.md` was never built. Comments are injected at ready-task pickup instead, which is the only place a worker is actually bound to a task and therefore the only place the briefing has comments to carry. Flagged rather than silently reinterpreted.

## Goals

`task_create` takes `goal_id` through tool, store and API, resolving it against the goal store first so an unknown id is a tool error rather than a dangling link.

Autonomy gets `goal_update` with the `status` field **removed from the schema**, not just discouraged in prose. Each run then programmatically flags active goals whose linked tasks are all `done`:

```rust
pub const GOAL_READY_FOR_REVIEW_NOTE: &str = "All linked tasks complete — ready for your review.";
```

Prepended to the goal's notes, keeping the agent's own assessment beneath it. Idempotent, treats `failed` as work remaining, never touches status. Goals never auto-complete.

## Quiet-while-active: rejected

Marked rejected in `autonomy.md` with the reasoning, not left on the phase list. Enrichment is most useful while the user is around to react to it, and the wake already carries the signal that matters — a user comment pulls the next run forward rather than pushing it away. A global "someone is talking, stand down" flag suppresses the run for reasons unrelated to the task it was going to work on.

## Testing

23 new tests. Adversarial ones:

- `concurrent_claims_produce_one_winner` / `concurrent_first_comments_leave_one_winner` — two agents race the same unowned task; exactly one wins, the loser gets a skip with nothing written
- `selection_excludes_work_from_the_previous_run` — and that a user comment clears the exclusion
- `selection_orders_user_engaged_then_never_enriched_then_stale`, `selection_respects_assignment_and_claim_unowned`
- `comment_rejects_another_agents_task` — wrong-agent access
- `budget_caps_distinct_tasks_per_run`
- `agent_comment_stamps_enrichment_and_user_comment_does_not`
- `goals_are_flagged_for_review_only_when_every_linked_task_is_done` — partial, zero-task and failed-task goals stay unflagged; re-running doesn't stack markers
- `deleting_a_task_removes_its_comments`, `create_rejects_an_unknown_goal_link`

Two of these were flaky on first write and the second commit fixes the causes, one of which was a real bug:

1. The user-engaged check used `>` against `last_enriched_at`. Both are millisecond-precision, so a user comment landing in the same millisecond as the preceding enrichment was silently dropped from selection. Now inclusive.
2. Test fixtures moved from shared-cache in-memory SQLite to a file-backed temp DB. Shared-cache raises `SQLITE_LOCKED` on contention, which `busy_timeout` doesn't retry — the concurrency tests were flaking on an artifact no deployment can hit.

**Validation state:** `cargo fmt --all --check`, `cargo check --all-targets`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`, `cargo test --lib` (1169 passed), `just check-typegen` (generated schema in sync), `bunx tsc --noEmit` and `bun run build` all pass. Migration safety passed — only new migration files. The final `cargo test --tests --no-run` step of `gate-pr.sh` was still running when I cut the PR; it passed on an earlier identical run of the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> [!NOTE]
> **AI Summary:** This PR implements the autonomy enrichment loop with durable task comments. Key additions: a new `task_comments` table with sequence-based ordering to prevent pagination issues, enrichment selection logic that prioritizes user-engaged tasks and excludes recent work, atomic task claiming for racing agents, goal review flagging when all linked tasks complete, and 23 new adversarial tests covering concurrency, budget enforcement, and access control. Two follow-up commits fix a millisecond-precision race condition in the user-engagement check and flaky concurrency tests by switching to file-backed SQLite. All validation checks pass (cargo fmt, clippy, 1169 lib tests, generated schema sync).
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [1ac3b5ad](https://github.com/spacedriveapp/spacebot/commit/1ac3b5ad).</sub>