### PR TITLE
Deliver worker outcome text instead of a placeholder result

### DIFF
--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -767,9 +767,17 @@ impl Worker {
                                 "one-shot worker stopped after recording terminal outcome"
                             );
                             self.persist_transcript(&compacted_history, &history).await;
-                            return Ok(WorkerOutcome::Success {
-                                result: "Worker reported a terminal outcome.".to_string(),
-                            });
+                            // The signaled outcome text is the worker's actual
+                            // result; the fallbacks cover a signal that carried
+                            // no text.
+                            let result = self
+                                .hook
+                                .take_outcome_text()
+                                .or_else(|| crate::agent::extract_last_assistant_text(&history))
+                                .unwrap_or_else(|| {
+                                    "Worker reported a terminal outcome.".to_string()
+                                });
+                            return Ok(WorkerOutcome::Success { result });
                         }
                         self.state = WorkerState::Failed;
                         self.hook.send_status("cancelled");
@@ -869,10 +877,12 @@ impl Worker {
                     worker_id = %self.id,
                     "worker produced empty text but outcome was signaled, treating as success"
                 );
-                // Use a synthetic result — the channel already received the
-                // outcome status via the event stream, so this is just for the
-                // worker result record.
-                result = "Task completed (outcome signaled via set_status).".to_string();
+                // Prefer the signaled outcome text so the worker result record
+                // carries the actual findings; the synthetic fallback covers a
+                // signal that carried no text.
+                result = self.hook.take_outcome_text().unwrap_or_else(|| {
+                    "Task completed (outcome signaled via set_status).".to_string()
+                });
             } else {
                 self.state = WorkerState::Failed;
                 self.hook.send_status("failed (empty result)");

--- a/src/hooks/spacebot.rs
+++ b/src/hooks/spacebot.rs
@@ -52,6 +52,10 @@ pub struct SpacebotHook {
     /// Once signaled, the nudge system allows text-only responses to pass
     /// through as legitimate completions.
     outcome_signaled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Full text of the last successful `set_status(kind: "outcome")` call.
+    /// Carried into `WorkerOutcome` so the durable result holds the worker's
+    /// findings rather than a placeholder.
+    outcome_text: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     /// One-shot workers terminate immediately after recording an outcome.
     /// Interactive workers keep their session open for follow-up input.
     terminate_on_outcome: bool,
@@ -135,6 +139,7 @@ impl SpacebotHook {
                 std::sync::atomic::AtomicBool::new(false),
             ),
             outcome_signaled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            outcome_text: std::sync::Arc::new(std::sync::Mutex::new(None)),
             terminate_on_outcome: false,
             nudge_attempts: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             loop_guard: std::sync::Arc::new(std::sync::Mutex::new(LoopGuard::new(
@@ -202,12 +207,19 @@ impl SpacebotHook {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Take the outcome text recorded by the last successful
+    /// `set_status(kind: "outcome")` call, if any.
+    pub fn take_outcome_text(&self) -> Option<String> {
+        self.outcome_text.lock().expect("outcome text lock").take()
+    }
+
     /// Reset per-prompt state (tool nudging, outcome tracking, and loop guard).
     pub fn reset_tool_nudge_state(&self) {
         self.completion_calls
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.outcome_signaled
             .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.outcome_text.lock().expect("outcome text lock").take();
         self.nudge_attempts
             .store(0, std::sync::atomic::Ordering::Relaxed);
         if let Ok(mut guard) = self.loop_guard.lock() {
@@ -1492,6 +1504,13 @@ where
             && parsed.get("success").and_then(|v| v.as_bool()) == Some(true)
             && parsed.get("kind").and_then(|v| v.as_str()) == Some("outcome")
         {
+            if let Some(text) = parsed
+                .get("outcome")
+                .and_then(|v| v.as_str())
+                .filter(|text| !text.trim().is_empty())
+            {
+                *self.outcome_text.lock().expect("outcome text lock") = Some(text.to_string());
+            }
             self.outcome_signaled
                 .store(true, std::sync::atomic::Ordering::Relaxed);
             if self.terminate_on_outcome {
@@ -1770,6 +1789,48 @@ mod tests {
                 if reason == SpacebotHook::WORKER_OUTCOME_RECORDED_REASON
         ));
         assert!(hook.outcome_signaled());
+    }
+
+    #[tokio::test]
+    async fn outcome_signal_retains_full_outcome_text() {
+        let hook = make_hook()
+            .with_tool_nudge_policy(ToolNudgePolicy::Enabled)
+            .with_terminate_on_outcome(true);
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"Console verified\",\"kind\":\"outcome\"}",
+            "{\"success\":true,\"worker_id\":1,\"status\":\"Console verified...\",\"outcome\":\"Console verified at http://127.0.0.1:4100 with PID 19671\",\"kind\":\"outcome\"}",
+        )
+        .await;
+
+        assert_eq!(
+            hook.take_outcome_text().as_deref(),
+            Some("Console verified at http://127.0.0.1:4100 with PID 19671"),
+        );
+        // Taking the text consumes it.
+        assert!(hook.take_outcome_text().is_none());
+    }
+
+    #[tokio::test]
+    async fn reset_clears_retained_outcome_text() {
+        let hook = make_hook()
+            .with_tool_nudge_policy(ToolNudgePolicy::Enabled)
+            .with_terminate_on_outcome(false);
+        let _ = <SpacebotHook as PromptHook<SpacebotModel>>::on_tool_result(
+            &hook,
+            "set_status",
+            None,
+            "internal_1",
+            "{\"status\":\"done\",\"kind\":\"outcome\"}",
+            "{\"success\":true,\"worker_id\":1,\"status\":\"done\",\"outcome\":\"done\",\"kind\":\"outcome\"}",
+        )
+        .await;
+
+        hook.reset_tool_nudge_state();
+        assert!(hook.take_outcome_text().is_none());
     }
 
     #[tokio::test]

--- a/src/tools/set_status.rs
+++ b/src/tools/set_status.rs
@@ -97,6 +97,11 @@ pub struct SetStatusOutput {
     pub worker_id: WorkerId,
     /// The status that was set.
     pub status: String,
+    /// Full outcome text when `kind` is `outcome`, uncapped so the worker's
+    /// terminal result survives into the durable completion record. Absent
+    /// for progress updates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<String>,
     /// The kind of status that was set.
     pub kind: StatusKind,
 }
@@ -132,21 +137,29 @@ impl Tool for SetStatusTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        // Cap status length to prevent context bloat in the status block.
-        // Status is rendered into every channel turn so it should stay short.
-        let status = if args.status.len() > 256 {
-            let end = args.status.floor_char_boundary(256);
-            let boundary = args.status[..end].rfind(char::is_whitespace).unwrap_or(end);
-            format!("{}...", &args.status[..boundary])
-        } else {
-            args.status
-        };
-
-        // Scrub tool secret values before the status reaches the channel.
+        // Scrub tool secret values before the status leaves the worker.
         // Layer 1: exact-match redaction of known secrets from the store.
         // Layer 2: regex-based redaction of unknown secret patterns.
-        let status = crate::secrets::scrub::scrub_secrets(&status, &self.tool_secret_pairs);
-        let status = crate::secrets::scrub::scrub_leaks(&status);
+        // Scrubbing runs on the full text so the display cap below can't
+        // truncate a secret out of exact-match range.
+        let scrubbed = crate::secrets::scrub::scrub_secrets(&args.status, &self.tool_secret_pairs);
+        let scrubbed = crate::secrets::scrub::scrub_leaks(&scrubbed);
+
+        // Cap status length to prevent context bloat in the status block.
+        // Status is rendered into every channel turn so it should stay short.
+        let status = if scrubbed.len() > 256 {
+            let end = scrubbed.floor_char_boundary(256);
+            let boundary = scrubbed[..end].rfind(char::is_whitespace).unwrap_or(end);
+            format!("{}...", &scrubbed[..boundary])
+        } else {
+            scrubbed.clone()
+        };
+
+        // An outcome status is the worker's terminal result, not just a
+        // progress line: the full text rides in the tool output so the
+        // completion path can deliver it, while the capped form feeds the
+        // live status stream.
+        let outcome = (args.kind == StatusKind::Outcome).then_some(scrubbed);
 
         if args.kind == StatusKind::Outcome && !self.interactive {
             match self
@@ -184,6 +197,7 @@ impl Tool for SetStatusTool {
             success: true,
             worker_id: self.worker_id,
             status,
+            outcome,
             kind: args.kind,
         })
     }
@@ -252,6 +266,35 @@ mod tests {
             logger,
             worker_id,
         )
+    }
+
+    #[tokio::test]
+    async fn outcome_output_carries_full_text_while_status_stays_capped() {
+        let (tool, _logger, _worker_id) = setup(false).await;
+        let long = format!("Verified the deployment. {}", "detail ".repeat(60));
+        let output = tool
+            .call(SetStatusArgs {
+                status: long.clone(),
+                kind: StatusKind::Outcome,
+            })
+            .await
+            .unwrap();
+        assert_eq!(output.outcome.as_deref(), Some(long.as_str()));
+        assert!(output.status.len() <= 260);
+        assert!(output.status.ends_with("..."));
+    }
+
+    #[tokio::test]
+    async fn progress_output_has_no_outcome_text() {
+        let (tool, _logger, _worker_id) = setup(false).await;
+        let output = tool
+            .call(SetStatusArgs {
+                status: "working on it".to_string(),
+                kind: StatusKind::Progress,
+            })
+            .await
+            .unwrap();
+        assert!(output.outcome.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
One-shot workers that finish via `set_status(kind: "outcome")` had their final text discarded. The status text was only broadcast as an ephemeral `WorkerStatus` event (capped at 256 chars), then the outcome-recorded termination path returned a hardcoded `"Worker reported a terminal outcome."` as the result. That placeholder became the durable terminal outcome and was exactly what the channel agent received on retrigger — so every outcome-signaled worker looked like it completed with nothing to say. Same story for the empty-result safety net, which substituted its own synthetic line.

The fix carries the real text through:

- `set_status` now scrubs the full text *before* the 256-char display cap (previously cap-then-scrub, so truncation could split a secret out of exact-match range) and, for `kind: "outcome"`, includes the full scrubbed text in the tool output as `outcome`.
- `SpacebotHook` retains that text when it detects the outcome signal, exposed via `take_outcome_text()` and cleared with the rest of the per-prompt state.
- `Worker::run()` uses the retained text as the result in both completion paths, falling back to the last assistant message, then the old placeholder only when the signal carried no text.

The task-level scrub in `spawn_worker_task` still runs on the final outcome, so the delivered text passes through both scrubbing layers.

Tests cover the full-text/capped-status split in the tool output, hook retention and take-consumes semantics, and reset clearing the retained text.

> [!NOTE]
> **Key Changes:**
>
> In `set_status.rs`: Moved secret scrubbing before the 256-char cap to prevent secrets from being split during truncation. Added `outcome` field to `SetStatusOutput` to carry the full uncapped text for outcome signals.
>
> In `spacebot.rs`: Added `outcome_text` field to `SpacebotHook` to retain the full outcome text. Implemented `take_outcome_text()` method for consuming retained text and updated `reset_tool_nudge_state()` to clear it. Added tests verifying full-text retention and reset behavior.
>
> In `worker.rs`: Updated both outcome completion paths to use `take_outcome_text()` with fallbacks to the last assistant message, then the original placeholder only when necessary.
>
> <sub>Written by [Tembo](https://app.tembo.io) for commit [43e8bbbd](https://github.com/spacedriveapp/spacebot/commit/43e8bbbd2ddbf14aa654fd3e0c082b803108fc39). This will update automatically on new commits.</sub>