### PR TITLE
Build resident autonomy channels

### DIFF
--- a/docs/design-docs/autonomy-lifecycle.md
+++ b/docs/design-docs/autonomy-lifecycle.md
@@ -18,9 +18,10 @@ Related: [autonomy.md](autonomy.md), [wakes.md](wakes.md),
 
 ## Current state (source-grounded)
 
-- `maybe_run_autonomy` fires from the cortex tick when
-  `autonomy_run_due(...)` says the interval elapsed or wake events are
-  pending. `interval_secs` defaults to 1800 and never varies.
+- A resident per-agent supervisor owns the autonomy channel. Its bounded
+  doorbell coalesces external wake notifications, and its interval heartbeat
+  calls `autonomy_run_due(...)` when no epoch is active. `interval_secs`
+  defaults to 1800 and never varies.
 - **Ready tasks are picked up by the cortex, not by autonomy.**
   `spawn_ready_task_loop` → `pickup_one_ready_task` claims the
   highest-priority ready task on the cortex tick interval, gated only by
@@ -32,8 +33,9 @@ Related: [autonomy.md](autonomy.md), [wakes.md](wakes.md),
   four status buckets (limit 200 each), plus 5 run summaries, wake events,
   goals, and active workers. No retrieval — everything the run knows is what
   was rendered.
-- The run ends with `autonomy_complete { summary, actions[] }`. It records
-  what happened; it says nothing about what should happen next or when.
+- The epoch ends with `autonomy_complete { summary, actions[] }`. The resident
+  channel returns to idle. The completion says nothing about what should
+  happen next or when.
 - Enrichment exists only as a prompt instruction ("enrich pending_approval
   tasks"), with no state marking a task as researched. Nothing stops a run
   from re-enriching the same task forever — and the 2026-08-12 audit found

--- a/docs/design-docs/autonomy-prompt-assembly.md
+++ b/docs/design-docs/autonomy-prompt-assembly.md
@@ -1,457 +1,108 @@
 # Autonomy Prompt Assembly
 
-The autonomy channel is one persistent channel that wakes, orients itself,
-works, records an outcome, and exits. Its prompt must distinguish standing
-policy from the state of the current run. Today that distinction is inverted:
-almost all autonomy policy and context are rendered into a synthetic first user
-message, while the normal channel system prompt retains instructions for
-talking to people.
-
-This design gives `ChannelKind::Autonomy` a dedicated system-prompt assembly
-path. It reuses the normal channel's durable context providers and chronicle
-storage. It does not create a second autonomy runtime or a second chronicle
-model. Each run begins with one tool-free model turn that writes a short wake
-orientation before the normal tool-enabled loop starts. The portal represents
-the start as a run divider rather than exposing the synthetic trigger.
-
-## Current State
-
-`Channel::build_system_prompt()` renders the normal `channel.md.j2` preamble
-for every channel kind. An autonomy run then calls
-`build_run_briefing()` in `src/agent/autonomy.rs`, which renders the entire
-`prompts/en/autonomy_channel.md.j2` template. That output becomes the first
-synthetic `InboundMessage` for channel id `autonomy`.
-
-The template currently contains all of the following:
-
-- Identity and no-human semantics.
-- Wake events and recent run summaries.
-- Task state, goals, and active workers.
-- Autonomy level permissions and task approval rules.
-- Empty-instance guidance.
-- Memory guidance, task budget, wrap-up behavior, and the
-  `autonomy_complete` contract.
-
-This has five consequences.
-
-1. Stable policy is stored repeatedly in the conversation history.
-2. Run context is represented as user input even though no participant sent it.
-3. The normal preamble tells an autonomy channel how to communicate with people,
-   when it should stay silent, and how adapter delivery works.
-4. Prompt inspection does not show autonomy context in the structured system
-   prompt blocks used by normal channels.
-5. The portal renders the full briefing as a system message even though it is
-   runtime scaffolding, not part of the conversation.
-
-The existing design already specifies the intended behavior. `autonomy.md`
-states that the briefing belongs in the system prompt and that the transcript
-holds the agent's output. The implementation has not reached that architecture.
+The autonomy channel is a resident internal process. It waits while idle, receives ephemeral heartbeat messages, and keeps live worker controls across autonomy epochs. Its prompt separates standing system policy from the current heartbeat briefing.
 
 ## Prompt Layers
 
-An autonomy run has three layers.
+An autonomy turn has three layers.
 
-### Standing policy
+### Standing Policy
 
-Standing policy is rendered into the system prompt. It includes:
+`Channel::build_system_prompt()` renders the normal shared context providers, but `channel.md.j2` selects an autonomy-specific operating contract for `ChannelKind::Autonomy`.
 
-- Autonomy identity and the fact that no human is present.
-- The autonomy level and allowed tool authority.
-- The approval boundary: `pending_approval` tasks may be enriched but never
-  executed; only `ready` tasks may execute at `act` level.
-- Restrictions on user messaging, cron creation, identity changes, and config
-  changes.
-- Task budget and wrap-up behavior.
-- Memory-saving guidance.
-- The required `autonomy_complete` terminal contract.
-- Empty-instance behavior.
+The autonomy contract states:
 
-This content changes only when configuration changes. It must not accumulate in
-the channel transcript.
+- No human receives channel text.
+- Work and outcomes happen through tools.
+- `pending_approval` tasks cannot execute.
+- Active work is tended before more work is admitted.
+- A heartbeat does not require activity.
+- `autonomy_complete` closes the current epoch, not the channel.
+- Useful workers are never cancelled to make an epoch finish.
 
-### Volatile context
+The autonomy path omits the user-channel communication and silence rules. It does not tell the process to reply, react, interpret mentions, or use `skip`.
 
-Volatile context is also rendered into the system prompt, inside a clearly
-labeled region rebuilt for every run:
+The runtime also applies the autonomy level to tool registration. `observe` and `suggest` do not receive execution or worker-routing tools. `observe` receives no task mutation tools. `act` receives execution, worker spawn, and worker routing capabilities.
 
-- Wake events and payloads.
-- Recent autonomy run summaries.
-- Current task state.
+Identity, memory, skills, projects, working memory, goals, and live process status continue to use the normal channel context providers. They remain system context.
+
+### Heartbeat Briefing
+
+`build_run_briefing()` renders `autonomy_channel.md.j2` for the current heartbeat. The briefing contains:
+
+- Trigger reason and elapsed epoch time.
+- Newly claimed wake events.
+- Recent completed epoch summaries.
+- Current task state and prior attempts.
 - Active goals.
-- Workers still running, including owner, lifecycle, last progress, and
-  recovery state.
-- Worker outcomes delivered since the prior autonomy run, including the bound
-  task, terminal outcome, bounded result, and transcript reference.
-- The autonomy channel's own chronicle view.
-- The configured home channel's chronicle view.
+- Every nonterminal worker, including retained interactive workers.
+- Autonomy level and task approval boundaries.
+- The per-epoch task budget.
 
-These are database-backed observations. They are context, not instructions from
-a participant. Wake instructions are data from an allowed wake definition and
-remain explicitly labelled as such.
+The supervisor sends this briefing as a synthetic system message tagged with:
 
-Worker continuity uses a durable outcome inbox, not channel history or an
-in-memory status block. An autonomy channel may exit while its workers continue
-under supervisor ownership. If one completes before the next wake, it is no
-longer an active worker and the original channel cannot process its completion
-event. The next run must therefore claim and render its unacknowledged terminal
-outcome from durable state. This remains separate from the live completion
-retrigger used while the current channel is still resident.
-
-### Ephemeral trigger
-
-The run uses two short, non-persisted synthetic messages. The first starts the
-tool-free orientation turn:
-
-```
-Orient yourself for this autonomy run using the current system context. Respond
-with a concise plain-text account of what woke you, what matters now, and what
-you intend to do first. Do not claim that you have taken any action.
+```text
+autonomy_generation = <u64>
+autonomy_epoch_start = <bool>
 ```
 
-The second starts the normal tool-enabled loop after the orientation has been
-recorded:
+System messages are excluded from conversation persistence. The generation tag prevents a queued message from an older epoch from entering the current one.
 
-```
-Proceed with the autonomy run using that orientation.
-```
+An epoch-start heartbeat clears the previous epoch's live model history and contract counters. It keeps worker handles, worker input routes, consumed outcome versions, and active process status. Heartbeats inside the same epoch retain history so worker results and follow-up decisions share context.
 
-Their sole purpose is to advance the run between phases. Soft wrap-up and
-hard-timeout notices remain ephemeral mid-run messages. These are one-run
-control signals and must not become transcript history.
+### Worker Results
 
-### Wake orientation
+Worker and branch results use `retrigger_autonomy.md.j2`. The retrigger contract is intentionally narrower than a heartbeat:
 
-The first model call is a single tool-free turn. It receives the specialized
-autonomy system prompt and the first ephemeral trigger, but no tool definitions.
-Its output is a short assistant message visible in the autonomy transcript.
+- Reconcile the result first.
+- Continue the intent that produced it.
+- Write required task comments, status changes, or memories.
+- Spawn or route only a direct follow-up.
+- Complete the epoch when the selected work is settled.
 
-The orientation is operational text, not hidden chain-of-thought. It states the
-wake cause, current priority, known constraints, and intended first action. It
-must not contain private reasoning traces, tool-call syntax, or claims about
-work that has not happened. For example:
+A worker result is not a fresh board survey. It does not authorize unrelated work.
 
-```
-Three task approval events triggered this wake. The newly approved migration
-task is the highest-priority executable work, but an active worker may already
-cover part of it. I will check ownership first, then execute it or record the
-blocker.
-```
+## Active-Worker Policy
 
-Build the orientation agent separately from the channel's normal agent. It has
-`max_turns = 1` and no `ToolServer` handle. Tools must not be temporarily removed
-from a shared server because another path could register them before the request
-is assembled. The absence of a tool server is the authority boundary for this
-phase.
+The heartbeat renders every nonterminal worker, not only workers whose display status is `running`. This includes `created`, `running`, `waiting_for_input`, `cancelling`, `timing_out`, and `completing` lifecycles.
 
-The orientation call does not use model-specific tool-use enforcement, malformed
-tool-syntax recovery, worker outcome nudging, or the `autonomy_complete`
-contract. It does count toward the run's wall-clock timeout and usage accounting,
-but not the configured tool-enabled turn budget. Provider transport retries may
-retry the same request. The runtime does not issue a second semantic orientation
-prompt.
+The decision order is:
 
-If the call fails or returns empty text, mark the run failed before any tools are
-registered. A run cannot enter its action phase without a completed orientation.
+1. Reconcile completed work.
+2. Tend work that serves the current highest-priority task.
+3. Wait when existing workers already cover the best available work.
+4. Add work only when it is independent, approved, goal-aligned, and worth the capacity.
+5. Record a no-action epoch when nothing needs attention.
 
-## Specialized System Prompt
+This policy is prompt guidance backed by runtime ownership. Every branch and worker spawned by an epoch registers as a child before the epoch can finish. Routing follow-up input to a retained worker registers that worker in the current epoch again.
 
-`Channel::build_system_prompt()` branches on `ChannelKind::Autonomy` before it
-calls `PromptEngine::render_channel_prompt_with_links()`.
+## Completion Contract
 
-Normal user and cron channels keep their existing preamble composition. The
-autonomy path calls a new `PromptEngine::render_autonomy_system_prompt(...)`.
-It composes the reusable context layers that remain meaningful without a human:
+`autonomy_complete` stores the first accepted summary and action list on the generation-specific `AutonomyRunHandle`.
 
-- Identity context.
-- Knowledge synthesis and memory store.
-- Skills and worker capabilities.
-- Project context.
-- Working memory.
-- Organization context.
-- System status.
-- Execution policy appropriate to direct autonomy work.
-- Autonomy standing policy.
-- Current autonomy run context.
+The tool rejects completion while registered children are active. Child admission and finish requests use the same mutex, so a spawn cannot pass a stale settling check. After children settle and pending retriggers drain, the channel marks the epoch quiescent. The supervisor commits the run row, publishes its summary once, clears that generation, and leaves the channel running.
 
-It deliberately omits normal-channel sections that assume a human participant:
-
-- Communication and reply wording.
-- Silence and mention rules.
-- Participant context.
-- Adapter-specific delivery guidance.
-- Available-channel prose intended for a conversational sender.
-- User-channel authority wording that depends on the current sender.
-
-The autonomy template must state its own bounded delivery rule. It has no
-`reply` tool and does not speak to a human as part of a run. Any future allowed
-outward action needs its own explicit policy and durable provenance.
-
-## Chronicle Context
-
-The autonomy channel already has a normal channel id, `autonomy`. Its own
-chronicle is rendered through the existing
-`agent::chronicle::render_chronicle_view()` call using that channel id. It has
-the same checkpoint storage, rollups, truncation behavior, and token budget as
-every other channel chronicle.
-
-The autonomy prompt also receives a second chronicle block when the agent has
-an explicit home channel.
-
-### Autonomy chronicle
-
-This block answers: what has autonomous work attempted, decided, completed, or
-left blocked over time?
-
-It is the normal chronicle for channel id `autonomy`. Terminal
-`autonomy_complete` summaries are assistant transcript entries, so checkpoint
-summaries naturally compact completed runs as the channel ages.
-
-### Home channel chronicle
-
-This block answers: what has the user recently asked for, decided, corrected,
-or deprioritized?
-
-Resolve the home target through `SettingsStore::home_channel()`. The setting is
-explicit and instance-scoped. Map its canonical target to the corresponding
-conversation id using the same target-routing normalization used by messaging.
-Do not infer a home channel from recent activity.
-
-Render a home chronicle only when all conditions hold:
-
-- A home channel is configured.
-- The target resolves to a known conversation id.
-- It is not the `autonomy` channel itself.
-- It has a non-empty chronicle view.
-
-Otherwise omit the block. Log resolution failures with the agent id and target,
-without failing the run.
-
-The two blocks stay separate:
-
-```
-## Autonomy Chronicle
-...
-
-## Home Channel Chronicle
-...
-```
-
-They serve different questions and must not be flattened into a cross-channel
-transcript dump.
-
-## Budgets
-
-Chronicle views are bounded by `ChronicleConfig.context_token_budget`. Rendering
-both views with the full channel budget would double the intended allowance.
-
-The autonomy prompt has an explicit context allocation:
-
-- Autonomy chronicle gets a bounded allocation.
-- Home chronicle gets a separate bounded allocation.
-- Recent run summaries use a newest-first character budget.
-- Task state retains its existing per-description truncation and has a total
-  block budget.
-- Wake events, goals, active workers, working memory, and system status remain
-  independently bounded.
-
-The assembly order preserves the information most useful for a live decision:
-
-1. Wake events.
-2. Active workers and blocked/ready task state.
-3. Home channel chronicle.
-4. Autonomy chronicle.
-5. Recent run summaries.
-
-Each source reports omission rather than silently dropping context. Chronicle
-views already collapse and remove oldest entries under their budget. Recent run
-history needs the character-budgeted newest-first policy tracked by task `#7`.
-
-The whole rendered system prompt remains subject to the existing request-size
-estimate. Tool schemas remain outside that estimate because Rig assembles them
-at call time.
+If a model turn returns without completing and has no active children or pending results, the channel sends a bounded contract retry. Exhausting that retry budget records the fallback summary. This is a completion contract, not a wall-clock timeout.
 
 ## Transcript Rules
 
-The autonomy transcript records the agent's output, not repeatedly rendered
-system context.
+- Heartbeats are not persisted.
+- Wake payloads and task surveys are not persisted.
+- Worker retrigger scaffolding is not persisted.
+- Current-epoch tool and assistant history remains live until the epoch closes.
+- Completed epoch summaries are stored in `autonomy_runs` and published once to the autonomy timeline.
+- The next epoch receives bounded recent summaries from the run store.
 
-- Neither run trigger is persisted.
-- Wake briefings, task surveys, goals, and run-history windows are not
-  persisted as messages.
-- Soft and hard timeout notices are not persisted.
-- A successful orientation writes exactly one assistant message before tools
-  become available.
-- The first durable terminal transition writes exactly one assistant summary to
-  the autonomy transcript.
-- External effects that the next run cannot re-derive are promoted into the
-  terminal summary or a durable journal entry with explicit provenance.
+The run row is the idempotency boundary. Only the caller that changes a run from `running` to a terminal state may publish its outcome.
 
-The live in-memory sequence for a successful run is:
+## Budgets
 
-```
-user      ephemeral orientation trigger
-assistant durable wake orientation
-user      ephemeral action trigger
-assistant/tool activity
-assistant durable terminal summary
-```
+`max_turns` bounds one agentic model invocation. It does not bound the channel or epoch lifetime. `max_tasks_per_run` limits task breadth inside an epoch.
 
-On the next wake, history hydration restores assistant output only. The two
-synthetic user messages are live role boundaries for their run and do not enter
-the durable transcript or chronicle.
+Provider calls, tools, and workers retain their own operation-level limits. Autonomy has no soft warning or hard run timeout. Heartbeats continue while an epoch owns work.
 
-The terminal run row is the idempotency boundary. Only the caller that changes
-an autonomy run from `running` to a terminal state may publish the transcript
-summary. Completion retries, timeout races, and late worker arrival paths must
-not append duplicate outcomes.
+## Inspection
 
-The orientation has a deterministic message id derived from the run id, for
-example `autonomy-orientation:{run_id}`. Persist it with `INSERT OR IGNORE`
-against the existing message primary key. A process retry reads and reuses the
-existing orientation or fails the run, never appends another one.
+Prompt records must identify the process as `ChannelKind::Autonomy`. Each heartbeat carries the epoch generation in message metadata, while durable run ids remain in `autonomy_runs`, `worker_runs.run_id`, and `branch_runs.run_id`.
 
-## Portal Timeline
-
-The autonomy channel displays the start of each run as a lifecycle divider:
-
-```
-──────── System wake 09:42 ────────
-```
-
-The divider is not a conversation message. Its durable source is the
-`autonomy_runs` row, using the run id as the timeline item id and `started_at` as
-its timestamp. The channel timeline API exposes it as a typed item such as
-`autonomy_wake`; it must not synthesize the divider by inspecting message text.
-The live event path emits the same typed item when `begin_run()` succeeds so the
-portal does not wait for a history refresh.
-
-The divider contains no briefing payload. Wake names and payloads remain in the
-volatile system context, while run provenance remains queryable through the
-run's `wake_event_ids`. A later expandable run inspector may resolve those ids,
-but the channel timeline stays concise by default.
-
-Existing autonomy system messages are historical briefing rows. The portal
-renders those rows as wake dividers for compatibility and never renders their
-content. New runs stop creating them. The history API should omit their raw
-content from autonomy timeline responses so UI hiding does not leave the
-briefing exposed over the network.
-
-Autonomy timeline queries and live state must be scoped by both agent id and
-channel id. The fixed `autonomy` conversation id is shared by agents and cannot
-identify an agent's run on its own.
-
-## Templates And APIs
-
-Replace the overloaded `autonomy_channel.md.j2` with:
-
-- `prompts/en/autonomy_system.md.j2` for standing policy and volatile context
-  blocks.
-- `prompts/en/autonomy_orientation.md.j2` for the tool-free orientation trigger.
-- `prompts/en/autonomy_run.md.j2` for the action-phase trigger.
-
-`PromptEngine` gains:
-
-```rust
-pub fn render_autonomy_system_prompt(
-    &self,
-    shared: AutonomySharedPromptContext,
-    run: AutonomyRunPromptContext,
-) -> Result<String>;
-
-pub fn render_autonomy_orientation_trigger(&self) -> Result<String>;
-
-pub fn render_autonomy_run_trigger(&self) -> Result<String>;
-```
-
-The context structs make ownership and budgets explicit. They should carry
-already-rendered bounded blocks rather than giving templates database access.
-
-`Channel::build_system_prompt()` owns shared context assembly. Autonomy-specific
-run context is collected through a narrow helper in `agent::autonomy`, then
-passed to the channel at construction or through a per-run state handle. Do not
-make `Channel` query autonomy stores on behalf of user channels.
-
-The run driver starts the orientation before `run_agent_turn()` registers direct
-mode tools. The resulting assistant text is inserted into live history and
-persisted through an orientation-specific logger. The action trigger then enters
-the existing channel loop. Do not route orientation output through normal reply
-handling because autonomy has no delivery target and plain text is otherwise
-treated as an incomplete tool-enabled turn.
-
-The timeline API gains a typed autonomy wake item assembled from
-`autonomy_runs`. The corresponding process event and SSE payload carry the run
-id, agent id, channel id, and start timestamp. They never carry the rendered
-briefing.
-
-## Migration
-
-The change does not require a schema migration. Chronicle checkpoints, channel
-history, home-channel settings, task state, run records, and the conversation
-message primary key already provide the required storage and idempotency.
-
-Existing autonomy system rows remain represented in the portal timeline as
-historic wake dividers. Their briefing content is not returned or rendered.
-They are not rehydrated as current briefing input. Future runs stop adding them.
-
-Existing run summaries remain in `autonomy_runs` and in the autonomy transcript
-where terminal publication already wrote them. The recent-runs context renderer
-continues to read the store until the character-budgeted continuity policy
-replaces it.
-
-## Verification
-
-### Prompt rendering
-
-- User and cron channel preambles remain unchanged.
-- Autonomy preambles omit communication, silence, participant, and adapter
-  guidance.
-- `observe`, `suggest`, and `act` each render the correct authority contract.
-- Wake events, task state, goals, active workers, and recent runs appear in
-  separate autonomy system-prompt blocks.
-- Prompt inspection returns the specialized autonomy preamble.
-
-### Chronicle selection
-
-- The autonomy block uses the same rendered chronicle view as a normal channel
-  with id `autonomy`.
-- An explicit home channel adds a second bounded view.
-- No configured home channel, an unresolved target, an empty view, and
-  `home == autonomy` omit the second block.
-- Each block remains inside its allocated budget and reports omitted entries.
-
-### Lifecycle
-
-- Starting an autonomy run persists no briefing message.
-- The orientation request contains no tool definitions and permits exactly one
-  plain-text model response.
-- No branch, worker, memory, shell, file, browser, or completion tool can run
-  before the orientation is recorded.
-- A successful orientation persists once and appears between the wake divider
-  and tool activity.
-- Orientation retries and restart recovery do not duplicate its assistant row.
-- An empty or failed orientation marks the run failed without registering
-  tools.
-- A successful completion, timeout, and failure each produce one terminal
-  assistant transcript entry when they win the `running -> terminal`
-  transition.
-- Duplicate completion, timeout/completion races, and retries produce no
-  duplicate outcome entry.
-- A restart rebuilds both chronicle blocks from durable state.
-
-### Portal timeline
-
-- A new run appears as a typed `System wake {time}` divider in history and over
-  the live event stream.
-- The divider timestamp comes from `autonomy_runs.started_at`, not browser
-  receipt time.
-- New runs do not persist or transmit the rendered briefing as a message.
-- Historical autonomy briefing rows render as dividers without exposing their
-  content.
-- Two agents can view their autonomy timelines without sharing runs or live
-  events.
-
-### Gates
-
-Run focused prompt, chronicle, home-channel resolution, and autonomy lifecycle
-tests. Then run `cargo fmt --all`, `cargo check --lib`, interface type checks
-and `bun run build`, followed by `just preflight` and `just gate-pr`.
+The portal should derive epoch dividers from `autonomy_runs`, not heartbeat message text. Wake provenance comes from `wake_event_ids` on the run row.

--- a/docs/design-docs/autonomy.md
+++ b/docs/design-docs/autonomy.md
@@ -1,6 +1,6 @@
 # Autonomy
 
-Spacebot has all the primitives for autonomous operation but no loop that ties them together. Tasks can be claimed. Workers can be spawned. Memories can be saved. Goals can be stored. The cortex observes everything. But none of this fires without a user message.
+Spacebot's autonomy channel is a resident process for self-directed work. Durable wakes and interval heartbeats bring it out of idle. Tasks, goals, workers, memories, and run history provide the state it needs to decide what deserves attention.
 
 This doc defines the autonomy system: how Spacebot wakes up, what it sees, what it can do, and how state is tracked — without a heartbeat.json or heartbeat.md.
 
@@ -16,18 +16,11 @@ This has a well-known failure mode: the agent writes malformed JSON, overwrites 
 
 ## The Autonomy Channel
 
-> **Superseded in part by [autonomy-lifecycle.md](autonomy-lifecycle.md).**
-> That doc replaces the fixed interval with run-scheduled wakes, splits the
-> run into a deliberation phase and an action phase, moves ready-task pickup
-> off the cortex and into the run, and adds explicit task enrichment state.
-> The philosophy, level semantics, wake model, and briefing-as-system-prompt
-> decisions below still hold.
+The autonomy channel starts with the agent and remains alive until shutdown. It is not per-task and not per-heartbeat. It waits while idle, retains interactive worker controls, and processes one event at a time.
 
-The autonomy channel is the agent's process for self-directed work. It is not per-task. It is one channel that wakes on a configured interval, surveys the task state, does as much enrichment and preparation as useful, executes ready tasks if any exist, and exits. On the next interval it wakes again.
+The interval is the default trigger. Schedules, webhooks, task approvals, user comments, worker results, and idle conditions can wake it sooner. The channel is the single consumer of these sources. See [`wakes.md`](wakes.md) for queue semantics and authority rules.
 
-The interval is the default trigger, not the only one. Wake events — schedules, webhooks, internal events like a task approval or a user comment, and idle/staleness conditions — pull the next run forward and appear in its context with their payloads and instructions. The channel is the single consumer of all wake sources; see [`wakes.md`](wakes.md) for the trigger model, queue semantics, and authority rules.
-
-It is structurally similar to a cron channel — periodic, no user present, full agent context. The difference is that it is persistent across runs and has awareness of its own history.
+The resident channel and an autonomy run have different lifetimes. The channel owns live process state. A run is a durable decision epoch with a run id, claimed wake events, child attribution, and a terminal summary. `autonomy_complete` closes the epoch and returns the channel to idle.
 
 The autonomy channel is the only process that:
 - Enriches and researches `pending_approval` tasks without a user present
@@ -41,59 +34,28 @@ It does **not** branch. Branches exist to keep memory tool calls out of user-fac
 
 ## Context on Wake
 
-The cortex assembles the autonomy channel's context before each wake. It gets:
+The autonomy supervisor assembles a fresh heartbeat briefing. It includes:
 
 - **Identity** — SOUL.md, IDENTITY.md, ROLE.md. The agent knows who it is.
 - **Memory bulletin** — the cortex's current knowledge synthesis.
 - **Working memory** — recent system events. What's been happening across all channels.
 - **Wake events** — what pulled this run forward, if anything: the wake's name, instructions, and payload for each pending event since the last run. Surfaced first, because they are usually why the run exists.
-- **Task state** — all active tasks: ready, in-progress, backlog, pending_approval. Full detail on each, including all comments.
+- **Task state** — active tasks grouped by status, with descriptions, execution plans, dependencies, ownership, and prior attempt summaries.
 - **Goals** — all active goals with descriptions and notes. Background context and direction, not a work queue. See [`goals.md`](goals.md).
 - **Active workers** — what's currently running so it doesn't duplicate work.
-- **Its own prior transcript** — the channel's persisted history, where each finished run has compacted to its `autonomy_complete` summary. This is the continuity mechanism; see [Continuity Between Runs](#continuity-between-runs).
+- **Recent epoch summaries** - compact continuity from `autonomy_complete`.
 
-Continuity arrives as the channel's own history rather than as injected run summaries — the run store stays the queryable index and provenance record, not a second delivery path for the same content. The autonomy channel wakes with spatial awareness of where things stand and what it did recently.
+The run store is the continuity index and provenance record. Live history belongs to the current epoch and is cleared before the next one. Retained worker controls are channel state, not transcript state.
 
-### The briefing is the system prompt, not a message
+### Heartbeats are control messages
 
-All of the above renders into the channel's system prompt, re-rendered on each wake. It is not delivered as an inbound message.
+The channel has a dedicated autonomy system contract. Each heartbeat arrives as an ephemeral system message tagged with the current run generation. It is never persisted as user conversation data.
 
-This matters because the autonomy channel is one conversation that spans every run — a single conversation id, one persistent transcript. Anything delivered as a message is written into that transcript and stays there. A briefing sent as a message means run fifty wakes to forty-nine copies of its own instructions, with its actual work crowded out between them. Rendering the same content as the system prompt costs nothing extra, since the cortex already assembles it fresh each wake, and it leaves no residue. It is also the honest representation: a briefing stored with a user role and a system sender describes a participant who does not exist.
+Generation tags fence late messages from older epochs. A bounded doorbell coalesces repeated wake notifications while a turn is busy. Durable wake rows carry the payload, so coalescing the in-memory signal cannot lose work.
 
-Two things legitimately arrive mid-run and so must be messages: the soft wrap-up warning at `warn_secs` and the hard timeout notice at `timeout_secs`. Both are ephemeral — present in the live run's context, never persisted to the transcript. They are scaffolding for one run, not history.
+Worker results are also control messages. They continue the intent that spawned or routed the worker. They do not grant permission to start unrelated work.
 
-The rule the channel is built around: **the transcript holds the agent's own output.** Everything the system tells it is either the system prompt, re-rendered per wake, or an ephemeral mid-run injection. Nothing the system says accumulates.
-
-### Journaled events
-
-That rule governs scaffolding. It does not exclude the agent's own actions — and some of those leave the transcript entirely. When a run sends a message to the home channel, the effect lands on a human, not in the conversation the run is having with itself. The next wake has no way to know it happened.
-
-So actions with effects outside the transcript are journaled into it as they occur:
-
-```text
-Sent to home channel (telegram:8659410676):
-"Found three open issues on the repo you cloned — the oldest looks like a quick win."
-```
-
-**These are recorded as the agent's own turn.** Not as a system row: `log_system_message` persists `role = "system"`, and rehydration keeps only `user` and `assistant` rows (`render_conversation_history_backfill`). A system row is visible in the dashboard and invisible to the agent, which is precisely backwards for a journal entry — the dashboard is not who needs to read it.
-
-What qualifies is decided by one test: **journal only what the next wake cannot re-derive.** Task state, goals, worker status, and run counts are all re-rendered into the system prompt on every wake, so journaling them duplicates content that is already arriving fresh. An outbound message fails that test on both counts — nothing regenerates it, and it cannot be undone. The agent has to know it already spoke.
-
-Held to that test, the set stays small: things a human perceived, and writes to the world outside the agent. Internal state transitions stay out. The failure mode to avoid is a transcript that degrades from a train of thought into a syslog, which is the same pollution the briefing rule exists to prevent, arriving through a different door.
-
-**Journaling is independent of waking.** Two axes that happen to share a vocabulary:
-
-| | Wakes the agent | Appears in the transcript |
-|---|---|---|
-| Registered as a wake trigger | yes | yes, via the run it causes |
-| Journal-only | no | yes, on the next wake |
-| Neither | no | no |
-
-An event is journaled because the agent needs to remember it, and it triggers a wake because it needs acting on *now*. Most things are one or the other. This is what several declared-but-unproduced `SystemEvent` variants are reaching for: `cortex.observation` wants to be journal-only.
-
-**Journal entries must survive compaction.** A run's detail collapses into its summary on exit, and "have I already told them this?" is a question spanning days — exactly the range compaction removes. An outbound-message record that lives only in run detail works for one wake and then silently stops. Outward-facing actions are promoted into the run summary rather than discarded with the rest of the detail.
-
----
+The transcript holds the current epoch's work. System scaffolding and previous epoch detail do not accumulate.
 
 ## What It Does
 
@@ -106,12 +68,12 @@ During a run it can:
 - **Execute ready tasks** — tasks the user has approved. Uses execution tools directly (shell, file, browser) with no forced delegation. Workers available for genuine parallelism.
 - **Create new tasks** — identifies follow-on work and adds it to `pending_approval`. The agent proposes; the user decides.
 - **Update task metadata** — priority, blockers, progress notes.
-- **Record what it notices** — the channel holds `memory_save` and `memory_recall` directly (it does not branch, so there is no persistence branch behind it). Findings are written as they are found, not batched at the end, because a run can time out and lose them.
+- **Record what it notices** — the channel holds `memory_save` and `memory_recall` directly. Durable findings are written as they are found rather than manufactured as a completion quota.
 
 Recording is licensed, not quota'd. A run that genuinely learned nothing records nothing, and the briefing says so in as many words. An agent told to always produce an observation will produce one — restating what it was already given, or narrating its own activity as a discovery — and manufactured memories are worse than none, because they degrade every future recall that has to sift past them.
 
 What it **cannot** do:
-- Hold a conversation. There is no `reply` tool: the channel has no inbound turn to answer, and a user who replies to something it sent is answered by the normal user channel for that conversation. Delivery to a configured target is not conversation — see **Reaching Out** below.
+- Hold a conversation or message users. There is no reply or outbound messaging tool.
 - Execute tasks that are still in `pending_approval`
 - Create cron jobs
 - Spawn other autonomy channels
@@ -129,28 +91,7 @@ The empty branch is built on one claim: **on an empty instance, learning the use
 - **Read what is actually here.** The workspace, registered projects, whatever the user has already done. A cloned repository is a statement of intent.
 - **Record what it learns**, under the rules above.
 - **Find capability gaps** via `spacebot_docs` — features that fit what the user appears to be doing and that they have not set up.
-- **Ask one good question.** If there is a single thing the user could say that would unlock the most, ask that.
-
-The last one is the point. A question that gets answered converts an empty instance into a non-empty one and compounds into every later run. Ten manufactured observations compound into nothing. When the empty branch is deciding what is worth doing, one good question outranks a full survey of an empty system.
-
-`spacebot_docs` is currently registered only on the branch and cortex tool servers (`create_branch_tool_server`, `create_cortex_tool_server`), not in `add_direct_mode_tools` — which is what the autonomy channel receives, and it does not branch. It has to be added there before any of this is reachable.
-
----
-
-## Reaching Out
-
-At `suggest` and above, a run may send to the home channel ([`home-channel.md`](home-channel.md)). This is the one place autonomous work becomes visible to a human without them going looking, so the bar is deliberately high — an agent that reports in every interval gets muted, and a muted agent is worth less than a silent one.
-
-Send when:
-
-- It needs something only the user can provide — a decision, access, a credential, missing context that blocks otherwise-ready work.
-- It found something time-sensitive, where waiting until the user next opens a channel has a cost.
-
-Do not send to report activity. "Here is what I did this run" is what run history is for, and it is visible on demand rather than pushed.
-
-Every send is journaled into the transcript as the agent's own turn, so the next run can see that it already raised something and decide against repeating it. That judgment is the primary control; the content-key backstop exists for loops, not for taste. An unanswered question asked twice in a week is a worse outcome than one asked once and left standing.
-
-With the dial at `observe`, or with no home channel configured, this section does not apply — findings are recorded and nothing is sent.
+- **Stop when orientation is exhausted.** A no-action epoch is correct when another pass would only repeat recent summaries.
 
 ---
 
@@ -206,7 +147,7 @@ wake → survey pending_approval tasks
   → reason about worker findings
   → add_task_comment: synthesised finding + worker_id(s)
   → repeat for next task within turn budget
-  → autonomy_complete → exit
+  → autonomy_complete → close the epoch and return to idle
 ```
 
 The autonomy channel system prompt instructs: investigate and comment freely; never execute a task still in `pending_approval`.
@@ -217,7 +158,9 @@ When a `ready` task is eventually executed, `WorkerContextMode::Briefed` pulls t
 
 ---
 
-## Task Selection and Deduplication
+## Future Task Selection
+
+The resident channel currently reasons from task summaries, dependency metadata, prior attempts, and recent run summaries. The `last_enriched_at` scheme below is a follow-up design and is not part of the current schema.
 
 ### `last_enriched_at`
 
@@ -262,33 +205,25 @@ The last few `autonomy_complete` summaries provide a second deduplication layer 
 
 ---
 
-## Soft Timeout
+## Liveness
 
-Hard timeouts waste runs — cutting off mid-task leaves work in undefined state. Spacebot uses a soft warning instead.
+Elapsed wall-clock time never ends an autonomy epoch and never cancels useful work. Provider requests, tools, and workers keep their own operation-level limits. Daemon shutdown and process restart are explicit terminal events.
 
-The cortex monitors elapsed time. At `warn_secs`, it injects an addendum into the channel's live context:
+An epoch can remain open while owned work is active. `autonomy_complete` is rejected at the tool boundary until every registered child has produced a result. Child admission and finish requests share one lock, which removes the check-then-spawn race.
 
-```
-You have approximately 2 minutes remaining in this run.
-Finish your current task, add any final comments, and call autonomy_complete.
-Do not start a new task.
-```
-
-The channel wraps up gracefully and exits cleanly. The hard `timeout_secs` remains as a safety net but should almost never fire.
-
-Delivery mechanism: a synthetic system message between turns, the same pattern the cron scheduler uses for its timeout wrap-up injection. The worker-style mid-turn injection hook (`inject_rx` on `SpacebotHook`) is wired only for workers today; giving `Channel` the same pair would let the warning land inside a live turn, but that is an enhancement, not a prerequisite.
+On restart, the new supervisor marks any leftover `running` epoch as interrupted before admitting another one. Generation fencing prevents late calls from an older epoch from clearing or completing the current epoch.
 
 ---
 
 ## Continuity Between Runs
 
-**Task comments** — the primary record of what has been investigated and found. Persist indefinitely. The next run sees all prior comments when it reads task state on wake, so it does not duplicate completed investigation.
+**Task comments** — the primary record of investigation findings. They persist indefinitely and are available through task tools and full task execution context. The compact heartbeat survey does not inline every comment.
 
-**Run summaries** — on exit, `autonomy_complete` records what was enriched, what was executed, what was created, and which wake events the run consumed. The summary is persisted as the run's assistant turn in the channel transcript, and the UI renders the consumed wakes as "woken by" provenance per run.
+**Run summaries** - `autonomy_complete` records what was enriched, executed, created, and which wake events the epoch consumed. The UI renders consumed wakes as provenance.
 
-**The summary is the compaction unit.** During a run the channel carries full detail: tool calls, worker results, intermediate reasoning. When the run ends, that detail collapses to the summary. What persists is a stream of summaries — roughly five lines per run — plus the live detail of whichever run is currently executing. The transcript is therefore a continuous record of the agent's own thinking that stays bounded no matter how many times it wakes.
+**The summary is the epoch boundary.** During an epoch the channel carries tool calls, worker results, and intermediate reasoning. The next epoch starts with fresh live history and recent summaries from the run store.
 
-This makes the transcript itself the continuity mechanism, so `run_history_count` is a compaction window rather than a second delivery path. Persisting the transcript *and* injecting the last N summaries from the runs table would feed the same content twice by two mechanisms; the run store remains the queryable index and the provenance record, not a parallel context source.
+`run_history_count` bounds the recent summaries injected into each heartbeat. The run store is both the continuity source and the provenance index. Live model history is scoped to the current epoch.
 
 One consequence worth stating: wake provenance lives in the run store and the UI, not in the transcript. Read on its own, the transcript is uninterrupted thought with no visible cause — "why did run 47 happen" is answered by run history, not by scrolling back.
 
@@ -305,16 +240,16 @@ Working memory provides broader system context. The transcript provides the auto
 > that queries rather than reading a rendered dump.
 
 ```
-Cortex tick
-  → elapsed since last autonomy run >= interval_secs
-    OR unconsumed wake events are pending
-  → no autonomy channel currently running
-  → autonomy.enabled = true
+Agent startup
+  → reconcile interrupted run rows
+  → start one resident autonomy channel and supervisor
+  → wait for heartbeat or durable wake doorbell
   ↓
-Cortex assembles context (identity + bulletin + working memory + tasks + goals)
-  → rendered into the channel's system prompt, not sent as a message
+Supervisor atomically admits one run epoch
+  → claims pending wake rows
+  → sends a generation-tagged system heartbeat
   ↓
-Autonomy channel wakes with full context + its own prior transcript
+Autonomy channel wakes with current tasks, goals, workers, and recent summaries
   ↓
   ├─ pending_approval tasks exist?
   │    → enrich: spawn investigation workers, reason about findings, add_task_comment
@@ -326,10 +261,10 @@ Autonomy channel wakes with full context + its own prior transcript
   └─ no tasks worth acting on?
        → create pending_approval tasks from goals, or exit with "nothing to do"
   ↓
-Calls autonomy_complete → summary recorded in the run store
-  → and persisted as the run's assistant turn; the run's detail compacts to it
+Calls autonomy_complete after owned work settles
+  → summary and actions recorded once
   ↓
-Channel exits → cortex records last_run_at, cleans up
+Epoch closes → channel returns to idle and keeps retained worker controls
 ```
 
 If the channel crashes mid-execution, the task returns to `ready`. If a task fails 3 consecutive times, it moves to `failed` and emits a working memory `Error` event. Enrichment runs (comments only) do not count as failures. `failed` is a new `TaskStatus` variant — the current set is pending_approval, backlog, ready, in_progress, done — so adding it includes the transition table, API, and UI sweep.
@@ -340,13 +275,11 @@ If the channel crashes mid-execution, the task returns to `ready`. If a task fai
 
 ```toml
 [autonomy]
-enabled = false                    # Off by default
+level = "off"                      # off | observe | suggest | act
 interval_secs = 1800               # How often to wake (seconds)
-active_hours = [8, 22]             # UTC hour range — suppress wakes outside this window (optional)
-max_turns = 20                     # Turn budget per run — on exhaustion, behaves like soft timeout
+active_hours = [8, 22]             # Agent-timezone hour range (optional)
+max_turns = 20                     # Agentic-loop turns per heartbeat
 max_tasks_per_run = 2              # Max tasks to work on per wake
-timeout_secs = 600                 # Hard timeout — last resort, should rarely fire
-warn_secs = 480                    # Cortex injects soft warning at this point
 run_history_count = 5              # How many past run summaries to surface on wake
 claim_unowned = true               # Pick up tasks with no assigned agent
 ```
@@ -355,34 +288,32 @@ claim_unowned = true               # Pick up tasks with no assigned agent
 
 Enforced at startup and on config reload — autonomy does not start if any rule is violated:
 
-- `timeout_secs` ≤ `interval_secs` — a run cannot outlast the interval. If equal, runs are back-to-back (continuous operation) — valid but intentional.
-- `warn_secs` < `timeout_secs` — warning must fire before hard timeout. Clamped to `timeout_secs - 60` if violated.
 - `max_tasks_per_run` ≥ 1
-- `interval_secs` ≥ 60 — minimum 1 minute, prevents accidental tight loops.
+- `interval_secs` ≥ 60
 
 ---
 
 ## Implementation
 
-**Phase 1 — Autonomy Channel**
+**Current - Autonomy Channel**
 - `AutonomyChannelContext` builder: identity + bulletin + working memory + tasks + goals + run summaries
-- `autonomy_channel.md.j2` system prompt (enrichment-first, `autonomy_complete` on exit, never execute `pending_approval`)
+- `autonomy_channel.md.j2` heartbeat briefing (worker-aware, `autonomy_complete` returns to idle, never execute `pending_approval`)
 - Goals table migration + `goal_create`, `goal_update`, `goal_list` tools (see `goals.md`)
-- Cortex: interval trigger, `last_run_at` tracking, context assembly, channel lifecycle, soft timeout addendum at `warn_secs`
+- Resident supervisor: interval heartbeat, durable wake claiming, epoch admission, channel lifecycle, and restart reconciliation
 - `autonomy_complete` tool + run summary storage + retrieval for run history. Intentionally distinct from `set_outcome`, which is an unpersisted last-write-wins delivery buffer with no completion contract. Model it on `memory_persistence_complete` instead, which already enforces call-the-terminal-tool-before-exit through the hook retry machinery.
-- `last_enriched_at` column on tasks; atomic claim via `assigned_agent_id`; selection query with priority ordering
-- Task retry/failure handling (3 strikes → `failed`, working memory error event)
 - All config fields + validation
 
-**Phase 2 — Task Comments**
+**Current - Task Comments**
 - `task_comments` table migration
 - `add_task_comment` tool (autonomy channel + workers)
-- Task comments included in task state context on wake
 - Task comments pulled into `WorkerContextMode::Briefed` pipeline
 - API endpoints: list and create comments per task
 - UI: chronological comments on task detail, worker pill with expandable full output
 
-**Phase 3 — Polish**
+**Follow-up**
+- `last_enriched_at` and deterministic enrichment selection
+- Task retry/failure handling
+- Bounded comment signals in the heartbeat survey
 - Autonomy UI surface: run history, last wake time, active enrichment progress
 - "Quiet while active" flag: suppress autonomy wakes when user channels have been recently active
 - Autonomy outcomes surfaced to relevant user channels via working memory synthesis

--- a/docs/design-docs/durable-worker-execution.md
+++ b/docs/design-docs/durable-worker-execution.md
@@ -62,7 +62,7 @@ condition into a terminal outcome. Replace each with checkpoint and recovery.
 | Provider retry ceiling | Fails the worker | Persist backoff state, retry through the routing chain, then suspend until the provider is available. |
 | OpenCode SSE inactivity timeout | Fails the worker | Reattach by session ID, poll the backend, or suspend with a reconnect action. |
 | Cortex liveness intervention | Aborts the handle | Request cooperative checkpointing. Escalate only to `Suspended` after the grace period. |
-| Channel or autonomy timeout | Orphans or cancels children | Transfer worker ownership to the durable supervisor. |
+| Cron channel timeout | Orphans or cancels children | Transfer worker ownership to the durable supervisor. Autonomy has a resident channel and no run timeout. |
 | Process shutdown | Leaves active work for startup failure reconciliation | Drain checkpoints before exit. On boot, restore active workers into `Recovering`. |
 | Startup reconciliation | Marks `Running` workers failed | Resume from checkpoint or mark `Suspended` with recovery evidence. |
 | Backend/session reconnect failure | Fails or retires the worker | Retain resume metadata and suspend for retry or operator remediation. |

--- a/docs/design-docs/session-chronicles.md
+++ b/docs/design-docs/session-chronicles.md
@@ -126,7 +126,7 @@ background_threshold = 0.80
 
 The default stays `Rolling`. Chronicle mode is the better architecture and this doc argues for it, but rolling is the path with production hours on it, and defaults should follow evidence rather than the persuasiveness of a design doc. The default flips when chronicle mode has soak time on real long-running channels, as a separate, deliberate change.
 
-Cron and autonomy channels (`ChannelKind::Cron`, `ChannelKind::Autonomy`, `src/agent/channel.rs:342`) are short-lived by construction — they self-exit once work settles. They stay on rolling compaction regardless of mode; chronicling a channel that will not outlive its run is pure cost.
+Cron channels are short-lived and self-exit once work settles. The autonomy channel is resident, but its live history is scoped to one durable epoch and cleared when the next epoch begins. Both stay on rolling compaction. Their durable summaries already provide the continuity a chronicle would duplicate.
 
 ### Entering chronicle mode with legacy history
 

--- a/docs/design-docs/worker-reliability.md
+++ b/docs/design-docs/worker-reliability.md
@@ -24,7 +24,7 @@ Why workers "die or time out frequently," concretely:
 | 2 | Cortex idle sweep, 600s without *events* | `cortex.rs:1227-1418` | Synthetic `WorkerComplete` | Partial -- live transcript drained if API map is shared |
 | 3 | `handle.abort()` (supervisor, API, `cancel` tool) | `channel.rs:423-544` | Synthetic `WorkerComplete` | Same caveat |
 | 4 | Turn/segment/retry ceilings (6 hard-coded constants) | `worker.rs:26-49`, `hooks/spacebot.rs:94` | Mixed: `Partial`, `Failed`, or `Cancelled` | Varies |
-| 5 | Channel hard-timeout aborts channel, workers orphaned | `cron/scheduler.rs:1488-1495`, `autonomy.rs:330-366` | **None, ever** | Worker keeps running into a void |
+| 5 | Cron channel hard-timeout aborts channel, workers orphaned | `cron/scheduler.rs` | **None, ever** | Worker keeps running into a void |
 | 6 | Broadcast lag drops `WorkerComplete` | `lib.rs:349`, `channel.rs:1433-1452` | **Lost in transit** | Slot leaks, self-exiting channels wedge |
 | 7 | Process shutdown | `main.rs:1780-1810` | **None** -- next boot marks rows `failed` | No |
 | 8 | OpenCode SSE 600s inactivity | `opencode/worker.rs:541-546` | `Failed` | No |
@@ -123,13 +123,13 @@ This inverts the current relationship between the cortex and workers. Today the 
 
 ### 6. Ownership survives channel death
 
-When a cron or autonomy channel hits its hard timeout, its workers transfer to cortex supervision instead of being orphaned. The channel abort path enumerates `worker_handles` and re-registers each worker as detached (same shape as task-pickup workers: cancel oneshot, lifecycle CAS, progress struct). The workers keep running -- their work is usually the valuable part of the cron run -- under stall monitoring, and their outcomes land in the outbox where the reconciliation pass delivers them.
+Autonomy no longer has a channel or run timeout. Its resident channel retains worker handles across heartbeats and consumes their results while active or idle. Cron still needs an ownership transfer path when its hard timeout fires. That abort path should enumerate `worker_handles` and re-register each worker as detached so useful work continues under stall monitoring and its outcome lands in the outbox.
 
-`cancel_all_workers_and_branches` (`channel.rs:668-701`), which was written for this and never wired up, is replaced by this adoption path.
+The resident autonomy supervisor now owns shutdown convergence. Final shutdown and agent deletion cancel and persist every retained child before the database closes. Restart cancels active epoch work but preserves idle interactive workers for session recovery.
 
 ### 7. Shutdown drains
 
-`std::process::exit(0)` with workers in flight is a crash that runs on every restart. Shutdown gains a bounded drain: signal every worker's cancellation token (stage 1), wait up to `shutdown_drain_secs` (default 30), persist what lands, and write `Stalled { phase: "shutdown" }` outbox rows for anything still running so the next boot's reconciliation has truth instead of guesswork. The existing next-boot pass (`history.rs:603-625`) stops inventing `"Spacebot restarted before completion"` failures for workers that actually completed their drain.
+The resident autonomy supervisor performs its drain before agent databases close. A future process-wide worker supervisor still needs the staged `shutdown_drain_secs` contract for user channels and cron-owned workers.
 
 ### 8. Workers are forks
 

--- a/prompts/en/autonomy_channel.md.j2
+++ b/prompts/en/autonomy_channel.md.j2
@@ -1,78 +1,85 @@
-You are {{ agent_name }}. This is your autonomy channel — a scheduled, self-directed run. No human is present and nothing you say is delivered to anyone; work happens through tools only, and the run ends when you call `autonomy_complete`.
+You are {{ agent_name }}. This is an internal autonomy heartbeat on your resident autonomy channel. No human is present and nothing you say is delivered. Work happens through tools. `autonomy_complete` records the current epoch and returns the channel to idle; it does not stop the channel or its retained interactive workers.
 
-## Woken By
+## Trigger
+
+Reason: `{{ trigger_reason }}`{% if elapsed_secs %}
+This epoch has been active for {{ elapsed_secs }} seconds.{% endif %}
 {% if wake_events %}
-These wake events pulled this run forward. They are usually why this run exists — reason about them first. Follow each wake's instructions within your level's rules below.
+
+These durable wake events arrived since the previous turn. Address them before considering unrelated work.
 {% for event in wake_events %}
-- `{{ event.name }}` fired {{ event.fired_at }}{% if event.delivery_count > 1 %} ({{ event.delivery_count }} coalesced firings){% endif %}{% if event.gated %} — observed only, below your current autonomy level: do not act on it{% endif %}{% if event.payload %} — payload: {{ event.payload }}{% endif %}
+- `{{ event.name }}` fired {{ event.fired_at }}{% if event.delivery_count > 1 %} ({{ event.delivery_count }} coalesced firings){% endif %}{% if event.gated %} — observe only; this event requires a higher autonomy level{% endif %}{% if event.payload %} — payload: {{ event.payload }}{% endif %}
 {% if event.instructions %}
   - Instructions: {{ event.instructions }}
 {% endif %}
 {% endfor %}
 {% else %}
-Scheduled interval — no wake events pending.
+
+No new wake events. This heartbeat is permission to inspect current state, not an instruction to manufacture activity.
 {% endif %}
 
 {% if run_history %}
-## Recent Runs
-Your previous run summaries, newest first. Do not repeat work a recent run already did.
+## Recent Epochs
+
+Do not repeat work already covered here.
 {% for run in run_history %}
-- {{ run.started_at }} [{{ run.status }}]{% if run.woken_by > 0 %} (woken by {{ run.woken_by }} event{% if run.woken_by > 1 %}s{% endif %}){% endif %}: {{ run.summary }}
+- {{ run.started_at }} [{{ run.status }}]{% if run.woken_by > 0 %} ({{ run.woken_by }} wake event{% if run.woken_by > 1 %}s{% endif %}){% endif %}: {{ run.summary }}
 {% endfor %}
 {% endif %}
 
 ## Task State
+
 {{ task_state }}
 
 {% if active_goals %}
 ## Active Goals
-Background context and direction, not a work queue. Use goals to decide which tasks matter most and what new work is worth proposing.
+
+Goals rank worthwhile work. They are context, not a queue or permission to ignore task approval.
 
 {{ active_goals }}
 {% endif %}
 
 {% if active_workers %}
 ## Active Workers
-Already running — do not duplicate this work.
+
+These processes are already carrying work. Tend them before starting anything else. Do not duplicate their tasks.{% if level == "act" %} An interactive worker may be retained across epochs and can be continued with `route` when a direct follow-up is necessary.{% else %} Your current level cannot start or route worker execution; use their status only to avoid duplicate work.{% endif %}
+
 {{ active_workers }}
 {% endif %}
 
-## How To Work
+## Decision Order
 
-Survey the task state above and decide what is most valuable, given the goals and what recent runs already covered. This is not a FIFO queue — reason about priorities.
+1. Reconcile newly completed work and required durable task updates.
+2. Tend active work that serves the current highest-priority task. A heartbeat alone is not a reason to add parallel work.
+3. If active workers already cover the most valuable available work, take no new action.
+4. Start new work only when it is clearly independent, goal-aligned, approved at your autonomy level, and more valuable than waiting.
+5. If nothing needs action, call `autonomy_complete` immediately with `actions: []`.
+
+Worker-result retriggers continue the intent that spawned or routed the worker. They are not a fresh board survey and must not start unrelated work.
+
+## Authority
 
 {% if level == "observe" %}
-Your autonomy level is **observe**: survey and summarize only. You may investigate and read anything, and you record what you learn with `memory_save` — observing without remembering is what the level is for. Otherwise you must NOT change anything: no creating tasks, no updating tasks, no executing work, no writing files. Your output is your memories and your `autonomy_complete` summary.
+Your autonomy level is **observe**. Investigate and save durable memories when something genuinely reusable is learned. Do not create or update tasks, execute work, or write files.
 {% elif level == "suggest" %}
-Your autonomy level is **suggest**: enrich and propose, never execute. You may:
-- **Enrich pending_approval tasks** — investigate (workers, web, files) and record findings in task metadata/updates so the user reviews a fully reasoned brief.
-- **Create new tasks** — propose follow-on work as `pending_approval` tasks{% if claim_unowned %} (you may also pick up unowned pending tasks for enrichment){% endif %}. You propose; the user decides.
-You must NOT execute tasks or make changes beyond task enrichment and proposals.
+Your autonomy level is **suggest**. You may enrich `pending_approval` tasks and create new `pending_approval` proposals{% if claim_unowned %}, including unowned proposals{% endif %}. Never execute them or make implementation changes.
 {% elif level == "act" %}
-Your autonomy level is **act**: the full loop. You may:
-- **Enrich pending_approval tasks** — investigate and record findings so the user reviews a fully reasoned brief.
-- **Execute ready tasks** — tasks the user has approved. Use your tools directly; spawn workers for genuine parallelism.
-- **Create new tasks** — propose follow-on work as `pending_approval` tasks{% if claim_unowned %} (you may also claim unowned tasks){% endif %}.
+Your autonomy level is **act**. You may enrich `pending_approval` tasks, execute `ready` tasks, and create follow-on work as `pending_approval`{% if claim_unowned %}. You may claim unowned work when it is clearly within scope{% endif %}.
 {% else %}
-Treat this run as observe: survey and summarize only. Do not mutate anything — no creating tasks, no updating tasks, no executing work, no writing files.
+Treat this epoch as observe-only.
 {% endif %}
 
 {% if instance_is_empty %}
-There are no tasks and no goals. That is not a reason to do nothing — on an instance this empty, learning about {{ agent_name }}'s user and this system is the most valuable work available, and it is what makes every later run better. This run:
-- **Look at what is actually here.** The workspace, registered projects, files the user has already put in place. A cloned repository is a statement of intent — read it and work out what they are trying to do.
-- **Record what you learn** as memories, following the rule below.
-- **Find the gaps.** Use `spacebot_docs` to check which capabilities fit what this user appears to be doing and have not been set up yet.
-- **Work out the one question worth asking.** If there is a single thing the user could tell you that would unlock the most, identify it and put it in your summary. One answered question is worth more than a long survey of an empty system.
-
-Do not invent tasks to look busy. Proposing work nobody asked for is worse than proposing nothing.
+The board and goal list are empty. Check recent epochs before doing discovery. Perform one bounded orientation pass only when it would reveal genuinely new information; otherwise record a no-action epoch. Never invent tasks to look busy.
 {% endif %}
 
-Record what you notice as you go, with `memory_save`, rather than saving it all up for the end — a run can be cut short by its timeout and lose everything it was holding. Save what would genuinely be useful to a future run or to the user: what this system is for, how they work, what they care about, what is broken. This is a licence, not a quota. A run that learned nothing records nothing, and that is a perfectly good run — do not restate what this briefing already told you, and do not record your own activity as though it were a discovery.
+Record reusable discoveries with `memory_save` when they occur. Do not save heartbeat activity, task progress, or facts already present in this briefing.
 
-Hard rules, regardless of level:
-- Tasks in `pending_approval` are NEVER executed. They are waiting for the user. Enrichment only.
+Hard rules:
+- Never execute `pending_approval` tasks.
 - Do not message users, create cron jobs, or modify identity/config.
-- You have up to {{ max_tasks_per_run }} task{% if max_tasks_per_run > 1 %}s{% endif %} this run. Depth beats breadth — leave the rest for the next run.
-- Expect a wrap-up notice after about {{ warn_minutes }} minute{% if warn_minutes > 1 %}s{% endif %}. When it arrives, finish what you're doing and complete the run — do not start a new task.
+- Use at most {{ max_tasks_per_run }} task{% if max_tasks_per_run > 1 %}s{% endif %} in this epoch. Depth beats breadth.
+- Do not cancel useful workers to make an epoch finish.
+- Do not start new work after calling `autonomy_complete`.
 
-When you are done (or have nothing worth doing), call `autonomy_complete` with a 2-5 line summary and one actions entry per task you enriched, created, or executed. Every run must end with this call.
+When this epoch has nothing left to decide or supervise, call `autonomy_complete` with a concise summary and one action per task actually enriched, created, or executed.

--- a/prompts/en/channel.md.j2
+++ b/prompts/en/channel.md.j2
@@ -2,6 +2,15 @@
 {{ identity_context }}
 {%- endif %}
 
+{% if autonomy_channel %}
+## Autonomy Operating Contract
+
+This is a resident internal control channel. No human receives your text output. Use tools to inspect and change state, and use `autonomy_complete` to close the current epoch when it has nothing left to decide or supervise.
+
+Own selected work until its result is durable and checked. Tend active workers before admitting more work. A heartbeat is permission to reassess current state, not an instruction to stay busy. Never cancel useful work merely to finish an epoch.
+
+Ground decisions in live task, goal, worker, and project state. Do not narrate internal process mechanics. Do not use `skip`, `reply`, or plain text as an outcome.
+{% else %}
 ## Operating Contract
 
 You own every request made of you until it is finished. Finished means the result exists and you have checked it — not that you described it, planned it, or handed it to another process.
@@ -54,6 +63,7 @@ You have a `skip` tool. Use it. Not every message needs a response from you.
 - The conversation has stalled and your input would restart it meaningfully.
 
 When in doubt, skip. Being a lurker who speaks when it matters is better than being a reply guy who can't read the room. The `skip` tool takes an optional reason — use it for your own tracking, the user never sees it.
+{% endif %}
 
 {%- if adapter_prompt %}
 ## Adapter Guidance
@@ -79,7 +89,11 @@ This section reflects what is registered for this turn. A capability not listed 
 
 ## Task Board
 
+{% if autonomy_channel %}
+Manage task state through the tools available in this direct execution channel. Approval remains authoritative: enrich `pending_approval`, execute only `ready`, and keep findings and outcomes durable.
+{% else %}
 Branch to manage the task board. The branch writes rich task specs and moves them across the board; active tasks appear in your Memory Store.
+{% endif %}
 {%- if agent_links %}
 
 ## Linked Agents

--- a/prompts/en/fragments/system/autonomy_contract_retry.md.j2
+++ b/prompts/en/fragments/system/autonomy_contract_retry.md.j2
@@ -1,1 +1,1 @@
-You must finish this autonomy run by calling autonomy_complete. Provide a 2-5 line summary of what this run observed and did, plus an actions entry for every task you enriched, created, or executed. Do not start new work.
+This autonomy epoch has no active work but has not called autonomy_complete. Call autonomy_complete now with a concise final summary and one action per task actually enriched, created, or executed. If no action was needed, use an empty actions list. Do not start new work.

--- a/prompts/en/fragments/system/autonomy_hard_timeout.md.j2
+++ b/prompts/en/fragments/system/autonomy_hard_timeout.md.j2
@@ -1,1 +1,0 @@
-Time is up. Some work may not have finished. Call autonomy_complete NOW with a summary of whatever this run accomplished. Do not start any new work.

--- a/prompts/en/fragments/system/autonomy_soft_warning.md.j2
+++ b/prompts/en/fragments/system/autonomy_soft_warning.md.j2
@@ -1,1 +1,0 @@
-You have approximately {{ remaining_minutes }} minute{% if remaining_minutes != 1 %}s{% endif %} remaining in this run. Finish your current task, add any final notes, and call autonomy_complete. Do not start a new task.

--- a/prompts/en/fragments/system/retrigger_autonomy.md.j2
+++ b/prompts/en/fragments/system/retrigger_autonomy.md.j2
@@ -1,4 +1,4 @@
-[System: {{ results | length }} background process(es) just completed. This is an autonomy run — no human is present and nothing you say is delivered to anyone. Incorporate the results below into your work, then continue or finish the run.
+[System: {{ results | length }} background process result(s) arrived for the current autonomy epoch. No human is present and nothing you say is delivered. Reconcile these results before doing anything else.
 
 {% for r in results %}
 --- {{ r.process_type }} {{ r.process_id }}{% if not r.success %} (FAILED){% endif %} ---
@@ -6,5 +6,7 @@
 {% endfor %}
 Instructions:
 - Do not attempt to relay these results to any user — there is no reply surface from this channel.
-- Use them to decide your next action: keep working, or call `autonomy_complete` with a summary that reflects what these results changed.
+- Continue the intent that produced these results. This is not a fresh board survey and not permission to begin unrelated work.
+- Apply any required task comment, status, memory, or direct follow-up.
+- If the selected work is settled, call `autonomy_complete`. Otherwise route or spawn only the direct follow-up required to settle it.
 - Do not mention internal processes (branch, worker, retrigger, process IDs).]

--- a/prompts/en/fragments/worker_capabilities.md.j2
+++ b/prompts/en/fragments/worker_capabilities.md.j2
@@ -68,4 +68,4 @@ When you tell the user you're using OpenCode, make it true in the tool call: inc
 Default to OpenCode for code work when it's enabled. Use builtin workers for short command/file tasks.
 {%- endif %}
 
-When spawning workers for project tasks, use the project's repo or worktree directory. For new work in an existing project, create a worktree for the target repo with `project_manage`'s `create_worktree` action before spawning an OpenCode worker in it.
+When spawning workers for project tasks, use the project's repo or worktree directory.{% if project_manage_available %} For new work in an existing project, create a worktree for the target repo with `project_manage`'s `create_worktree` action before spawning an OpenCode worker in it.{% endif %}

--- a/prompts/en/tools/autonomy_complete_description.md.j2
+++ b/prompts/en/tools/autonomy_complete_description.md.j2
@@ -1,7 +1,7 @@
-Record the outcome of this autonomy run and end it. Required — every autonomy run must finish with exactly one call to this tool, including runs where nothing was worth doing.
+Record the outcome of the current autonomy epoch and return the resident channel to idle. Required once the epoch has nothing left to decide or supervise, including heartbeats where no action was needed. This does not stop retained interactive workers.
 
 Provide:
 - `summary`: 2-5 lines covering what you observed, what you did, and anything the next run should know. This is your primary continuity mechanism — the next run reads it verbatim.
 - `actions`: one entry per task you touched, with `kind` set to "enriched" (investigated and recorded findings), "created" (proposed a new pending_approval task), or "executed" (ran an approved ready task), the `task_number` when applicable, and a one-line `detail`.
 
-Do not call this while workers you spawned are still running work you intend to use — synthesize their results first. After this call, do not start any new work.
+Do not call this while workers are still running work this epoch needs. Synthesize their results first. After this call, do not start or route new work until a later heartbeat opens another epoch.

--- a/src/agent/autonomy.rs
+++ b/src/agent/autonomy.rs
@@ -1,9 +1,9 @@
 //! The autonomy channel: the agent's process for self-directed work.
 //!
-//! One channel wakes on a configured interval (or when wake events are
-//! pending), surveys task state, enriches and proposes work according to the
-//! configured [`AutonomyLevel`], executes user-approved tasks at level `act`,
-//! records a run summary via `autonomy_complete`, and exits. See
+//! One resident channel receives interval heartbeats and durable wake events,
+//! surveys task state, enriches and proposes work according to the configured
+//! [`AutonomyLevel`], executes user-approved tasks at level `act`, and records
+//! durable run epochs via `autonomy_complete`. See
 //! `docs/design-docs/autonomy.md` and `docs/design-docs/wakes.md`.
 
 use crate::agent::channel::{Channel, ChannelKind};
@@ -14,10 +14,11 @@ use crate::tasks::{Task, TaskListFilter, TaskStatus};
 use crate::wakes::{AutonomyRunStatus, AutonomyRunStore};
 use crate::{AgentDeps, InboundMessage, MessageContent, RoutedResponse};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::{Notify, mpsc, watch};
 
 /// Conversation id (and channel id) for the autonomy channel. One per agent.
 pub const AUTONOMY_CONVERSATION_ID: &str = "autonomy";
@@ -27,9 +28,6 @@ const WAKE_EVENT_RETENTION_DAYS: u32 = 30;
 
 /// Maximum pending wake events pulled into a single run's context.
 const WAKE_EVENT_BATCH_LIMIT: i64 = 200;
-
-/// Grace period after the hard-timeout wrap-up message before aborting.
-const HARD_TIMEOUT_GRACE_SECS: u64 = 60;
 
 /// Retry budget for the completion contract — the same budget the
 /// memory-persistence contract uses.
@@ -44,9 +42,24 @@ pub const AUTONOMY_FALLBACK_SUMMARY: &str = "run ended without summary";
 #[derive(Debug, Clone)]
 pub struct AutonomyRunHandle {
     pub run_id: String,
+    pub generation: u64,
     pub store: Arc<AutonomyRunStore>,
     completed: Arc<AtomicBool>,
-    finish_request: Arc<Mutex<Option<AutonomyFinishRequest>>>,
+    state: Arc<Mutex<AutonomyRunState>>,
+    changed: Arc<Notify>,
+}
+
+#[derive(Debug, Default)]
+struct AutonomyRunState {
+    finish_request: Option<AutonomyFinishRequest>,
+    active_children: HashSet<AutonomyChild>,
+    quiescent: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AutonomyChild {
+    Branch(crate::BranchId),
+    Worker(crate::WorkerId),
 }
 
 #[derive(Debug, Clone)]
@@ -56,12 +69,14 @@ pub struct AutonomyFinishRequest {
 }
 
 impl AutonomyRunHandle {
-    pub fn new(run_id: String, store: Arc<AutonomyRunStore>) -> Self {
+    pub fn new(run_id: String, generation: u64, store: Arc<AutonomyRunStore>) -> Self {
         Self {
             run_id,
+            generation,
             store,
             completed: Arc::new(AtomicBool::new(false)),
-            finish_request: Arc::new(Mutex::new(None)),
+            state: Arc::new(Mutex::new(AutonomyRunState::default())),
+            changed: Arc::new(Notify::new()),
         }
     }
 
@@ -76,32 +91,261 @@ impl AutonomyRunHandle {
 
     /// Store the first finish request so duplicate tool calls cannot replace
     /// the summary that will be committed after child workers settle.
-    pub fn request_finish(&self, request: AutonomyFinishRequest) -> bool {
-        let mut finish_request = self
-            .finish_request
+    pub fn request_finish(
+        &self,
+        request: AutonomyFinishRequest,
+    ) -> std::result::Result<bool, usize> {
+        let mut state = self
+            .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if finish_request.is_some() {
-            return false;
+        if state.finish_request.is_some() {
+            return Ok(false);
         }
-        *finish_request = Some(request);
-        true
+        if !state.active_children.is_empty() {
+            return Err(state.active_children.len());
+        }
+        state.finish_request = Some(request);
+        drop(state);
+        self.changed.notify_one();
+        Ok(true)
     }
 
     pub fn finish_requested(&self) -> bool {
-        let finish_request = self
-            .finish_request
+        let state = self
+            .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        finish_request.is_some()
+        state.finish_request.is_some()
     }
 
     pub fn finish_request(&self) -> Option<AutonomyFinishRequest> {
-        let finish_request = self
-            .finish_request
+        let state = self
+            .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        finish_request.clone()
+        state.finish_request.clone()
+    }
+
+    /// Register work before it can race the run's finish request.
+    pub fn register_child(&self, child: AutonomyChild) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.finish_request.is_some() {
+            return false;
+        }
+        state.quiescent = false;
+        state.active_children.insert(child)
+    }
+
+    pub fn settle_child(&self, child: AutonomyChild) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.active_children.remove(&child) {
+            drop(state);
+            self.changed.notify_one();
+        }
+    }
+
+    pub fn has_active_children(&self) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        !state.active_children.is_empty()
+    }
+
+    pub fn active_children(&self) -> Vec<AutonomyChild> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active_children.iter().copied().collect()
+    }
+
+    pub fn owns_child(&self, child: AutonomyChild) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active_children.contains(&child)
+    }
+
+    pub fn mark_quiescent(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !state.quiescent {
+            state.quiescent = true;
+            drop(state);
+            self.changed.notify_one();
+        }
+    }
+
+    pub fn is_quiescent(&self) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.quiescent
+    }
+
+    pub async fn changed(&self) {
+        self.changed.notified().await;
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AutonomyRunSlot {
+    state: Arc<Mutex<AutonomyRunSlotState>>,
+}
+
+#[derive(Debug, Default)]
+struct AutonomyRunSlotState {
+    generation: u64,
+    current: Option<AutonomyRunHandle>,
+}
+
+impl AutonomyRunSlot {
+    pub fn begin(&self, run_id: String, store: Arc<AutonomyRunStore>) -> AutonomyRunHandle {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.generation = state.generation.saturating_add(1);
+        let handle = AutonomyRunHandle::new(run_id, state.generation, store);
+        state.current = Some(handle.clone());
+        handle
+    }
+
+    pub fn current(&self) -> Option<AutonomyRunHandle> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.current.clone()
+    }
+
+    pub fn clear_if_current(&self, generation: u64) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.current.as_ref().map(|run| run.generation) != Some(generation) {
+            return false;
+        }
+        state.current = None;
+        true
+    }
+}
+
+/// Cloneable doorbell installed in every [`AgentDeps`]. The bounded channel
+/// coalesces repeated heartbeats while the resident supervisor is busy.
+#[derive(Debug, Clone, Default)]
+pub struct AutonomyControl {
+    check_tx: Arc<Mutex<Option<mpsc::Sender<()>>>>,
+    shutdown_tx: Arc<Mutex<Option<watch::Sender<bool>>>>,
+    stopped: Arc<AtomicBool>,
+    stopped_notify: Arc<Notify>,
+    preserve_idle_workers: Arc<AtomicBool>,
+    ready: Arc<AtomicBool>,
+}
+
+impl AutonomyControl {
+    fn attach(&self, check_tx: mpsc::Sender<()>, shutdown_tx: watch::Sender<bool>) {
+        self.stopped.store(false, Ordering::Release);
+        *self
+            .check_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(check_tx);
+        *self
+            .shutdown_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(shutdown_tx);
+    }
+
+    pub fn request_check(&self) {
+        let sender = self
+            .check_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(sender) = sender {
+            match sender.try_send(()) {
+                Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {}
+                Err(mpsc::error::TrySendError::Closed(())) => {
+                    tracing::debug!("autonomy supervisor doorbell is closed");
+                }
+            }
+        }
+    }
+
+    pub fn activate(&self) {
+        self.ready.store(true, Ordering::Release);
+        self.request_check();
+    }
+
+    fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    fn request_shutdown(&self, preserve_idle_workers: bool) {
+        self.preserve_idle_workers
+            .store(preserve_idle_workers, Ordering::Release);
+        let sender = self
+            .shutdown_tx
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        if let Some(sender) = sender {
+            sender.send_replace(true);
+        }
+    }
+
+    pub async fn shutdown_and_wait(&self) {
+        self.request_shutdown(false);
+        while !self.stopped.load(Ordering::Acquire) {
+            let notified = self.stopped_notify.notified();
+            if self.stopped.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+    }
+
+    fn mark_stopped(&self) {
+        self.stopped.store(true, Ordering::Release);
+        self.stopped_notify.notify_waiters();
+    }
+
+    fn should_preserve_idle_workers(&self) -> bool {
+        self.preserve_idle_workers.load(Ordering::Acquire)
+    }
+}
+
+pub struct AutonomySupervisorHandle {
+    control: AutonomyControl,
+    task: tokio::task::JoinHandle<()>,
+    channel_state: crate::agent::channel::ChannelState,
+}
+
+impl AutonomySupervisorHandle {
+    pub fn channel_state(&self) -> crate::agent::channel::ChannelState {
+        self.channel_state.clone()
+    }
+
+    pub async fn shutdown(self, preserve_idle_workers: bool) {
+        self.control.request_shutdown(preserve_idle_workers);
+        if let Err(error) = self.task.await
+            && !error.is_cancelled()
+        {
+            tracing::warn!(%error, "autonomy supervisor failed during shutdown");
+        }
     }
 }
 
@@ -150,179 +394,30 @@ pub fn task_visible_to_agent(task: &Task, agent_id: &str, claim_unowned: bool) -
     }
 }
 
-/// Cortex-tick check: start an autonomy run when one is due.
-///
-/// The run row is inserted before the run task is spawned so the next tick's
-/// `has_active_run` guard sees it — the cortex tick is serial, which makes
-/// this the single-flight gate.
+/// Ask the resident autonomy supervisor to inspect its durable wake state.
 pub async fn maybe_run_autonomy(deps: &AgentDeps) {
-    let config = **deps.runtime_config.autonomy.load();
-    // The instance ceiling caps the per-agent dial without overwriting it:
-    // the run executes at the intersection of the two levels.
-    let config = AutonomyConfig {
-        level: config.level.min(**deps.autonomy_ceiling.load()),
-        ..config
-    };
-    if config.level == AutonomyLevel::Off {
-        return;
-    }
-
-    // A pause is an emergency stop on new work, and a self-directed run is
-    // the most new work the agent can start.
-    if deps.pause_reason().is_some() {
-        return;
-    }
-
-    let stale_after_secs = config.timeout_secs.saturating_mul(2).max(60);
-    match deps
-        .autonomy_run_store
-        .has_active_run(stale_after_secs)
-        .await
-    {
-        Ok(true) => return,
-        Ok(false) => {}
-        Err(error) => {
-            tracing::warn!(%error, "failed to check for active autonomy run");
-            return;
-        }
-    }
-
-    let last_run_started_at = match deps.autonomy_run_store.last_run_started_at().await {
-        Ok(value) => value,
-        Err(error) => {
-            tracing::warn!(%error, "failed to read last autonomy run start");
-            return;
-        }
-    };
-    let pending_wake_events = match deps.wake_event_store.pending_count().await {
-        Ok(count) => count,
-        Err(error) => {
-            tracing::warn!(%error, "failed to count pending wake events");
-            return;
-        }
-    };
-    let (current_hour, _timezone) =
-        crate::cron::scheduler::current_hour_and_timezone(&deps.runtime_config);
-
-    if !autonomy_run_due(
-        config.level,
-        chrono::Utc::now(),
-        last_run_started_at,
-        pending_wake_events,
-        config.active_hours,
-        current_hour,
-        config.interval_secs,
-    ) {
-        return;
-    }
-
-    let run_id = match deps.autonomy_run_store.begin_run().await {
-        Ok(run_id) => run_id,
-        Err(error) => {
-            tracing::warn!(%error, "failed to begin autonomy run");
-            return;
-        }
-    };
-
-    tracing::info!(
-        agent_id = %deps.agent_id,
-        run_id = %run_id,
-        level = %config.level,
-        pending_wake_events,
-        "starting autonomy run"
-    );
-
-    let deps = deps.clone();
-    tokio::spawn(async move {
-        if let Err(error) = run_autonomy_channel(&deps, run_id.clone(), config).await {
-            tracing::error!(%error, run_id = %run_id, "autonomy run failed");
-            match deps
-                .autonomy_run_store
-                .finish_run_status(
-                    &run_id,
-                    AutonomyRunStatus::Failed,
-                    Some(&format!("run failed: {error}")),
-                )
-                .await
-            {
-                Ok(true) => {
-                    publish_terminal_summary(&deps, &run_id, &format!("run failed: {error}"))
-                }
-                Ok(false) => {}
-                Err(finish_error) => {
-                    tracing::warn!(%finish_error, run_id = %run_id, "failed to record autonomy run failure");
-                }
-            }
-        }
-    });
+    deps.autonomy_control.request_check();
 }
 
 /// Handle an external wake by checking whether an autonomy run is due.
 pub async fn wake_one(deps: &AgentDeps) {
-    maybe_run_autonomy(deps).await;
+    deps.autonomy_control.request_check();
 }
 
-/// Execute a single autonomy run: consume pending wake events, assemble the
-/// run briefing, drive the channel to completion under the soft/hard timeout,
-/// and record the outcome.
-pub async fn run_autonomy_channel(
-    deps: &AgentDeps,
-    run_id: String,
-    config: AutonomyConfig,
-) -> anyhow::Result<()> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(config.timeout_secs);
-    // Consume pending wake events at run start. A crash after this point does
-    // not replay events — crash semantics for tasks are handled by task
-    // status, not event replay.
-    let pending_events = deps
-        .wake_event_store
-        .pending(WAKE_EVENT_BATCH_LIMIT)
-        .await?;
-    let event_ids: Vec<String> = pending_events
-        .iter()
-        .map(|event| event.id.clone())
-        .collect();
-    if !event_ids.is_empty() {
-        deps.wake_event_store.consume(&event_ids, &run_id).await?;
-        deps.autonomy_run_store
-            .set_wake_events(&run_id, &event_ids)
-            .await?;
-    }
+pub fn spawn_autonomy_supervisor(deps: AgentDeps) -> AutonomySupervisorHandle {
+    let (check_tx, check_rx) = mpsc::channel(1);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    deps.autonomy_control
+        .attach(check_tx.clone(), shutdown_tx.clone());
 
-    let briefing = build_run_briefing(deps, &config, &pending_events).await?;
-
-    // Timeout prompts are rendered before the channel spawns so a template
-    // failure surfaces immediately instead of mid-run. Config validation
-    // guarantees warn < timeout.
-    let remaining_secs = config.timeout_secs.saturating_sub(config.warn_secs).max(1);
-    let (soft_warning_prompt, hard_timeout_prompt) = {
-        let prompt_engine = deps.runtime_config.prompts.load();
-        let soft = prompt_engine
-            .render_system_autonomy_soft_warning(remaining_secs.div_ceil(60).max(1))
-            .map_err(|error| anyhow::anyhow!("failed to render autonomy soft warning: {error}"))?;
-        let hard = prompt_engine
-            .render_system_autonomy_hard_timeout()
-            .map_err(|error| anyhow::anyhow!("failed to render autonomy hard timeout: {error}"))?;
-        (soft, hard)
-    };
-
+    let run_slot = AutonomyRunSlot::default();
     let channel_id: crate::ChannelId = Arc::from(AUTONOMY_CONVERSATION_ID);
-    let (response_tx, mut response_rx) = tokio::sync::mpsc::channel::<RoutedResponse>(32);
-    // The autonomy channel has no delivery target — drain and drop anything
-    // the channel tries to send so the bounded channel never backs up.
-    tokio::spawn(async move { while response_rx.recv().await.is_some() {} });
+    let (response_tx, response_rx) = tokio::sync::mpsc::channel::<RoutedResponse>(32);
     let event_rx = deps.event_tx.subscribe();
-
-    // Direct tool access: the autonomy channel does not branch — it has no
-    // user-facing context to protect, so it uses memory/execution tools
-    // directly.
     let resolved_settings = ResolvedConversationSettings {
         delegation: DelegationMode::Direct,
         ..ResolvedConversationSettings::default()
     };
-
-    let handle = AutonomyRunHandle::new(run_id.clone(), deps.autonomy_run_store.clone());
-
     let screenshot_dir = deps
         .runtime_config
         .workspace_dir
@@ -333,173 +428,430 @@ pub async fn run_autonomy_channel(
         .workspace_dir
         .join(".spacebot")
         .join("logs");
-
     let (channel, channel_tx) = Channel::new(
-        channel_id.clone(),
+        channel_id,
         ChannelKind::Autonomy,
         deps.clone(),
         response_tx,
         event_rx,
         screenshot_dir,
         logs_dir,
-        None, // autonomy channels don't share live transcript cache
+        None,
         resolved_settings,
-        None, // no cron outcome — delivery is not a concept here
-        Some(handle.clone()),
+        None,
+        Some(run_slot.clone()),
     );
+    let channel_state = channel.state.clone();
 
-    let mut channel_handle = tokio::spawn(channel.run());
-
-    let message = InboundMessage {
-        id: uuid::Uuid::new_v4().to_string(),
-        source: "autonomy".into(),
-        adapter: None,
-        conversation_id: AUTONOMY_CONVERSATION_ID.to_string(),
-        sender_id: "system".into(),
-        agent_id: Some(deps.agent_id.clone()),
-        content: MessageContent::Text(briefing),
-        timestamp: chrono::Utc::now(),
-        metadata: HashMap::new(),
-        formatted_author: None,
-    };
-
-    if let Err(error) = channel_tx.send(message).await {
-        channel_handle.abort();
-        anyhow::bail!("failed to send autonomy briefing to channel: {error}");
+    let control = deps.autonomy_control.clone();
+    let task_control = control.clone();
+    let task = tokio::spawn(async move {
+        if let Err(error) = run_autonomy_supervisor(
+            deps,
+            check_rx,
+            shutdown_rx,
+            run_slot,
+            channel,
+            channel_tx,
+            response_rx,
+        )
+        .await
+        {
+            tracing::error!(%error, "autonomy supervisor stopped with an error");
+        }
+        task_control.mark_stopped();
+    });
+    AutonomySupervisorHandle {
+        control,
+        task,
+        channel_state,
     }
+}
 
-    // Soft warning at warn_secs, hard timeout at timeout_secs.
-    let warn_after = Duration::from_secs(config.warn_secs.min(config.timeout_secs).max(1));
-    let mut timed_out = false;
-    let first_phase = tokio::time::timeout(warn_after, &mut channel_handle).await;
-    let join_result = match first_phase {
-        Ok(join_result) => Some(join_result),
-        Err(_elapsed) => {
-            tracing::info!(
-                run_id = %run_id,
-                remaining_secs,
-                "autonomy run reached soft warning, injecting wrap-up notice"
-            );
-            if channel_tx
-                .send(system_message(deps, soft_warning_prompt))
-                .await
-                .is_err()
-            {
-                tracing::debug!(
-                    run_id = %run_id,
-                    "soft warning not delivered; autonomy channel already exited"
-                );
-            }
+struct ActiveEpoch {
+    handle: AutonomyRunHandle,
+    config: AutonomyConfig,
+    wake_event_ids: Vec<String>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    last_heartbeat: tokio::time::Instant,
+}
 
-            match tokio::time::timeout(Duration::from_secs(remaining_secs), &mut channel_handle)
-                .await
-            {
-                Ok(join_result) => Some(join_result),
-                Err(_elapsed) => {
-                    // Hard timeout: give the LLM one direct turn to record the
-                    // run, mirroring the cron wrap-up pattern.
-                    timed_out = true;
-                    tracing::warn!(run_id = %run_id, "autonomy run hit hard timeout, sending wrap-up prompt");
-                    channel_tx
-                        .send(system_message(deps, hard_timeout_prompt))
-                        .await
-                        .ok();
-                    drop(channel_tx);
-
-                    let grace = Duration::from_secs(HARD_TIMEOUT_GRACE_SECS);
-                    match tokio::time::timeout(grace, &mut channel_handle).await {
-                        Ok(join_result) => Some(join_result),
-                        Err(_elapsed) => {
-                            channel_handle.abort();
-                            if let Err(join_error) = (&mut channel_handle).await
-                                && !join_error.is_cancelled()
-                            {
-                                tracing::warn!(
-                                    run_id = %run_id,
-                                    %join_error,
-                                    "autonomy channel task failed after abort"
-                                );
-                            }
-                            None
+async fn run_autonomy_supervisor(
+    deps: AgentDeps,
+    mut check_rx: mpsc::Receiver<()>,
+    mut shutdown_rx: watch::Receiver<bool>,
+    run_slot: AutonomyRunSlot,
+    channel: Channel,
+    channel_tx: mpsc::Sender<InboundMessage>,
+    mut response_rx: mpsc::Receiver<RoutedResponse>,
+) -> anyhow::Result<()> {
+    loop {
+        match deps
+            .autonomy_run_store
+            .reconcile_running_runs("run interrupted by process restart")
+            .await
+        {
+            Ok(_) => break,
+            Err(error) => {
+                tracing::warn!(%error, "failed to reconcile autonomy runs; retrying");
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            return Ok(());
                         }
                     }
                 }
             }
         }
-    };
+    }
 
-    let channel_failed = match join_result {
-        Some(Ok(Ok(()))) => None,
-        Some(Ok(Err(error))) => Some(format!("autonomy channel failed: {error}")),
-        Some(Err(join_error)) => Some(format!("autonomy channel join failed: {join_error}")),
-        None => None,
-    };
+    let response_drain = tokio::spawn(async move { while response_rx.recv().await.is_some() {} });
+    let channel_control = channel.control_handle();
+    let mut channel_handle = tokio::spawn(channel.run());
+    let heartbeat_period = Duration::from_secs(60);
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + heartbeat_period,
+        heartbeat_period,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut active_epoch: Option<ActiveEpoch> = None;
+    let mut exit_error: Option<anyhow::Error> = None;
 
-    // A finish request closes dispatch before the channel exits. Wait for the
-    // durable child rows instead of cancelling useful work to make closure fit
-    // the parent deadline.
-    let settled = settle_owned_children(&handle, deadline).await?;
+    loop {
+        let run_changed = async {
+            match active_epoch.as_ref() {
+                Some(epoch) => epoch.handle.changed().await,
+                None => std::future::pending::<()>().await,
+            }
+        };
+        let mut should_check = false;
+        tokio::select! {
+            _ = heartbeat.tick() => should_check = true,
+            check = check_rx.recv() => {
+                if check.is_none() {
+                    break;
+                }
+                should_check = true;
+            }
+            _ = run_changed => {}
+            changed = shutdown_rx.changed() => {
+                if changed.is_err() || *shutdown_rx.borrow() {
+                    break;
+                }
+            }
+            result = &mut channel_handle => {
+                match result {
+                    Ok(Ok(())) => exit_error = Some(anyhow::anyhow!("resident autonomy channel exited")),
+                    Ok(Err(error)) => exit_error = Some(error.into()),
+                    Err(error) => exit_error = Some(anyhow::anyhow!("resident autonomy channel task failed: {error}")),
+                }
+                break;
+            }
+        }
 
-    // Record the run outcome after owned noninteractive children settled, or
-    // after the configured hard deadline. The latter retains child attribution
-    // and lets their normal terminal paths finish without parent cancellation.
-    if let Some(request) = handle.finish_request() {
-        let recorded = deps
+        if active_epoch
+            .as_ref()
+            .is_some_and(|epoch| epoch.handle.finish_requested() && epoch.handle.is_quiescent())
+        {
+            let epoch = active_epoch.as_ref().expect("epoch checked as present");
+            match finish_epoch(&deps, &run_slot, epoch).await {
+                Ok(true) => {
+                    active_epoch = None;
+                    should_check = true;
+                }
+                Ok(false) => {
+                    tracing::warn!(run_id = %epoch.handle.run_id, "autonomy epoch is quiescent but durable children have not settled");
+                }
+                Err(error) => {
+                    tracing::warn!(run_id = %epoch.handle.run_id, %error, "failed to finish autonomy epoch; will retry");
+                }
+            }
+        }
+
+        if should_check {
+            if !deps.autonomy_control.is_ready() {
+                continue;
+            }
+            match active_epoch.as_mut() {
+                Some(epoch) if !epoch.handle.finish_requested() => {
+                    if let Err(error) = send_heartbeat(&deps, &channel_tx, epoch).await {
+                        tracing::warn!(run_id = %epoch.handle.run_id, %error, "failed to deliver autonomy heartbeat; will retry");
+                    }
+                }
+                Some(_) => {}
+                None => match start_epoch_if_due(&deps, &run_slot, &channel_tx).await {
+                    Ok(epoch) => active_epoch = epoch,
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to admit autonomy epoch; supervisor remains active");
+                        if let Some(handle) = run_slot.current() {
+                            let summary = format!("epoch admission failed: {error}");
+                            if deps
+                                .autonomy_run_store
+                                .finish_run_status(
+                                    &handle.run_id,
+                                    AutonomyRunStatus::Failed,
+                                    Some(&summary),
+                                )
+                                .await
+                                .unwrap_or(false)
+                            {
+                                publish_terminal_summary(&deps, &handle.run_id, &summary);
+                            }
+                            run_slot.clear_if_current(handle.generation);
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    let interrupted = active_epoch
+        .as_ref()
+        .map(|epoch| epoch.handle.clone())
+        .or_else(|| run_slot.current());
+    if deps.autonomy_control.should_preserve_idle_workers() {
+        if let Some(handle) = &interrupted {
+            for child in handle.active_children() {
+                match child {
+                    AutonomyChild::Branch(branch_id) => {
+                        channel_control
+                            .cancel_branch_with_reason(branch_id, "daemon restarting")
+                            .await;
+                    }
+                    AutonomyChild::Worker(worker_id) => {
+                        channel_control
+                            .cancel_worker_with_reason(worker_id, "daemon restarting")
+                            .await;
+                    }
+                }
+            }
+        }
+        channel_control.detach_idle_workers_for_restart().await;
+    } else {
+        channel_control
+            .cancel_all_workers_and_branches("autonomy supervisor shutting down")
+            .await;
+    }
+
+    if let Some(handle) = interrupted {
+        if deps
             .autonomy_run_store
-            .complete_run_if_children_settled(&run_id, &request.summary, &request.actions, !settled)
-            .await?;
-        if recorded {
-            handle.mark_completed();
-            publish_terminal_summary(deps, &run_id, &request.summary);
+            .finish_run_status(
+                &handle.run_id,
+                AutonomyRunStatus::Failed,
+                Some("run interrupted while autonomy supervisor stopped"),
+            )
+            .await
+            .unwrap_or_else(|error| {
+                tracing::warn!(%error, run_id = %handle.run_id, "failed to terminalize interrupted autonomy epoch");
+                false
+            })
+        {
+            publish_terminal_summary(
+                &deps,
+                &handle.run_id,
+                "run interrupted while autonomy supervisor stopped",
+            );
         }
-    } else if !handle.completed() {
-        if let Some(failure) = &channel_failed {
-            let recorded = deps
-                .autonomy_run_store
-                .finish_run_status(&run_id, AutonomyRunStatus::Failed, Some(failure))
-                .await?;
-            if recorded {
-                publish_terminal_summary(deps, &run_id, failure);
-            }
-        } else if timed_out {
-            let recorded = deps
-                .autonomy_run_store
-                .finish_run_status(
-                    &run_id,
-                    AutonomyRunStatus::Timeout,
-                    Some(AUTONOMY_FALLBACK_SUMMARY),
-                )
-                .await?;
-            if recorded {
-                publish_terminal_summary(deps, &run_id, AUTONOMY_FALLBACK_SUMMARY);
-            }
-        } else {
-            // The channel-side contract retries were exhausted without a
-            // completion call — record the run with a synthesized summary.
-            let recorded = deps
-                .autonomy_run_store
-                .complete_run(&run_id, AUTONOMY_FALLBACK_SUMMARY, &[])
-                .await?;
-            if recorded {
-                publish_terminal_summary(deps, &run_id, AUTONOMY_FALLBACK_SUMMARY);
-            }
-        }
+        run_slot.clear_if_current(handle.generation);
     }
-
-    if let Err(error) = deps
-        .wake_event_store
-        .prune_consumed(WAKE_EVENT_RETENTION_DAYS)
-        .await
+    channel_handle.abort();
+    if let Err(error) = channel_handle.await
+        && !error.is_cancelled()
     {
-        tracing::warn!(%error, "failed to prune consumed wake events");
+        tracing::warn!(%error, "resident autonomy channel failed while stopping");
     }
-
-    if let Some(failure) = channel_failed {
-        anyhow::bail!(failure);
+    drop(channel_control);
+    response_drain.abort();
+    match exit_error {
+        Some(error) => Err(error),
+        None => Ok(()),
     }
+}
 
-    tracing::info!(run_id = %run_id, timed_out, completed = handle.completed(), "autonomy run finished");
+async fn start_epoch_if_due(
+    deps: &AgentDeps,
+    run_slot: &AutonomyRunSlot,
+    channel_tx: &mpsc::Sender<InboundMessage>,
+) -> anyhow::Result<Option<ActiveEpoch>> {
+    let raw_config = **deps.runtime_config.autonomy.load();
+    let config = AutonomyConfig {
+        level: raw_config.level.min(**deps.autonomy_ceiling.load()),
+        ..raw_config
+    };
+    if config.level == AutonomyLevel::Off || deps.pause_reason().is_some() {
+        return Ok(None);
+    }
+    let pending_count = deps.wake_event_store.pending_count().await?;
+    let last_run_started_at = deps.autonomy_run_store.last_run_started_at().await?;
+    let (current_hour, _) = crate::cron::scheduler::current_hour_and_timezone(&deps.runtime_config);
+    if !autonomy_run_due(
+        config.level,
+        chrono::Utc::now(),
+        last_run_started_at,
+        pending_count,
+        config.active_hours,
+        current_hour,
+        config.interval_secs,
+    ) {
+        return Ok(None);
+    }
+    let permit = match channel_tx.try_reserve() {
+        Ok(permit) => permit,
+        Err(mpsc::error::TrySendError::Full(_)) => return Ok(None),
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            anyhow::bail!("resident autonomy channel inbox is closed")
+        }
+    };
+    let Some(run_id) = deps.autonomy_run_store.try_begin_run().await? else {
+        return Ok(None);
+    };
+    let handle = run_slot.begin(run_id.clone(), deps.autonomy_run_store.clone());
+    let events = deps
+        .wake_event_store
+        .pending(WAKE_EVENT_BATCH_LIMIT)
+        .await?;
+    let event_ids: Vec<String> = events.iter().map(|event| event.id.clone()).collect();
+    let briefing = build_run_briefing(deps, &config, &events, "heartbeat", None).await?;
+    commit_wake_claim(&deps.sqlite_pool, &run_id, &event_ids, &event_ids).await?;
+    permit.send(autonomy_message(deps, briefing, handle.generation, true));
+    tracing::info!(agent_id = %deps.agent_id, %run_id, generation = handle.generation, "autonomy epoch started");
+    Ok(Some(ActiveEpoch {
+        handle,
+        config,
+        wake_event_ids: event_ids,
+        started_at: chrono::Utc::now(),
+        last_heartbeat: tokio::time::Instant::now(),
+    }))
+}
+
+async fn send_heartbeat(
+    deps: &AgentDeps,
+    channel_tx: &mpsc::Sender<InboundMessage>,
+    epoch: &mut ActiveEpoch,
+) -> anyhow::Result<()> {
+    let config = **deps.runtime_config.autonomy.load();
+    let pending_count = deps.wake_event_store.pending_count().await?;
+    if pending_count == 0
+        && epoch.last_heartbeat.elapsed() < Duration::from_secs(config.interval_secs.max(1))
+    {
+        return Ok(());
+    }
+    let permit = match channel_tx.try_reserve() {
+        Ok(permit) => permit,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::debug!(run_id = %epoch.handle.run_id, "autonomy heartbeat coalesced behind queued channel work");
+            return Ok(());
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            anyhow::bail!("resident autonomy channel inbox is closed");
+        }
+    };
+    epoch.config = AutonomyConfig {
+        level: config.level.min(**deps.autonomy_ceiling.load()),
+        ..config
+    };
+    let events = deps
+        .wake_event_store
+        .pending(WAKE_EVENT_BATCH_LIMIT)
+        .await?;
+    let event_ids: Vec<String> = events.iter().map(|event| event.id.clone()).collect();
+    let elapsed = chrono::Utc::now()
+        .signed_duration_since(epoch.started_at)
+        .num_seconds()
+        .max(0) as u64;
+    let briefing =
+        build_run_briefing(deps, &epoch.config, &events, "heartbeat", Some(elapsed)).await?;
+    let mut all_event_ids = epoch.wake_event_ids.clone();
+    all_event_ids.extend(event_ids.iter().cloned());
+    commit_wake_claim(
+        &deps.sqlite_pool,
+        &epoch.handle.run_id,
+        &event_ids,
+        &all_event_ids,
+    )
+    .await?;
+    permit.send(autonomy_message(
+        deps,
+        briefing,
+        epoch.handle.generation,
+        false,
+    ));
+    epoch.wake_event_ids = all_event_ids;
+    epoch.last_heartbeat = tokio::time::Instant::now();
     Ok(())
+}
+
+async fn commit_wake_claim(
+    pool: &sqlx::SqlitePool,
+    run_id: &str,
+    event_ids: &[String],
+    all_event_ids: &[String],
+) -> anyhow::Result<()> {
+    if event_ids.is_empty() {
+        return Ok(());
+    }
+    let placeholders = vec!["?"; event_ids.len()].join(", ");
+    let mut transaction = pool.begin().await?;
+    let query = format!(
+        "UPDATE wake_events SET consumed_by = ? WHERE consumed_by IS NULL AND id IN ({placeholders})"
+    );
+    let mut consume = sqlx::query(&query).bind(run_id);
+    for event_id in event_ids {
+        consume = consume.bind(event_id);
+    }
+    let claimed = consume.execute(&mut *transaction).await?.rows_affected();
+    anyhow::ensure!(
+        claimed == event_ids.len() as u64,
+        "wake event claim lost a concurrency race"
+    );
+    let run_updated = sqlx::query(
+        "UPDATE autonomy_runs SET wake_event_ids = ? WHERE id = ? AND status = 'running'",
+    )
+    .bind(serde_json::to_string(all_event_ids)?)
+    .bind(run_id)
+    .execute(&mut *transaction)
+    .await?
+    .rows_affected();
+    anyhow::ensure!(run_updated == 1, "autonomy run is no longer active");
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn finish_epoch(
+    deps: &AgentDeps,
+    run_slot: &AutonomyRunSlot,
+    epoch: &ActiveEpoch,
+) -> anyhow::Result<bool> {
+    let Some(request) = epoch.handle.finish_request() else {
+        anyhow::bail!("quiescent autonomy epoch has no finish request");
+    };
+    let recorded = deps
+        .autonomy_run_store
+        .complete_run_if_children_settled(
+            &epoch.handle.run_id,
+            &request.summary,
+            &request.actions,
+            false,
+        )
+        .await?;
+    if recorded {
+        epoch.handle.mark_completed();
+        publish_terminal_summary(deps, &epoch.handle.run_id, &request.summary);
+    } else if deps
+        .autonomy_run_store
+        .run_is_active(&epoch.handle.run_id)
+        .await?
+    {
+        return Ok(false);
+    }
+    run_slot.clear_if_current(epoch.handle.generation);
+    deps.wake_event_store
+        .prune_consumed(WAKE_EVENT_RETENTION_DAYS)
+        .await?;
+    tracing::info!(run_id = %epoch.handle.run_id, generation = epoch.handle.generation, "autonomy epoch finished; channel remains resident");
+    Ok(true)
 }
 
 /// The run table transition is the idempotency boundary. Only the caller that
@@ -523,26 +875,18 @@ fn publish_terminal_summary(deps: &AgentDeps, run_id: &str, summary: &str) {
     }
 }
 
-async fn settle_owned_children(
-    handle: &AutonomyRunHandle,
-    deadline: tokio::time::Instant,
-) -> anyhow::Result<bool> {
-    loop {
-        if !handle
-            .store
-            .has_active_owned_children(&handle.run_id)
-            .await?
-        {
-            return Ok(true);
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Ok(false);
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-}
+pub const AUTONOMY_GENERATION_KEY: &str = "autonomy_generation";
+pub const AUTONOMY_EPOCH_START_KEY: &str = "autonomy_epoch_start";
 
-fn system_message(deps: &AgentDeps, text: String) -> InboundMessage {
+fn autonomy_message(
+    deps: &AgentDeps,
+    text: String,
+    generation: u64,
+    epoch_start: bool,
+) -> InboundMessage {
+    let mut metadata = HashMap::new();
+    metadata.insert(AUTONOMY_GENERATION_KEY.to_string(), generation.into());
+    metadata.insert(AUTONOMY_EPOCH_START_KEY.to_string(), epoch_start.into());
     InboundMessage {
         id: uuid::Uuid::new_v4().to_string(),
         source: "system".into(),
@@ -552,7 +896,7 @@ fn system_message(deps: &AgentDeps, text: String) -> InboundMessage {
         agent_id: Some(deps.agent_id.clone()),
         content: MessageContent::Text(text),
         timestamp: chrono::Utc::now(),
-        metadata: HashMap::new(),
+        metadata,
         formatted_author: None,
     }
 }
@@ -562,6 +906,8 @@ async fn build_run_briefing(
     deps: &AgentDeps,
     config: &AutonomyConfig,
     wake_events: &[crate::wakes::WakeEvent],
+    trigger_reason: &str,
+    elapsed_secs: Option<u64>,
 ) -> anyhow::Result<String> {
     let agent_name = deps
         .agent_names
@@ -646,9 +992,10 @@ async fn build_run_briefing(
             (!active_goals.is_empty()).then_some(active_goals.as_str()),
             active_workers.as_deref(),
             config.max_tasks_per_run,
-            config.warn_secs.div_ceil(60).max(1),
             config.claim_unowned,
             instance_is_empty,
+            trigger_reason,
+            elapsed_secs,
         )
         .map_err(|error| anyhow::anyhow!("failed to render autonomy channel prompt: {error}"))
 }
@@ -775,12 +1122,22 @@ fn render_task_line(task: &Task, agent_id: &str, prior_attempts: Option<&str>) -
     line
 }
 
-/// Render currently running workers so the run doesn't duplicate in-flight work.
+/// Render every nonterminal worker so heartbeats can tend retained interactive
+/// sessions as well as actively running work.
 async fn render_active_workers(deps: &AgentDeps) -> anyhow::Result<Option<String>> {
     let logger = crate::conversation::ProcessRunLogger::new(deps.sqlite_pool.clone());
     let (workers, _total) = logger
-        .list_worker_runs(&deps.agent_id, 20, 0, Some("running"))
+        .list_worker_runs(&deps.agent_id, 100, 0, None)
         .await?;
+    let workers: Vec<_> = workers
+        .into_iter()
+        .filter(|worker| {
+            !matches!(
+                worker.lifecycle.as_str(),
+                "succeeded" | "partial" | "cancelled" | "timed_out" | "blocked" | "failed"
+            )
+        })
+        .collect();
     if workers.is_empty() {
         return Ok(None);
     }
@@ -788,9 +1145,19 @@ async fn render_active_workers(deps: &AgentDeps) -> anyhow::Result<Option<String
     let mut output = String::new();
     for worker in workers {
         let task_line = crate::summarize_first_non_empty_line(&worker.task, 160);
+        let ownership = worker
+            .run_id
+            .as_deref()
+            .map(|run_id| format!(", originating epoch {run_id}"))
+            .unwrap_or_default();
+        let interaction = if worker.interactive {
+            ", interactive"
+        } else {
+            ""
+        };
         output.push_str(&format!(
-            "- {} [{}] {}\n",
-            worker.id, worker.worker_type, task_line
+            "- {} [{}; {}{}{}] {}\n",
+            worker.id, worker.worker_type, worker.lifecycle, interaction, ownership, task_line
         ));
     }
     Ok(Some(output))
@@ -800,6 +1167,26 @@ async fn render_active_workers(deps: &AgentDeps) -> anyhow::Result<Option<String
 mod tests {
     use super::*;
     use chrono::TimeZone as _;
+
+    async fn run_store() -> Arc<AutonomyRunStore> {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        Arc::new(AutonomyRunStore::new(pool))
+    }
+
+    async fn test_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
 
     fn utc(secs: i64) -> chrono::DateTime<chrono::Utc> {
         chrono::Utc.timestamp_opt(secs, 0).unwrap()
@@ -959,5 +1346,84 @@ mod tests {
         assert!(!task_visible_to_agent(&theirs, "agent-a", true));
         assert!(task_visible_to_agent(&unowned, "agent-a", true));
         assert!(!task_visible_to_agent(&unowned, "agent-a", false));
+    }
+
+    #[tokio::test]
+    async fn finish_waits_for_owned_children() {
+        let store = run_store().await;
+        let run_id = store.begin_run().await.unwrap();
+        let handle = AutonomyRunHandle::new(run_id, 1, store);
+        let worker_id = crate::WorkerId::new_v4();
+
+        assert!(handle.register_child(AutonomyChild::Worker(worker_id)));
+        assert_eq!(
+            handle.request_finish(AutonomyFinishRequest {
+                summary: "worker still active".to_string(),
+                actions: Vec::new(),
+            }),
+            Err(1)
+        );
+        handle.settle_child(AutonomyChild::Worker(worker_id));
+        assert_eq!(
+            handle.request_finish(AutonomyFinishRequest {
+                summary: "worker result incorporated".to_string(),
+                actions: Vec::new(),
+            }),
+            Ok(true)
+        );
+        assert!(!handle.register_child(AutonomyChild::Worker(crate::WorkerId::new_v4())));
+    }
+
+    #[tokio::test]
+    async fn stale_generation_cannot_clear_current_epoch() {
+        let store = run_store().await;
+        let slot = AutonomyRunSlot::default();
+        let first = slot.begin("first".to_string(), store.clone());
+        assert!(slot.clear_if_current(first.generation));
+        let second = slot.begin("second".to_string(), store);
+
+        assert!(!slot.clear_if_current(first.generation));
+        assert_eq!(slot.current().unwrap().run_id, "second");
+        assert!(slot.clear_if_current(second.generation));
+        assert!(slot.current().is_none());
+    }
+
+    #[tokio::test]
+    async fn autonomy_doorbell_coalesces_while_pending() {
+        let control = AutonomyControl::default();
+        let (check_tx, mut check_rx) = mpsc::channel(1);
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        control.attach(check_tx, shutdown_tx);
+
+        assert!(!control.is_ready());
+        control.activate();
+        assert!(control.is_ready());
+        control.request_check();
+
+        assert_eq!(check_rx.recv().await, Some(()));
+        assert!(check_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn wake_claim_rolls_back_when_epoch_is_not_active() {
+        let pool = test_pool().await;
+        let wake_store = crate::wakes::WakeEventStore::new(pool.clone());
+        wake_store
+            .enqueue("task.approved", "task:7", &serde_json::json!({"task": 7}))
+            .await
+            .unwrap();
+        let event = wake_store.pending(1).await.unwrap().remove(0);
+
+        assert!(
+            commit_wake_claim(
+                &pool,
+                "missing-run",
+                std::slice::from_ref(&event.id),
+                std::slice::from_ref(&event.id),
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(wake_store.pending_count().await.unwrap(), 1);
     }
 }

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -423,8 +423,8 @@ struct AgentTurnResult {
 /// What kind of conversation a channel is serving.
 ///
 /// Channels behave differently depending on who is on the other end: user
-/// channels are driven by incoming messages, while cron and autonomy channels
-/// are system-initiated runs that do their work and exit.
+/// channels are driven by incoming messages, cron channels are one-shot, and
+/// autonomy is a resident system channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelKind {
     User,
@@ -443,10 +443,9 @@ impl std::fmt::Display for ChannelKind {
 }
 
 impl ChannelKind {
-    /// System-initiated channels receive no further user messages after the
-    /// initial prompt, so the event loop exits once all work settles.
+    /// Cron channels receive one prompt and exit once all work settles.
     pub fn self_exits(&self) -> bool {
-        matches!(self, ChannelKind::Cron | ChannelKind::Autonomy)
+        matches!(self, ChannelKind::Cron)
     }
 
     /// System-initiated runs repeat the same procedure on a schedule and
@@ -456,8 +455,7 @@ impl ChannelKind {
     }
 
     /// System-initiated channels have no user to send a reset message, so the
-    /// retrigger cap would permanently stall multi-worker jobs. The job
-    /// timeout is the natural bound instead.
+    /// retrigger cap would permanently stall multi-worker jobs.
     pub fn caps_retriggers(&self) -> bool {
         matches!(self, ChannelKind::User)
     }
@@ -535,13 +533,18 @@ pub struct ChannelState {
     /// router-side control plane can apply a mode change mid-turn; the
     /// channel reads it at every gate instead of its startup snapshot.
     pub response_mode: Arc<std::sync::atomic::AtomicU8>,
-    /// Autonomy run state for the `autonomy_complete` tool. Set only on
-    /// `ChannelKind::Autonomy` channels; the run loop uses it to enforce the
-    /// completion contract before self-exit.
-    pub autonomy_run: Option<crate::agent::autonomy::AutonomyRunHandle>,
+    /// Current autonomy epoch. The slot survives between epochs while each
+    /// generation gets a fresh handle and completion contract.
+    pub autonomy_run: Option<crate::agent::autonomy::AutonomyRunSlot>,
 }
 
 impl ChannelState {
+    pub fn autonomy_run(&self) -> Option<crate::agent::autonomy::AutonomyRunHandle> {
+        self.autonomy_run
+            .as_ref()
+            .and_then(crate::agent::autonomy::AutonomyRunSlot::current)
+    }
+
     /// Append a message this agent sent into the channel from outside the
     /// channel's own turn loop, so the next turn sees what was said.
     ///
@@ -734,7 +737,7 @@ impl ChannelState {
         Ok(())
     }
 
-    async fn cleanup_worker_routing(&self, worker_id: WorkerId) {
+    pub(crate) async fn cleanup_worker_routing(&self, worker_id: WorkerId) {
         self.worker_inputs.write().await.remove(&worker_id);
         self.worker_injections.write().await.remove(&worker_id);
         self.active_workers.write().await.remove(&worker_id);
@@ -980,6 +983,57 @@ impl ChannelControlHandle {
                 .await;
         }
     }
+
+    /// Stop local tasks for idle interactive workers without changing their
+    /// durable waiting state. Startup reconnects these sessions by worker id.
+    pub async fn detach_idle_workers_for_restart(&self) {
+        let idle_worker_ids: Vec<WorkerId> = self
+            .inner
+            .state
+            .status_block
+            .read()
+            .await
+            .active_workers
+            .iter()
+            .filter(|worker| worker.interactive && worker.status == "idle")
+            .map(|worker| worker.id)
+            .collect();
+        for worker_id in idle_worker_ids {
+            if let Some(mut control) = self
+                .inner
+                .state
+                .worker_handles
+                .write()
+                .await
+                .remove(&worker_id)
+            {
+                control.handle.abort();
+                if let Err(error) = (&mut control.handle).await
+                    && !error.is_cancelled()
+                {
+                    tracing::warn!(%error, %worker_id, "idle worker task failed while detaching for restart");
+                }
+            }
+            self.inner
+                .state
+                .worker_inputs
+                .write()
+                .await
+                .remove(&worker_id);
+            self.inner
+                .state
+                .worker_injections
+                .write()
+                .await
+                .remove(&worker_id);
+            self.inner
+                .state
+                .active_workers
+                .write()
+                .await
+                .remove(&worker_id);
+        }
+    }
 }
 
 /// RAII flag for the shared turn-active cell: set on entry to message
@@ -1094,10 +1148,11 @@ pub struct Channel {
     /// Injected into the system prompt (not into chat history) so the LLM
     /// treats it as read-only context rather than actionable user messages.
     backfill_transcript: Option<String>,
-    /// Retry-prompts sent so far for the autonomy completion contract.
-    /// Autonomy channels must call `autonomy_complete` before self-exit;
-    /// this bounds how many times the run loop nudges them.
+    /// Retry prompts sent for the current autonomy epoch's completion contract.
     autonomy_contract_retries: usize,
+    /// A lifecycle event was dropped from the broadcast receiver. While set,
+    /// heartbeats reconcile owned workers from durable lifecycle state.
+    autonomy_event_lagged: bool,
     /// Handle exposed to the supervision control plane.
     control_handle: ChannelControlHandle,
     /// Per-conversation resolved settings (memory mode, delegation mode, model override).
@@ -1195,7 +1250,7 @@ impl Channel {
         live_process_transcripts: Option<LiveProcessTranscripts>,
         resolved_settings: ResolvedConversationSettings,
         cron_outcome: Option<crate::cron::CronOutcome>,
-        autonomy_run: Option<crate::agent::autonomy::AutonomyRunHandle>,
+        autonomy_run: Option<crate::agent::autonomy::AutonomyRunSlot>,
     ) -> (Self, mpsc::Sender<InboundMessage>) {
         let process_id = ProcessId::Channel(id.clone());
         let hook = SpacebotHook::new(
@@ -1334,6 +1389,7 @@ impl Channel {
             send_agent_message_tool,
             backfill_transcript: None,
             autonomy_contract_retries: 0,
+            autonomy_event_lagged: false,
             control_handle,
             resolved_settings,
         };
@@ -1344,11 +1400,10 @@ impl Channel {
     /// Set the backfill transcript for injection into the system prompt.
     /// Whether this channel sheds history through the chronicle.
     ///
-    /// Cron and autonomy channels self-exit once their work settles, so
-    /// chronicling them costs an LLM call for a story nobody will read.
+    /// System channels use bounded run summaries instead of chronicles.
     fn uses_chronicle(&self) -> bool {
         self.deps.runtime_config.compaction.load().mode == CompactionMode::Chronicle
-            && !self.state.kind.self_exits()
+            && self.state.kind == ChannelKind::User
     }
 
     /// Run whichever context monitor this channel is configured for.
@@ -1391,7 +1446,7 @@ impl Channel {
     /// fresh single-shot session whose prior rows are its own wake prompts, and
     /// its briefing carries the continuity it needs.
     async fn hydrate_history(&mut self) {
-        if self.state.kind.self_exits() {
+        if self.state.kind != ChannelKind::User {
             return;
         }
         if !self.state.history.read().await.is_empty() {
@@ -1879,6 +1934,185 @@ impl Channel {
         }
     }
 
+    async fn begin_autonomy_epoch(&mut self, generation: u64) -> bool {
+        let Some(run) = self.state.autonomy_run() else {
+            return false;
+        };
+        if run.generation != generation {
+            tracing::debug!(
+                generation,
+                current = run.generation,
+                "ignoring stale autonomy epoch message"
+            );
+            return false;
+        }
+
+        self.state.history.write().await.clear();
+        self.state.history_fence.note_head_mutation();
+        self.message_count = 0;
+        self.retrigger_count = 0;
+        self.pending_retrigger = false;
+        self.pending_retrigger_metadata.clear();
+        self.retrigger_deadline = None;
+        self.coalesce_buffer.clear();
+        self.coalesce_deadline = None;
+        self.autonomy_contract_retries = 0;
+        if !self.pending_results.is_empty() {
+            self.pending_retrigger = true;
+            self.retrigger_deadline = Some(
+                tokio::time::Instant::now()
+                    + std::time::Duration::from_millis(RETRIGGER_DEBOUNCE_MS),
+            );
+        }
+        true
+    }
+
+    async fn drive_autonomy_contract(&mut self) -> Result<()> {
+        if self.state.kind != ChannelKind::Autonomy {
+            return Ok(());
+        }
+        let Some(run) = self.state.autonomy_run() else {
+            return Ok(());
+        };
+        if run.finish_requested() {
+            if !run.has_active_children()
+                && !self.pending_retrigger
+                && self.retrigger_deadline.is_none()
+            {
+                run.mark_quiescent();
+            }
+            return Ok(());
+        }
+        if self.message_count == 0
+            || run.has_active_children()
+            || self.pending_retrigger
+            || self.retrigger_deadline.is_some()
+        {
+            return Ok(());
+        }
+
+        if self.autonomy_contract_retries < crate::agent::autonomy::AUTONOMY_CONTRACT_MAX_RETRIES {
+            self.autonomy_contract_retries += 1;
+            let retry_prompt = self
+                .deps
+                .runtime_config
+                .prompts
+                .load()
+                .render_system_autonomy_contract_retry()?;
+            self.handle_message(InboundMessage {
+                id: uuid::Uuid::new_v4().to_string(),
+                source: "system".into(),
+                adapter: None,
+                conversation_id: crate::agent::autonomy::AUTONOMY_CONVERSATION_ID.to_string(),
+                sender_id: "system".into(),
+                agent_id: Some(self.deps.agent_id.clone()),
+                content: crate::MessageContent::Text(retry_prompt),
+                timestamp: chrono::Utc::now(),
+                metadata: HashMap::new(),
+                formatted_author: None,
+            })
+            .await?;
+            return Ok(());
+        }
+
+        if run
+            .request_finish(crate::agent::autonomy::AutonomyFinishRequest {
+                summary: crate::agent::autonomy::AUTONOMY_FALLBACK_SUMMARY.to_string(),
+                actions: Vec::new(),
+            })
+            .is_err()
+        {
+            return Ok(());
+        }
+        run.mark_quiescent();
+        Ok(())
+    }
+
+    async fn recover_lagged_autonomy_children(&mut self) -> Result<()> {
+        let Some(run) = self.state.autonomy_run() else {
+            return Ok(());
+        };
+        let mut recovered = 0usize;
+        for child in run.active_children() {
+            let crate::agent::autonomy::AutonomyChild::Worker(worker_id) = child else {
+                tracing::warn!(
+                    ?child,
+                    "cannot recover a lagged autonomy branch result from durable state"
+                );
+                continue;
+            };
+            let Some(lifecycle) = self
+                .state
+                .process_run_logger
+                .read_worker_lifecycle(worker_id)
+                .await?
+            else {
+                continue;
+            };
+            if lifecycle == crate::conversation::WorkerLifecycle::WaitingForInput {
+                self.state
+                    .status_block
+                    .write()
+                    .await
+                    .update(&ProcessEvent::WorkerIdle {
+                        agent_id: self.deps.agent_id.clone(),
+                        worker_id,
+                        channel_id: Some(self.id.clone()),
+                    });
+                self.pending_results.push(PendingResult {
+                    process_type: "worker",
+                    process_id: worker_id.to_string(),
+                    result: "The interactive worker reached idle, but its live result event was lost. Inspect its durable transcript with worker_inspect before deciding the follow-up."
+                        .to_string(),
+                    success: true,
+                });
+                run.settle_child(child);
+                recovered += 1;
+            } else if lifecycle.is_terminal()
+                && let Some(terminal) = self
+                    .state
+                    .process_run_logger
+                    .read_worker_terminal(worker_id)
+                    .await?
+            {
+                self.consumed_worker_outcomes
+                    .insert(worker_id, terminal.outcome_version);
+                self.state.worker_handles.write().await.remove(&worker_id);
+                self.state.worker_inputs.write().await.remove(&worker_id);
+                self.state
+                    .worker_injections
+                    .write()
+                    .await
+                    .remove(&worker_id);
+                self.state
+                    .status_block
+                    .write()
+                    .await
+                    .remove_worker(worker_id);
+                self.pending_results.push(PendingResult {
+                    process_type: "worker",
+                    process_id: worker_id.to_string(),
+                    result: terminal.result,
+                    success: terminal.outcome_kind.is_success(),
+                });
+                run.settle_child(child);
+                recovered += 1;
+            }
+        }
+        if recovered > 0 {
+            self.pending_retrigger = true;
+            self.retrigger_deadline = Some(
+                tokio::time::Instant::now()
+                    + std::time::Duration::from_millis(RETRIGGER_DEBOUNCE_MS),
+            );
+            tracing::warn!(
+                recovered,
+                "recovered autonomy child results after event receiver lag"
+            );
+        }
+        Ok(())
+    }
+
     /// Run the channel event loop.
     pub async fn run(mut self) -> Result<()> {
         tracing::info!(channel_id = %self.id, "channel started");
@@ -1887,7 +2121,9 @@ impl Channel {
         let mut last_lag_warning: Option<std::time::Instant> = None;
 
         loop {
-            // Self-exiting channels (cron, autonomy) have no further user messages
+            self.drive_autonomy_contract().await?;
+
+            // Self-exiting cron channels have no further user messages
             // after the initial prompt. Once all workers/branches finish and no
             // retrigger is pending, exit so the caller can flush the reply buffer.
             // Without this the channel would wait on the broadcast event_rx (which
@@ -1899,64 +2135,6 @@ impl Channel {
                 && self.state.worker_handles.read().await.is_empty()
                 && self.state.active_branches.read().await.is_empty()
             {
-                // Autonomy runs must record their outcome via autonomy_complete
-                // before exiting. When the call is missing, nudge the LLM with
-                // a retry prompt (same budget as the memory-persistence
-                // contract) before giving up; the run driver records a
-                // fallback summary if the budget is exhausted.
-                if let Some(run) = self.state.autonomy_run.clone()
-                    && !run.completed()
-                    && !run.finish_requested()
-                    && self.autonomy_contract_retries
-                        < crate::agent::autonomy::AUTONOMY_CONTRACT_MAX_RETRIES
-                {
-                    self.autonomy_contract_retries += 1;
-                    tracing::warn!(
-                        channel_id = %self.id,
-                        attempt = self.autonomy_contract_retries,
-                        "autonomy run missing autonomy_complete call, retrying"
-                    );
-                    let retry_prompt = match self
-                        .deps
-                        .runtime_config
-                        .prompts
-                        .load()
-                        .render_system_autonomy_contract_retry()
-                    {
-                        Ok(text) => text,
-                        Err(error) => {
-                            tracing::error!(
-                                %error,
-                                channel_id = %self.id,
-                                "failed to render autonomy contract retry prompt"
-                            );
-                            break;
-                        }
-                    };
-                    let retry = InboundMessage {
-                        id: uuid::Uuid::new_v4().to_string(),
-                        source: "system".into(),
-                        adapter: None,
-                        conversation_id: self.conversation_id.clone().unwrap_or_else(|| {
-                            crate::agent::autonomy::AUTONOMY_CONVERSATION_ID.to_string()
-                        }),
-                        sender_id: "system".into(),
-                        agent_id: Some(self.deps.agent_id.clone()),
-                        content: crate::MessageContent::Text(retry_prompt),
-                        timestamp: chrono::Utc::now(),
-                        metadata: HashMap::new(),
-                        formatted_author: None,
-                    };
-                    if let Err(error) = self.handle_message(retry).await {
-                        tracing::error!(
-                            %error,
-                            channel_id = %self.id,
-                            "autonomy completion-contract retry failed"
-                        );
-                        break;
-                    }
-                    continue;
-                }
                 tracing::info!(channel_id = %self.id, "self-exiting channel finished all work, exiting");
                 break;
             }
@@ -1981,6 +2159,35 @@ impl Channel {
 
             tokio::select! {
                 Some(message) = self.message_rx.recv() => {
+                    if self.state.kind == ChannelKind::Autonomy
+                        && let Some(generation) = message
+                            .metadata
+                            .get(crate::agent::autonomy::AUTONOMY_GENERATION_KEY)
+                            .and_then(serde_json::Value::as_u64)
+                    {
+                        let epoch_start = message
+                            .metadata
+                            .get(crate::agent::autonomy::AUTONOMY_EPOCH_START_KEY)
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false);
+                        let current = self.state.autonomy_run().map(|run| run.generation);
+                        if current != Some(generation) {
+                            tracing::debug!(generation, ?current, "ignoring autonomy message for stale generation");
+                            continue;
+                        }
+                        if epoch_start && !self.begin_autonomy_epoch(generation).await {
+                            continue;
+                        }
+                        if self.autonomy_event_lagged {
+                            if let Err(error) = self.recover_lagged_autonomy_children().await {
+                                tracing::error!(%error, "failed to reconcile autonomy children on heartbeat");
+                            }
+                            self.autonomy_event_lagged = self
+                                .state
+                                .autonomy_run()
+                                .is_some_and(|run| run.has_active_children());
+                        }
+                    }
                     let config = self.deps.runtime_config.coalesce.load();
                     if self.should_coalesce(&message, &config) {
                         self.coalesce_buffer.push(message);
@@ -2022,6 +2229,9 @@ impl Channel {
                             }
                         }
                         crate::BroadcastRecvResult::Lagged(skipped) => {
+                            if self.state.kind == ChannelKind::Autonomy {
+                                self.autonomy_event_lagged = true;
+                            }
                             #[cfg(feature = "metrics")]
                             crate::telemetry::Metrics::global()
                                 .event_receiver_lagged_events_total
@@ -2041,6 +2251,11 @@ impl Channel {
                                     skipped,
                                     "channel event receiver lagged, dropping old events"
                                 );
+                            }
+                            if self.state.kind == ChannelKind::Autonomy
+                                && let Err(error) = self.recover_lagged_autonomy_children().await
+                            {
+                                tracing::error!(%error, "failed to recover autonomy children after event lag");
                             }
                         }
                         crate::BroadcastRecvResult::Closed => {
@@ -2835,7 +3050,11 @@ impl Channel {
             *reply_target = extract_message_id(&message);
         }
 
-        let is_retrigger = message.source == "system";
+        let is_autonomy_heartbeat = self.state.kind == ChannelKind::Autonomy
+            && message
+                .metadata
+                .contains_key(crate::agent::autonomy::AUTONOMY_GENERATION_KEY);
+        let is_retrigger = message.source == "system" && !is_autonomy_heartbeat;
         let attachment_content = if !attachments.is_empty() {
             if let Some(ref saved_data) = saved_attachment_data {
                 // Reuse already-downloaded bytes for images/text; audio still
@@ -3356,13 +3575,27 @@ impl Channel {
         let opencode_enabled = rc.opencode.load().enabled;
         let mcp_tool_names = self.deps.mcp_manager.get_tool_names().await;
         let worker_context = self.state.worker_context_settings.read().await.clone();
-        let worker_capabilities = prompt_engine.render_worker_capabilities(
-            browser_enabled,
-            web_search_enabled,
-            opencode_enabled,
-            &mcp_tool_names,
-            &worker_context,
-        )?;
+        let autonomy_level = self
+            .deps
+            .runtime_config
+            .autonomy
+            .load()
+            .level
+            .min(**self.deps.autonomy_ceiling.load());
+        let worker_capabilities = if self.state.kind == ChannelKind::Autonomy
+            && autonomy_level != crate::config::AutonomyLevel::Act
+        {
+            String::new()
+        } else {
+            prompt_engine.render_worker_capabilities(
+                browser_enabled,
+                web_search_enabled,
+                opencode_enabled,
+                &mcp_tool_names,
+                &worker_context,
+                self.state.kind != ChannelKind::Autonomy,
+            )?
+        };
 
         // Time no longer renders here — it rides on the current user message
         // envelope instead, so this prompt stays byte-stable across turns
@@ -3438,6 +3671,7 @@ impl Channel {
                 active_goals,
                 execution_mode,
                 authority,
+                autonomy_channel: self.state.kind == ChannelKind::Autonomy,
             })?;
 
         segmented.adopt_appended(
@@ -3506,53 +3740,62 @@ impl Channel {
         // them on the table to be talked into calling.
         let sender_is_authority = crate::commands::dispatch::sender_is_authority(&current_inbound);
 
-        match self.resolved_settings.delegation {
-            DelegationMode::Standard => {
-                // Current behavior - standard channel tools only
-                if let Err(error) = crate::tools::add_channel_tools(
-                    &self.tool_server,
-                    self.state.clone(),
-                    routed_sender,
-                    reply_target,
-                    conversation_id,
-                    skip_flag.clone(),
-                    replied_flag.clone(),
-                    self.deps.cron_tool.clone(),
-                    send_agent_message_tool,
-                    allow_direct_reply,
-                    adapter.map(|s| s.to_string()),
-                    slack_thread_ts.as_deref(),
-                    self.state.cron_outcome.clone(),
-                    sender_is_authority,
-                )
-                .await
-                {
-                    tracing::error!(%error, "failed to add channel tools");
-                    return Err(AgentError::Other(error.into()).into());
-                }
+        if self.state.kind == ChannelKind::Autonomy {
+            if let Err(error) =
+                crate::tools::add_autonomy_tools(&self.tool_server, self.state.clone()).await
+            {
+                tracing::error!(%error, "failed to add autonomy tools");
+                return Err(AgentError::Other(error.into()).into());
             }
-            DelegationMode::Direct => {
-                // Full tool access (cortex chat style)
-                if let Err(error) = crate::tools::add_direct_mode_tools(
-                    &self.tool_server,
-                    self.state.clone(),
-                    routed_sender,
-                    reply_target,
-                    conversation_id,
-                    skip_flag.clone(),
-                    replied_flag.clone(),
-                    self.deps.cron_tool.clone(),
-                    send_agent_message_tool,
-                    allow_direct_reply,
-                    adapter.map(|s| s.to_string()),
-                    slack_thread_ts.as_deref(),
-                    self.state.cron_outcome.clone(),
-                    sender_is_authority,
-                )
-                .await
-                {
-                    tracing::error!(%error, "failed to add direct mode tools");
-                    return Err(AgentError::Other(error.into()).into());
+        } else {
+            match self.resolved_settings.delegation {
+                DelegationMode::Standard => {
+                    // Current behavior - standard channel tools only
+                    if let Err(error) = crate::tools::add_channel_tools(
+                        &self.tool_server,
+                        self.state.clone(),
+                        routed_sender,
+                        reply_target,
+                        conversation_id,
+                        skip_flag.clone(),
+                        replied_flag.clone(),
+                        self.deps.cron_tool.clone(),
+                        send_agent_message_tool,
+                        allow_direct_reply,
+                        adapter.map(|s| s.to_string()),
+                        slack_thread_ts.as_deref(),
+                        self.state.cron_outcome.clone(),
+                        sender_is_authority,
+                    )
+                    .await
+                    {
+                        tracing::error!(%error, "failed to add channel tools");
+                        return Err(AgentError::Other(error.into()).into());
+                    }
+                }
+                DelegationMode::Direct => {
+                    // Full tool access (cortex chat style)
+                    if let Err(error) = crate::tools::add_direct_mode_tools(
+                        &self.tool_server,
+                        self.state.clone(),
+                        routed_sender,
+                        reply_target,
+                        conversation_id,
+                        skip_flag.clone(),
+                        replied_flag.clone(),
+                        self.deps.cron_tool.clone(),
+                        send_agent_message_tool,
+                        allow_direct_reply,
+                        adapter.map(|s| s.to_string()),
+                        slack_thread_ts.as_deref(),
+                        self.state.cron_outcome.clone(),
+                        sender_is_authority,
+                    )
+                    .await
+                    {
+                        tracing::error!(%error, "failed to add direct mode tools");
+                        return Err(AgentError::Other(error.into()).into());
+                    }
                 }
             }
         }
@@ -3758,12 +4001,17 @@ impl Channel {
             }
         }
 
-        let remove_result = match self.resolved_settings.delegation {
-            DelegationMode::Direct => {
-                crate::tools::remove_direct_mode_tools(&self.tool_server, allow_direct_reply).await
-            }
-            DelegationMode::Standard => {
-                crate::tools::remove_channel_tools(&self.tool_server, allow_direct_reply).await
+        let remove_result = if self.state.kind == ChannelKind::Autonomy {
+            crate::tools::remove_direct_mode_tools(&self.tool_server, allow_direct_reply).await
+        } else {
+            match self.resolved_settings.delegation {
+                DelegationMode::Direct => {
+                    crate::tools::remove_direct_mode_tools(&self.tool_server, allow_direct_reply)
+                        .await
+                }
+                DelegationMode::Standard => {
+                    crate::tools::remove_channel_tools(&self.tool_server, allow_direct_reply).await
+                }
             }
         };
         if let Err(error) = remove_result {
@@ -4138,6 +4386,9 @@ impl Channel {
                     self.branch_reply_targets.remove(branch_id);
                     return Ok(());
                 }
+                if let Some(run) = self.state.autonomy_run() {
+                    run.settle_child(crate::agent::autonomy::AutonomyChild::Branch(*branch_id));
+                }
 
                 #[cfg(feature = "metrics")]
                 crate::telemetry::Metrics::global()
@@ -4241,6 +4492,9 @@ impl Channel {
                 self.consumed_worker_outcomes
                     .insert(*worker_id, terminal.outcome_version);
                 self.state.worker_handles.write().await.remove(worker_id);
+                if let Some(run) = self.state.autonomy_run() {
+                    run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(*worker_id));
+                }
                 let result = terminal.result;
                 let success = terminal.outcome_kind.is_success();
 
@@ -4338,6 +4592,13 @@ impl Channel {
             ProcessEvent::WorkerInitialResult {
                 worker_id, result, ..
             } => {
+                if self.state.kind == ChannelKind::Autonomy
+                    && let Some(run) = self.state.autonomy_run()
+                    && !run.owns_child(crate::agent::autonomy::AutonomyChild::Worker(*worker_id))
+                {
+                    tracing::debug!(%worker_id, "duplicate or stale autonomy worker result ignored");
+                    return Ok(());
+                }
                 // Interactive worker completed a task (initial or follow-up)
                 // but stays alive for more input. Deliver the result to the
                 // channel without removing the worker from the active set.
@@ -4347,6 +4608,9 @@ impl Channel {
                     result: result.clone(),
                     success: true,
                 });
+                if let Some(run) = self.state.autonomy_run() {
+                    run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(*worker_id));
+                }
                 should_retrigger = true;
                 tracing::info!(
                     worker_id = %worker_id,
@@ -4363,6 +4627,10 @@ impl Channel {
         // Multiple branch/worker completions within the debounce window are
         // coalesced into a single retrigger to prevent message spam.
         if should_retrigger {
+            if self.state.kind == ChannelKind::Autonomy && self.state.autonomy_run().is_none() {
+                self.deps.autonomy_control.request_check();
+                return Ok(());
+            }
             let cap_applies = self.state.kind.caps_retriggers();
             if cap_applies && self.retrigger_count >= MAX_RETRIGGERS_PER_TURN {
                 tracing::warn!(
@@ -4661,6 +4929,9 @@ impl Channel {
     /// trigger — reflection included — obeys the conversation's memory
     /// persistence controls.
     async fn check_memory_persistence(&mut self) {
+        if self.state.kind == ChannelKind::Autonomy {
+            return;
+        }
         let config = **self.deps.runtime_config.memory_persistence.load();
         let persistence_enabled = config.enabled
             && config.message_interval != 0

--- a/src/agent/channel_dispatch.rs
+++ b/src/agent/channel_dispatch.rs
@@ -358,8 +358,13 @@ async fn spawn_branch(
     dispatch_type: &'static str,
     branch_options: BranchSpawnOptions,
 ) -> std::result::Result<BranchId, AgentError> {
-    if state
-        .autonomy_run
+    let autonomy_run = state.autonomy_run();
+    if state.kind == crate::agent::channel::ChannelKind::Autonomy && autonomy_run.is_none() {
+        return Err(AgentError::Other(anyhow::anyhow!(
+            "can't spawn branch: no active autonomy epoch"
+        )));
+    }
+    if autonomy_run
         .as_ref()
         .is_some_and(crate::agent::autonomy::AutonomyRunHandle::finish_requested)
     {
@@ -445,7 +450,15 @@ async fn spawn_branch(
 
     let prompt = prompt.to_owned();
 
-    state
+    if let Some(run) = &autonomy_run
+        && !run.register_child(crate::agent::autonomy::AutonomyChild::Branch(branch_id))
+    {
+        return Err(AgentError::Other(anyhow::anyhow!(
+            "can't spawn branch: autonomy epoch is finishing"
+        )));
+    }
+
+    if let Err(error) = state
         .process_run_logger
         .log_branch_started(
             &state.channel_id,
@@ -455,13 +468,15 @@ async fn spawn_branch(
             &profile_name,
             &model_name,
             branch_max_turns,
-            state
-                .autonomy_run
-                .as_ref()
-                .map(|autonomy_run| autonomy_run.run_id.as_str()),
+            autonomy_run.as_ref().map(|run| run.run_id.as_str()),
         )
         .await
-        .map_err(|error| AgentError::Other(anyhow::anyhow!(error)))?;
+    {
+        if let Some(run) = &autonomy_run {
+            run.settle_child(crate::agent::autonomy::AutonomyChild::Branch(branch_id));
+        }
+        return Err(AgentError::Other(anyhow::anyhow!(error)));
+    }
 
     // Capture what the spawned task needs to notify the channel on failure.
     // branch.run() only sends BranchResult on the success path, so the
@@ -733,8 +748,13 @@ pub async fn spawn_worker_from_state(
     worker_context: &WorkerContextMode,
     task_context: WorkerTaskContext<'_>,
 ) -> std::result::Result<WorkerId, AgentError> {
-    if state
-        .autonomy_run
+    let autonomy_run = state.autonomy_run();
+    if state.kind == crate::agent::channel::ChannelKind::Autonomy && autonomy_run.is_none() {
+        return Err(AgentError::Other(anyhow::anyhow!(
+            "can't spawn worker: no active autonomy epoch"
+        )));
+    }
+    if autonomy_run
         .as_ref()
         .is_some_and(crate::agent::autonomy::AutonomyRunHandle::finish_requested)
     {
@@ -985,8 +1005,17 @@ async fn spawn_worker_inner(
 
     let worker_id = worker.id;
     let transcript_snapshot = worker.transcript_snapshot();
+    let autonomy_run = state.autonomy_run();
+    if let Some(run) = &autonomy_run
+        && !run.register_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id))
+    {
+        state.cleanup_worker_routing(worker_id).await;
+        return Err(AgentError::Other(anyhow::anyhow!(
+            "can't spawn worker: autonomy epoch is finishing"
+        )));
+    }
 
-    state
+    if let Err(error) = state
         .process_run_logger
         .log_worker_started(
             Some(&state.channel_id),
@@ -996,14 +1025,17 @@ async fn spawn_worker_inner(
             &state.deps.agent_id,
             interactive,
             None,
-            state
-                .autonomy_run
-                .as_ref()
-                .map(|autonomy_run| autonomy_run.run_id.as_str()),
+            autonomy_run.as_ref().map(|run| run.run_id.as_str()),
             task_context.origin_branch_id,
         )
         .await
-        .map_err(|error| AgentError::Other(anyhow::anyhow!(error)))?;
+    {
+        if let Some(run) = &autonomy_run {
+            run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id));
+        }
+        state.cleanup_worker_routing(worker_id).await;
+        return Err(AgentError::Other(anyhow::anyhow!(error)));
+    }
 
     let worker_span = tracing::info_span!(
         "worker.run",
@@ -1225,8 +1257,17 @@ async fn spawn_opencode_worker_inner(
     };
 
     let worker_id = worker.id;
+    let autonomy_run = state.autonomy_run();
+    if let Some(run) = &autonomy_run
+        && !run.register_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id))
+    {
+        state.cleanup_worker_routing(worker_id).await;
+        return Err(AgentError::Other(anyhow::anyhow!(
+            "can't spawn worker: autonomy epoch is finishing"
+        )));
+    }
 
-    state
+    if let Err(error) = state
         .process_run_logger
         .log_worker_started(
             Some(&state.channel_id),
@@ -1236,14 +1277,17 @@ async fn spawn_opencode_worker_inner(
             &state.deps.agent_id,
             interactive,
             Some(&persist_directory),
-            state
-                .autonomy_run
-                .as_ref()
-                .map(|autonomy_run| autonomy_run.run_id.as_str()),
+            autonomy_run.as_ref().map(|run| run.run_id.as_str()),
             task_context.origin_branch_id,
         )
         .await
-        .map_err(|error| AgentError::Other(anyhow::anyhow!(error)))?;
+    {
+        if let Some(run) = &autonomy_run {
+            run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id));
+        }
+        state.cleanup_worker_routing(worker_id).await;
+        return Err(AgentError::Other(anyhow::anyhow!(error)));
+    }
 
     let worker_span = tracing::info_span!(
         "worker.run",

--- a/src/agent/cortex_chat.rs
+++ b/src/agent/cortex_chat.rs
@@ -857,6 +857,7 @@ impl CortexChatSession {
             opencode_enabled,
             &mcp_tool_names,
             &worker_context,
+            true,
         )?;
 
         // Load channel transcript if a channel context is active

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -931,6 +931,22 @@ impl Worker {
                     WorkerLifecycle::WaitingForInput,
                 )
                 .await;
+                let scrubbed = if let Some(store) =
+                    self.deps.runtime_config.secrets.load().as_ref().as_ref()
+                {
+                    crate::secrets::scrub::scrub_with_store(&result, store, &self.deps.agent_id)
+                } else {
+                    result.clone()
+                };
+                self.deps
+                    .event_tx
+                    .send(crate::ProcessEvent::WorkerInitialResult {
+                        agent_id: self.deps.agent_id.clone(),
+                        worker_id: self.id,
+                        channel_id: self.channel_id.clone(),
+                        result: crate::secrets::scrub::scrub_leaks(&scrubbed),
+                    })
+                    .ok();
                 self.hook.send_status("waiting for input");
                 self.hook.send_worker_idle();
             }

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -560,6 +560,7 @@ pub(super) async fn trigger_warmup(
                 autonomy_run_store: Arc::new(crate::wakes::AutonomyRunStore::new(
                     sqlite_pool.clone(),
                 )),
+                autonomy_control: crate::agent::autonomy::AutonomyControl::default(),
                 project_store,
                 links: Arc::new(arc_swap::ArcSwap::from_pointee(Vec::new())),
                 agent_names: Arc::new(std::collections::HashMap::new()),
@@ -1005,6 +1006,7 @@ pub async fn create_agent_internal(
         autonomy_ceiling: state.autonomy_ceiling.clone(),
         wake_def_store: Arc::new(crate::wakes::WakeDefStore::new(db.sqlite.clone())),
         autonomy_run_store: Arc::new(crate::wakes::AutonomyRunStore::new(db.sqlite.clone())),
+        autonomy_control: crate::agent::autonomy::AutonomyControl::default(),
         project_store: project_store.clone(),
         cron_tool: None,
         runtime_config: runtime_config.clone(),
@@ -1156,14 +1158,24 @@ pub async fn create_agent_internal(
     let sqlite_pool = db.sqlite.clone();
     let mut deps_with_cron = deps.clone();
     deps_with_cron.cron_tool = Some(cron_tool);
+    let autonomy_control = deps_with_cron.autonomy_control.clone();
+    let autonomy_supervisor =
+        crate::agent::autonomy::spawn_autonomy_supervisor(deps_with_cron.clone());
     let agent = crate::Agent {
         id: arc_agent_id.clone(),
         config: agent_config.clone(),
         db,
         deps: deps_with_cron,
+        autonomy_supervisor: Some(autonomy_supervisor),
     };
     if let Err(error) = state.agent_tx.send(agent).await {
-        tracing::error!(%error, "failed to send new agent to main loop");
+        let mut agent = error.0;
+        if let Some(supervisor) = agent.autonomy_supervisor.take() {
+            supervisor.shutdown(false).await;
+        }
+        state.wake_registry.write().await.remove(&arc_agent_id);
+        tracing::error!(agent_id = %agent_id, "failed to send new agent to main loop");
+        return Err("main loop is not accepting new agents".to_string());
     }
 
     {
@@ -1236,6 +1248,8 @@ pub async fn create_agent_internal(
             .cortex_chat_sessions
             .store(std::sync::Arc::new(sessions));
     }
+
+    autonomy_control.activate();
 
     tracing::info!(agent_id = %agent_id, "agent created and initialized via API");
 
@@ -1467,9 +1481,12 @@ pub(super) async fn delete_agent(
     // Drop the wake-manager registration only after the fallible config write
     // succeeds. Removing it earlier would leave the agent alive but unwakeable
     // if the write failed mid-flight.
-    {
+    let removed_deps = {
         let key: crate::AgentId = std::sync::Arc::from(agent_id.as_str());
-        state.wake_registry.write().await.remove(&key);
+        state.wake_registry.write().await.remove(&key)
+    };
+    if let Some(deps) = removed_deps {
+        deps.autonomy_control.shutdown_and_wait().await;
     }
 
     // Close the SQLite pool before removing state

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -72,8 +72,6 @@ pub struct AutonomySection {
     pub active_hours: Option<(u8, u8)>,
     pub max_turns: u32,
     pub max_tasks_per_run: u32,
-    pub timeout_secs: u64,
-    pub warn_secs: u64,
     pub run_history_count: u32,
     pub claim_unowned: bool,
 }
@@ -257,8 +255,6 @@ pub(super) struct AutonomyUpdate {
     active_hours: Option<Vec<u8>>,
     max_turns: Option<u32>,
     max_tasks_per_run: Option<u32>,
-    timeout_secs: Option<u64>,
-    warn_secs: Option<u64>,
     run_history_count: Option<u32>,
     claim_unowned: Option<bool>,
 }
@@ -410,8 +406,6 @@ pub(super) async fn get_agent_config(
             active_hours: autonomy.active_hours,
             max_turns: autonomy.max_turns,
             max_tasks_per_run: autonomy.max_tasks_per_run,
-            timeout_secs: autonomy.timeout_secs,
-            warn_secs: autonomy.warn_secs,
             run_history_count: autonomy.run_history_count,
             claim_unowned: autonomy.claim_unowned,
         },
@@ -896,9 +890,6 @@ fn update_autonomy_table(
     let built_in = crate::config::AutonomyConfig::default();
     let default_interval =
         defaults_autonomy_u64(doc, "interval_secs").unwrap_or(built_in.interval_secs);
-    let default_timeout =
-        defaults_autonomy_u64(doc, "timeout_secs").unwrap_or(built_in.timeout_secs);
-    let default_warn = defaults_autonomy_u64(doc, "warn_secs").unwrap_or(built_in.warn_secs);
 
     let agent = get_agent_table_mut(doc, agent_idx)?;
     let table = get_or_create_subtable(agent, "autonomy")?;
@@ -942,12 +933,6 @@ fn update_autonomy_table(
         }
         table["max_tasks_per_run"] = toml_edit::value(i64::from(v));
     }
-    if let Some(v) = autonomy.timeout_secs {
-        table["timeout_secs"] = toml_edit::value(to_i64_from_u64("timeout_secs", v)?);
-    }
-    if let Some(v) = autonomy.warn_secs {
-        table["warn_secs"] = toml_edit::value(to_i64_from_u64("warn_secs", v)?);
-    }
     if let Some(v) = autonomy.run_history_count {
         table["run_history_count"] = toml_edit::value(i64::from(v));
     }
@@ -955,31 +940,10 @@ fn update_autonomy_table(
         table["claim_unowned"] = toml_edit::value(v);
     }
 
-    // Validate the merged result (existing table values plus the patch) so
-    // partial updates are checked in context, mirroring
-    // `AutonomyConfig::validated`. The load path clamps an out-of-range
-    // `warn_secs`; an interactive caller gets an error instead.
+    // Validate the merged result so partial updates are checked in context.
     let interval_secs = table_u64(table, "interval_secs").unwrap_or(default_interval);
-    let timeout_secs = table_u64(table, "timeout_secs").unwrap_or(default_timeout);
-    let warn_secs = table_u64(table, "warn_secs").unwrap_or(default_warn);
     if interval_secs < 60 {
         tracing::warn!(interval_secs, "autonomy interval_secs must be >= 60");
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    if timeout_secs > interval_secs {
-        tracing::warn!(
-            timeout_secs,
-            interval_secs,
-            "autonomy timeout_secs must be <= interval_secs"
-        );
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    if warn_secs >= timeout_secs {
-        tracing::warn!(
-            warn_secs,
-            timeout_secs,
-            "autonomy warn_secs must be < timeout_secs"
-        );
         return Err(StatusCode::BAD_REQUEST);
     }
     Ok(())

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -363,8 +363,6 @@ impl AutonomyConfig {
             max_tasks_per_run: overrides
                 .max_tasks_per_run
                 .unwrap_or(defaults.max_tasks_per_run),
-            timeout_secs: overrides.timeout_secs.unwrap_or(defaults.timeout_secs),
-            warn_secs: overrides.warn_secs.unwrap_or(defaults.warn_secs),
             run_history_count: overrides
                 .run_history_count
                 .unwrap_or(defaults.run_history_count),
@@ -2930,10 +2928,6 @@ mod autonomy_config_tests {
         assert_eq!(resolved.interval_secs, 900);
         assert_eq!(resolved.active_hours, Some((8, 22)));
         // Untouched fields inherit the defaults.
-        assert_eq!(
-            resolved.timeout_secs,
-            AutonomyConfig::default().timeout_secs
-        );
         assert_eq!(
             resolved.claim_unowned,
             AutonomyConfig::default().claim_unowned

--- a/src/config/toml_schema.rs
+++ b/src/config/toml_schema.rs
@@ -438,8 +438,6 @@ pub(super) struct TomlAutonomyConfig {
     pub(super) active_hours: Option<(u8, u8)>,
     pub(super) max_turns: Option<u32>,
     pub(super) max_tasks_per_run: Option<u32>,
-    pub(super) timeout_secs: Option<u64>,
-    pub(super) warn_secs: Option<u64>,
     pub(super) run_history_count: Option<u32>,
     pub(super) claim_unowned: Option<bool>,
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1375,11 +1375,6 @@ pub struct AutonomyConfig {
     pub max_turns: u32,
     /// Maximum tasks to work on per wake.
     pub max_tasks_per_run: u32,
-    /// Hard wall-clock timeout for a run. Should rarely fire — the soft
-    /// warning at `warn_secs` asks the channel to wrap up first.
-    pub timeout_secs: u64,
-    /// When to inject the soft "wrap up" warning into the run.
-    pub warn_secs: u64,
     /// How many past run summaries to surface on wake.
     pub run_history_count: u32,
     /// Whether this agent picks up tasks with no assigned agent.
@@ -1394,8 +1389,6 @@ impl Default for AutonomyConfig {
             active_hours: None,
             max_turns: 20,
             max_tasks_per_run: 2,
-            timeout_secs: 600,
-            warn_secs: 480,
             run_history_count: 5,
             claim_unowned: true,
         }
@@ -1403,22 +1396,13 @@ impl Default for AutonomyConfig {
 }
 
 impl AutonomyConfig {
-    /// Validate the invariants from autonomy.md, clamping `warn_secs` to
-    /// `timeout_secs - 60` when it does not fire before the hard timeout.
-    /// `scope` names the config path (e.g. "defaults.autonomy") so load
-    /// errors point at the offending section.
-    pub fn validated(mut self, scope: &str) -> Result<Self> {
+    /// Validate autonomy bounds. `scope` names the config path so load errors
+    /// point at the offending section.
+    pub fn validated(self, scope: &str) -> Result<Self> {
         if self.interval_secs < 60 {
             return Err(ConfigError::Invalid(format!(
                 "{scope}.interval_secs must be >= 60, got {}",
                 self.interval_secs
-            ))
-            .into());
-        }
-        if self.timeout_secs > self.interval_secs {
-            return Err(ConfigError::Invalid(format!(
-                "{scope}.timeout_secs ({}) must be <= interval_secs ({})",
-                self.timeout_secs, self.interval_secs
             ))
             .into());
         }
@@ -1434,17 +1418,6 @@ impl AutonomyConfig {
                 "{scope}.active_hours hours must be 0-23, got [{start}, {end}]"
             ))
             .into());
-        }
-        if self.warn_secs >= self.timeout_secs {
-            let clamped = self.timeout_secs.saturating_sub(60);
-            tracing::warn!(
-                scope,
-                warn_secs = self.warn_secs,
-                timeout_secs = self.timeout_secs,
-                clamped,
-                "autonomy warn_secs must be < timeout_secs, clamping"
-            );
-            self.warn_secs = clamped;
         }
         Ok(self)
     }
@@ -3592,8 +3565,6 @@ mod autonomy_config_validation_tests {
     fn autonomy_rejects_short_interval() {
         let error = AutonomyConfig {
             interval_secs: 59,
-            timeout_secs: 59,
-            warn_secs: 30,
             ..AutonomyConfig::default()
         }
         .validated("defaults.autonomy")
@@ -3603,56 +3574,6 @@ mod autonomy_config_validation_tests {
                 .to_string()
                 .contains("defaults.autonomy.interval_secs")
         );
-    }
-
-    #[test]
-    fn autonomy_rejects_timeout_longer_than_interval() {
-        let error = AutonomyConfig {
-            interval_secs: 300,
-            timeout_secs: 301,
-            ..AutonomyConfig::default()
-        }
-        .validated("agents.main.autonomy")
-        .expect_err("timeout > interval must fail");
-        assert!(
-            error
-                .to_string()
-                .contains("agents.main.autonomy.timeout_secs")
-        );
-    }
-
-    #[test]
-    fn autonomy_allows_timeout_equal_to_interval() {
-        // Back-to-back runs (continuous operation) are valid but intentional.
-        let config = AutonomyConfig {
-            interval_secs: 600,
-            timeout_secs: 600,
-            ..AutonomyConfig::default()
-        }
-        .validated("defaults.autonomy")
-        .expect("timeout == interval is valid");
-        assert_eq!(config.timeout_secs, 600);
-    }
-
-    #[test]
-    fn autonomy_clamps_warn_at_or_past_timeout() {
-        let config = AutonomyConfig {
-            timeout_secs: 600,
-            warn_secs: 600,
-            ..AutonomyConfig::default()
-        }
-        .validated("defaults.autonomy")
-        .expect("warn violation clamps, not errors");
-        assert_eq!(config.warn_secs, 540);
-
-        let config = AutonomyConfig {
-            timeout_secs: 600,
-            warn_secs: 9999,
-            ..AutonomyConfig::default()
-        }
-        .validated("defaults.autonomy")
-        .expect("warn violation clamps, not errors");
-        assert_eq!(config.warn_secs, 540);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,6 +525,9 @@ pub struct AgentDeps {
     pub wake_def_store: Arc<wakes::WakeDefStore>,
     /// Per-agent autonomy run history (begin/complete + recent summaries).
     pub autonomy_run_store: Arc<wakes::AutonomyRunStore>,
+    /// Doorbell for the resident autonomy channel. The shared cell is wired
+    /// when the supervisor starts, so cloned dependency bundles stay valid.
+    pub autonomy_control: agent::autonomy::AutonomyControl,
     pub project_store: Arc<projects::ProjectStore>,
     pub cron_tool: Option<tools::CronTool>,
     pub runtime_config: Arc<config::RuntimeConfig>,
@@ -603,6 +606,7 @@ pub struct Agent {
     pub config: config::ResolvedAgentConfig,
     pub db: db::Db,
     pub deps: AgentDeps,
+    pub autonomy_supervisor: Option<agent::autonomy::AutonomySupervisorHandle>,
 }
 
 /// Standard metadata keys set by all adapters.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1369,6 +1369,46 @@ async fn run(
             }
 
             for (conversation_id, workers) in by_channel {
+                if conversation_id == spacebot::agent::autonomy::AUTONOMY_CONVERSATION_ID {
+                    let Some(supervisor) = agent.autonomy_supervisor.as_ref() else {
+                        tracing::warn!(agent_id = %agent_id, "autonomy supervisor missing during idle worker recovery");
+                        continue;
+                    };
+                    let state = supervisor.channel_state();
+                    for idle_worker in workers {
+                        if idle_worker.worker_type == "opencode"
+                            && idle_worker.opencode_session_id.is_none()
+                        {
+                            if let Err(error) = run_logger.retire_idle_worker(&idle_worker.id).await
+                            {
+                                tracing::warn!(worker_id = %idle_worker.id, %error, "failed to retire idle autonomy worker");
+                            }
+                            continue;
+                        }
+                        match spacebot::agent::channel_dispatch::resume_idle_worker_into_state(
+                            &state,
+                            idle_worker,
+                        )
+                        .await
+                        {
+                            Ok(worker_id) => tracing::info!(
+                                %worker_id,
+                                agent_id = %agent_id,
+                                "resumed retained autonomy worker"
+                            ),
+                            Err(reason) => {
+                                if let Err(error) =
+                                    run_logger.retire_idle_worker(&idle_worker.id).await
+                                {
+                                    tracing::warn!(worker_id = %idle_worker.id, %error, "failed to retire autonomy worker after resume failure");
+                                }
+                                tracing::info!(worker_id = %idle_worker.id, %reason, "retired retained autonomy worker after resume failure");
+                            }
+                        }
+                    }
+                    continue;
+                }
+
                 // Ensure the channel exists. If it's already in active_channels
                 // (unlikely at startup), use its state. Otherwise, pre-create it.
                 let channel_key =
@@ -1636,6 +1676,12 @@ async fn run(
                     );
                 }
             }
+        }
+    }
+
+    if agents_initialized {
+        for agent in agents.values() {
+            agent.deps.autonomy_control.activate();
         }
     }
 
@@ -2042,7 +2088,10 @@ async fn run(
             }
             Some(agent_id) = agent_remove_rx.recv() => {
                 let key: spacebot::AgentId = Arc::from(agent_id.as_str());
-                if let Some(agent) = agents.remove(&key) {
+                if let Some(mut agent) = agents.remove(&key) {
+                    if let Some(supervisor) = agent.autonomy_supervisor.take() {
+                        supervisor.shutdown(false).await;
+                    }
                     agent.deps.mcp_manager.disconnect_all().await;
                     tracing::info!(agent_id = %agent_id, "removed agent from main loop");
                 } else {
@@ -2227,6 +2276,14 @@ async fn run(
 
     // Graceful shutdown
     drop(active_channels);
+
+    for agent in agents.values_mut() {
+        if let Some(supervisor) = agent.autonomy_supervisor.take() {
+            supervisor
+                .shutdown(final_state == spacebot::lifecycle::LifecycleState::Restart)
+                .await;
+        }
+    }
 
     for scheduler in &cron_schedulers_for_shutdown {
         scheduler.shutdown().await;
@@ -2674,6 +2731,7 @@ async fn initialize_agents(
             autonomy_ceiling: api_state.autonomy_ceiling.clone(),
             wake_def_store: Arc::new(spacebot::wakes::WakeDefStore::new(db.sqlite.clone())),
             autonomy_run_store: Arc::new(spacebot::wakes::AutonomyRunStore::new(db.sqlite.clone())),
+            autonomy_control: spacebot::agent::autonomy::AutonomyControl::default(),
             project_store: project_store.clone(),
             cron_tool: None,
             runtime_config,
@@ -2701,6 +2759,7 @@ async fn initialize_agents(
             config: agent_config.clone(),
             db,
             deps,
+            autonomy_supervisor: None,
         };
 
         // Register with the wake manager so external triggers can reach this agent.
@@ -3416,6 +3475,12 @@ async fn initialize_agents(
     api_state.set_cron_stores(cron_stores_map);
     api_state.set_cron_schedulers(cron_schedulers_map);
     tracing::info!("cron stores and schedulers registered with API state");
+
+    for (agent_id, agent) in agents.iter_mut() {
+        let supervisor = spacebot::agent::autonomy::spawn_autonomy_supervisor(agent.deps.clone());
+        agent.autonomy_supervisor = Some(supervisor);
+        tracing::info!(%agent_id, "resident autonomy channel started");
+    }
 
     // Start memory ingestion loops for each agent
     for (agent_id, agent) in agents.iter() {

--- a/src/opencode/worker.rs
+++ b/src/opencode/worker.rs
@@ -431,7 +431,14 @@ impl OpenCodeWorker {
                 self.send_status("resumed — waiting for follow-up");
                 self.send_idle();
             } else {
-                // Fresh worker: emit the initial result so the channel can retrigger.
+                self.persist_transcript_snapshot(&event_state).await;
+                self.persist_lifecycle_transition(
+                    crate::conversation::WorkerLifecycle::Running,
+                    crate::conversation::WorkerLifecycle::WaitingForInput,
+                )
+                .await;
+                // Persist the result and waiting lifecycle before notification
+                // so a lagged channel can recover it from durable state.
                 let scrubbed_result = self.scrub_text(&result_text);
                 let scrubbed_result = crate::secrets::scrub::scrub_leaks(&scrubbed_result);
                 let _ = self.event_tx.send(ProcessEvent::WorkerInitialResult {
@@ -440,13 +447,6 @@ impl OpenCodeWorker {
                     channel_id: self.channel_id.clone(),
                     result: scrubbed_result,
                 });
-
-                self.persist_transcript_snapshot(&event_state).await;
-                self.persist_lifecycle_transition(
-                    crate::conversation::WorkerLifecycle::Running,
-                    crate::conversation::WorkerLifecycle::WaitingForInput,
-                )
-                .await;
                 self.send_status("waiting for follow-up");
                 self.send_idle();
             }
@@ -487,9 +487,13 @@ impl OpenCodeWorker {
                     .await
                 {
                     Ok(_) => {
-                        // Emit follow-up result so the channel can retrigger
-                        // and relay this to the user — same as initial result.
                         let follow_up_text = event_state.last_text.clone();
+                        self.persist_transcript_snapshot(&event_state).await;
+                        self.persist_lifecycle_transition(
+                            crate::conversation::WorkerLifecycle::Running,
+                            crate::conversation::WorkerLifecycle::WaitingForInput,
+                        )
+                        .await;
                         if !follow_up_text.is_empty() {
                             let scrubbed = self.scrub_text(&follow_up_text);
                             let scrubbed = crate::secrets::scrub::scrub_leaks(&scrubbed);
@@ -500,12 +504,6 @@ impl OpenCodeWorker {
                                 result: scrubbed,
                             });
                         }
-                        self.persist_transcript_snapshot(&event_state).await;
-                        self.persist_lifecycle_transition(
-                            crate::conversation::WorkerLifecycle::Running,
-                            crate::conversation::WorkerLifecycle::WaitingForInput,
-                        )
-                        .await;
                         self.send_status("waiting for follow-up");
                         self.send_idle();
                     }

--- a/src/prompts/engine.rs
+++ b/src/prompts/engine.rs
@@ -109,6 +109,7 @@ pub struct ChannelPromptInputs {
     pub active_goals: Option<String>,
     pub execution_mode: String,
     pub authority: String,
+    pub autonomy_channel: bool,
 }
 
 impl ChannelPromptInputs {
@@ -132,6 +133,7 @@ impl ChannelPromptInputs {
             .text("active_goals", self.active_goals)
             .text("execution_mode", Some(self.execution_mode))
             .text("authority", Some(self.authority))
+            .inline("autonomy_channel", self.autonomy_channel)
             .inline("agent_links", self.agent_links)
     }
 }
@@ -315,14 +317,6 @@ impl PromptEngine {
             crate::prompts::text::get("fragments/system/autonomy_contract_retry"),
         )?;
         env.add_template(
-            "fragments/system/autonomy_soft_warning",
-            crate::prompts::text::get("fragments/system/autonomy_soft_warning"),
-        )?;
-        env.add_template(
-            "fragments/system/autonomy_hard_timeout",
-            crate::prompts::text::get("fragments/system/autonomy_hard_timeout"),
-        )?;
-        env.add_template(
             "fragments/system/profile_synthesis",
             crate::prompts::text::get("fragments/system/profile_synthesis"),
         )?;
@@ -464,6 +458,7 @@ impl PromptEngine {
         opencode_enabled: bool,
         mcp_tool_names: &[String],
         worker_context: &crate::conversation::settings::WorkerContextMode,
+        project_manage_available: bool,
     ) -> Result<String> {
         self.render(
             "fragments/worker_capabilities",
@@ -477,6 +472,7 @@ impl PromptEngine {
                     crate::conversation::settings::WorkerHistoryMode::Fork
                 ),
                 worker_memory => worker_context.memory.as_str(),
+                project_manage_available => project_manage_available,
             },
         )
     }
@@ -700,21 +696,6 @@ impl PromptEngine {
         self.render_static("fragments/system/autonomy_contract_retry")
     }
 
-    /// Soft-timeout warning injected into an autonomy run at `warn_secs`.
-    pub fn render_system_autonomy_soft_warning(&self, remaining_minutes: u64) -> Result<String> {
-        self.render(
-            "fragments/system/autonomy_soft_warning",
-            context! {
-                remaining_minutes => remaining_minutes,
-            },
-        )
-    }
-
-    /// Hard-timeout wrap-up injected when an autonomy run's `timeout_secs` elapses.
-    pub fn render_system_autonomy_hard_timeout(&self) -> Result<String> {
-        self.render_static("fragments/system/autonomy_hard_timeout")
-    }
-
     /// Render the profile synthesis prompt with identity context.
     pub fn render_system_profile_synthesis(
         &self,
@@ -826,9 +807,10 @@ impl PromptEngine {
         active_goals: Option<&str>,
         active_workers: Option<&str>,
         max_tasks_per_run: u32,
-        warn_minutes: u64,
         claim_unowned: bool,
         instance_is_empty: bool,
+        trigger_reason: &str,
+        elapsed_secs: Option<u64>,
     ) -> Result<String> {
         self.render(
             "autonomy_channel",
@@ -841,9 +823,10 @@ impl PromptEngine {
                 active_goals => active_goals,
                 active_workers => active_workers,
                 max_tasks_per_run => max_tasks_per_run,
-                warn_minutes => warn_minutes,
                 claim_unowned => claim_unowned,
                 instance_is_empty => instance_is_empty,
+                trigger_reason => trigger_reason,
+                elapsed_secs => elapsed_secs,
             },
         )
     }
@@ -1614,21 +1597,22 @@ mod tests {
                 Some("### [HIGH] Ship v2"),
                 None,
                 2,
-                8,
                 true,
                 false,
+                "heartbeat",
+                Some(480),
             )
             .expect("observe prompt should render");
         assert!(observe.contains("You are Iris."));
         assert!(observe.contains("CI failed on main"));
         assert!(observe.contains("Instructions: Investigate the failing job."));
-        assert!(observe.contains("observed only, below your current autonomy level"));
+        assert!(observe.contains("observe only; this event requires a higher autonomy level"));
         assert!(observe.contains("3 coalesced firings"));
         assert!(observe.contains("Enriched task #4."));
-        assert!(observe.contains("survey and summarize only"));
-        assert!(observe.contains("up to 2 tasks this run"));
-        assert!(observe.contains("about 8 minutes"));
-        assert!(observe.contains("`pending_approval` are NEVER executed"));
+        assert!(observe.contains("Your autonomy level is **observe**"));
+        assert!(observe.contains("at most 2 tasks in this epoch"));
+        assert!(observe.contains("active for 480 seconds"));
+        assert!(observe.contains("Never execute `pending_approval` tasks"));
 
         let act = engine
             .render_autonomy_channel_prompt(
@@ -1640,19 +1624,18 @@ mod tests {
                 None,
                 None,
                 1,
-                1,
                 false,
                 true,
+                "heartbeat",
+                None,
             )
             .expect("act prompt should render");
-        assert!(act.contains("Scheduled interval — no wake events pending."));
-        assert!(act.contains("Execute ready tasks"));
-        assert!(act.contains("up to 1 task this run"));
-        assert!(!act.contains("claim unowned tasks"));
-        // An empty instance gets cold-start guidance instead of a bare survey.
-        assert!(act.contains("There are no tasks and no goals."));
-        assert!(act.contains("spacebot_docs"));
-        assert!(act.contains("Do not invent tasks to look busy."));
+        assert!(act.contains("No new wake events"));
+        assert!(act.contains("execute `ready` tasks"));
+        assert!(act.contains("at most 1 task in this epoch"));
+        assert!(!act.contains("claim unowned work"));
+        assert!(act.contains("The board and goal list are empty"));
+        assert!(act.contains("Never invent tasks to look busy."));
 
         // An unrecognized level falls back to observe-only rules.
         let unknown = engine
@@ -1665,15 +1648,15 @@ mod tests {
                 None,
                 None,
                 1,
-                1,
                 false,
                 false,
+                "heartbeat",
+                None,
             )
             .expect("unknown level prompt should render");
-        assert!(unknown.contains("Treat this run as observe: survey and summarize only."));
-        // Recording is instructed at every level; cold-start guidance is not.
-        assert!(unknown.contains("Record what you notice as you go"));
-        assert!(!unknown.contains("There are no tasks and no goals."));
+        assert!(unknown.contains("Treat this epoch as observe-only."));
+        assert!(unknown.contains("Record reusable discoveries"));
+        assert!(!unknown.contains("The board and goal list are empty"));
     }
 
     #[test]
@@ -1685,31 +1668,10 @@ mod tests {
             .expect("contract retry should render");
         assert_eq!(
             retry,
-            "You must finish this autonomy run by calling autonomy_complete. Provide a 2-5 \
-             line summary of what this run observed and did, plus an actions entry for every \
-             task you enriched, created, or executed. Do not start new work."
-        );
-
-        let singular = engine
-            .render_system_autonomy_soft_warning(1)
-            .expect("soft warning should render");
-        assert_eq!(
-            singular,
-            "You have approximately 1 minute remaining in this run. Finish your current task, \
-             add any final notes, and call autonomy_complete. Do not start a new task."
-        );
-        let plural = engine
-            .render_system_autonomy_soft_warning(5)
-            .expect("soft warning should render");
-        assert!(plural.contains("approximately 5 minutes remaining"));
-
-        let hard = engine
-            .render_system_autonomy_hard_timeout()
-            .expect("hard timeout should render");
-        assert_eq!(
-            hard,
-            "Time is up. Some work may not have finished. Call autonomy_complete NOW with a \
-             summary of whatever this run accomplished. Do not start any new work."
+            "This autonomy epoch has no active work but has not called autonomy_complete. Call \
+             autonomy_complete now with a concise final summary and one action per task actually \
+             enriched, created, or executed. If no action was needed, use an empty actions list. \
+             Do not start new work."
         );
     }
 

--- a/src/prompts/text.rs
+++ b/src/prompts/text.rs
@@ -153,12 +153,6 @@ fn lookup(lang: &str, key: &str) -> &'static str {
         ("en", "fragments/system/autonomy_contract_retry") => {
             include_str!("../../prompts/en/fragments/system/autonomy_contract_retry.md.j2")
         }
-        ("en", "fragments/system/autonomy_soft_warning") => {
-            include_str!("../../prompts/en/fragments/system/autonomy_soft_warning.md.j2")
-        }
-        ("en", "fragments/system/autonomy_hard_timeout") => {
-            include_str!("../../prompts/en/fragments/system/autonomy_hard_timeout.md.j2")
-        }
         ("en", "fragments/system/profile_synthesis") => {
             include_str!("../../prompts/en/fragments/system/profile_synthesis.md.j2")
         }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -512,7 +512,7 @@ pub async fn add_channel_tools(
     let chronicle_channel_id = state.channel_id.to_string();
     let chronicle_pool = state.deps.sqlite_pool.clone();
     let compaction = **state.deps.runtime_config.compaction.load();
-    let autonomy_run = state.autonomy_run.clone();
+    let autonomy_run = state.autonomy_run();
 
     if allow_direct_reply {
         let agent_display_name = state
@@ -866,6 +866,226 @@ pub async fn add_direct_mode_tools(
     Ok(())
 }
 
+/// Add the resident autonomy channel's level-scoped capability set.
+pub async fn add_autonomy_tools(
+    handle: &ToolServerHandle,
+    state: ChannelState,
+) -> Result<(), rig::tool::server::ToolServerError> {
+    let level = state
+        .deps
+        .runtime_config
+        .autonomy
+        .load()
+        .level
+        .min(**state.deps.autonomy_ceiling.load());
+    handle
+        .add_tool(memory_save_with_events(
+            state.deps.memory_search.clone(),
+            state.deps.agent_id.clone(),
+            state.deps.memory_event_tx.clone(),
+            Some(state.deps.working_memory.clone()),
+        ))
+        .await?;
+    handle
+        .add_tool(MemoryRecallTool::new(state.deps.memory_search.clone()))
+        .await?;
+    handle.add_tool(SpacebotDocsTool::new()).await?;
+    handle
+        .add_tool(FileReadTool::new(
+            state.deps.runtime_config.workspace_dir.clone(),
+            state.deps.sandbox.clone(),
+        ))
+        .await?;
+    handle
+        .add_tool(FileListTool::new(
+            state.deps.runtime_config.workspace_dir.clone(),
+            state.deps.sandbox.clone(),
+        ))
+        .await?;
+    handle
+        .add_tool(ReadSkillTool::new(state.deps.runtime_config.clone()))
+        .await?;
+    handle
+        .add_tool(SkillsSearchTool::new(state.deps.runtime_config.clone()))
+        .await?;
+    handle
+        .add_tool(GoalListTool::new(state.deps.goal_store.clone()))
+        .await?;
+    let Some(run) = state.autonomy_run() else {
+        return Ok(());
+    };
+    handle.add_tool(AutonomyCompleteTool::new(run)).await?;
+
+    let mut task_history =
+        TaskHistoryTool::new(state.deps.task_store.clone(), state.deps.agent_id.clone());
+    if let Some(api_state) = &state.deps.api_state {
+        task_history = task_history.with_api_state(api_state.clone());
+    }
+    handle
+        .add_tool(TaskListTool::new(
+            state.deps.task_store.clone(),
+            state.deps.agent_id.to_string(),
+        ))
+        .await?;
+    handle.add_tool(task_history).await?;
+    handle
+        .add_tool(WorkerInspectTool::new(
+            state.process_run_logger.clone(),
+            state.deps.agent_id.to_string(),
+        ))
+        .await?;
+
+    if level >= crate::config::AutonomyLevel::Suggest {
+        let mut task_create = TaskCreateTool::new(
+            state.deps.task_store.clone(),
+            state.deps.agent_id.to_string(),
+            "autonomy",
+        )
+        .with_execution_context(
+            state.deps.project_store.clone(),
+            state.deps.runtime_config.clone(),
+        );
+        let mut add_task_comment = AddTaskCommentTool::for_branch(
+            state.deps.task_store.clone(),
+            state.deps.agent_id.clone(),
+        );
+        if let Some(api_state) = &state.deps.api_state {
+            task_create = task_create.with_api_state(api_state.clone());
+            add_task_comment = add_task_comment.with_api_state(api_state.clone());
+        }
+        handle.add_tool(task_create).await?;
+        handle
+            .add_tool(TaskUpdateTool::for_autonomy(
+                state.deps.task_store.clone(),
+                state.deps.agent_id.clone(),
+                level,
+            ))
+            .await?;
+        handle.add_tool(add_task_comment).await?;
+    }
+
+    if let Some(key) = state
+        .deps
+        .runtime_config
+        .brave_search_key
+        .load()
+        .as_ref()
+        .clone()
+    {
+        handle.add_tool(WebSearchTool::new(key)).await?;
+    }
+    if let Some(store) = &state.deps.wiki_store {
+        handle.add_tool(WikiReadTool::new(store.clone())).await?;
+        handle.add_tool(WikiListTool::new(store.clone())).await?;
+        handle.add_tool(WikiSearchTool::new(store.clone())).await?;
+        handle.add_tool(WikiHistoryTool::new(store.clone())).await?;
+    }
+
+    if level == crate::config::AutonomyLevel::Act {
+        handle.add_tool(SpawnWorkerTool::new(state.clone())).await?;
+        handle.add_tool(RouteTool::new(state.clone())).await?;
+        handle.add_tool(CancelTool::new(state.clone())).await?;
+        let workspace = state.deps.runtime_config.workspace_dir.clone();
+        let sandbox = state.deps.sandbox.clone();
+        handle
+            .add_tool(ShellTool::new(workspace.clone(), sandbox.clone()))
+            .await?;
+        handle
+            .add_tool(FileWriteTool::new(workspace.clone(), sandbox.clone()))
+            .await?;
+        handle
+            .add_tool(FileEditTool::new(workspace, sandbox))
+            .await?;
+
+        let browser_config = state.deps.runtime_config.browser_config.load();
+        if browser_config.enabled {
+            let context = browser::BrowserContext::new(
+                if let Some(shared) = state
+                    .deps
+                    .runtime_config
+                    .shared_browser
+                    .as_ref()
+                    .filter(|_| browser_config.persist_session)
+                {
+                    shared.clone()
+                } else {
+                    browser::new_shared_browser_handle()
+                },
+                BrowserConfig::clone(&browser_config),
+                state.screenshot_dir.clone(),
+                state
+                    .deps
+                    .runtime_config
+                    .secrets
+                    .load()
+                    .as_ref()
+                    .as_ref()
+                    .cloned(),
+            );
+            handle
+                .add_tool(browser::BrowserLaunchTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserNavigateTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserSnapshotTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserClickTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserTypeTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserPressKeyTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserScreenshotTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserEvaluateTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserTabOpenTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserTabListTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserTabCloseTool {
+                    context: context.clone(),
+                })
+                .await?;
+            handle
+                .add_tool(browser::BrowserCloseTool { context })
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
 fn default_delivery_target_for_conversation(
     conversation_id: &str,
     slack_thread_ts: Option<&str>,
@@ -982,6 +1202,12 @@ pub async fn remove_direct_mode_tools(
     remove_optional_tool(handle, WikiListTool::NAME).await;
     remove_optional_tool(handle, WikiSearchTool::NAME).await;
     remove_optional_tool(handle, WikiHistoryTool::NAME).await;
+    remove_optional_tool(handle, TaskCreateTool::NAME).await;
+    remove_optional_tool(handle, TaskListTool::NAME).await;
+    remove_optional_tool(handle, TaskUpdateTool::NAME).await;
+    remove_optional_tool(handle, TaskHistoryTool::NAME).await;
+    remove_optional_tool(handle, AddTaskCommentTool::NAME).await;
+    remove_optional_tool(handle, WorkerInspectTool::NAME).await;
 
     Ok(())
 }

--- a/src/tools/autonomy_complete.rs
+++ b/src/tools/autonomy_complete.rs
@@ -131,10 +131,16 @@ impl Tool for AutonomyCompleteTool {
             });
         }
 
-        self.handle.request_finish(AutonomyFinishRequest {
-            summary: summary.to_string(),
-            actions: actions.clone(),
-        });
+        self.handle
+            .request_finish(AutonomyFinishRequest {
+                summary: summary.to_string(),
+                actions: actions.clone(),
+            })
+            .map_err(|active_children| {
+                AutonomyCompleteError(format!(
+                    "{active_children} owned background process(es) are still active; wait for and synthesize their results before completing the epoch"
+                ))
+            })?;
 
         Ok(AutonomyCompleteOutput {
             success: true,
@@ -166,7 +172,7 @@ mod tests {
     async fn records_summary_and_actions() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id.clone(), Arc::new(store.clone()));
+        let handle = AutonomyRunHandle::new(run_id.clone(), 1, Arc::new(store.clone()));
         let tool = AutonomyCompleteTool::new(handle.clone());
 
         let output = tool
@@ -194,7 +200,7 @@ mod tests {
     async fn rejects_invalid_action_kind() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id, Arc::new(store));
+        let handle = AutonomyRunHandle::new(run_id, 1, Arc::new(store));
         let tool = AutonomyCompleteTool::new(handle.clone());
 
         let error = tool
@@ -217,7 +223,7 @@ mod tests {
     async fn rejects_trivial_summary() {
         let store = store().await;
         let run_id = store.begin_run().await.expect("begin");
-        let handle = AutonomyRunHandle::new(run_id, Arc::new(store));
+        let handle = AutonomyRunHandle::new(run_id, 1, Arc::new(store));
         let tool = AutonomyCompleteTool::new(handle);
 
         let error = tool
@@ -229,5 +235,26 @@ mod tests {
             .expect_err("trivial summary must fail");
 
         assert!(error.to_string().contains("summary"));
+    }
+
+    #[tokio::test]
+    async fn rejects_completion_while_owned_work_is_active() {
+        let store = store().await;
+        let run_id = store.begin_run().await.expect("begin");
+        let handle = AutonomyRunHandle::new(run_id, 1, Arc::new(store));
+        handle.register_child(crate::agent::autonomy::AutonomyChild::Worker(
+            crate::WorkerId::new_v4(),
+        ));
+        let tool = AutonomyCompleteTool::new(handle);
+
+        let error = tool
+            .call(AutonomyCompleteArgs {
+                summary: "Tried to finish before the worker returned.".to_string(),
+                actions: Vec::new(),
+            })
+            .await
+            .expect_err("active work must block completion");
+
+        assert!(error.to_string().contains("still active"));
     }
 }

--- a/src/tools/route.rs
+++ b/src/tools/route.rs
@@ -96,15 +96,29 @@ impl Tool for RouteTool {
         match worker_is_idle {
             // Worker is idle (WaitingForInput) — deliver as interactive follow-up.
             Some(true) => {
+                let autonomy_run = self.state.autonomy_run();
+                if let Some(run) = &autonomy_run
+                    && !run.register_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id))
+                {
+                    return Err(RouteError(
+                        "The autonomy epoch is finishing or already owns an active operation for this worker"
+                            .to_string(),
+                    ));
+                }
                 let inputs = self.state.worker_inputs.read().await;
                 if let Some(input_tx) = inputs.get(&worker_id).cloned() {
                     drop(inputs);
 
-                    input_tx.send(args.message).await.map_err(|_| {
-                        RouteError(format!(
+                    if input_tx.send(args.message).await.is_err() {
+                        if let Some(run) = autonomy_run {
+                            run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(
+                                worker_id,
+                            ));
+                        }
+                        return Err(RouteError(format!(
                             "Worker {worker_id} has stopped accepting input (channel closed)"
-                        ))
-                    })?;
+                        )));
+                    }
 
                     tracing::info!(
                         worker_id = %worker_id,
@@ -121,6 +135,9 @@ impl Tool for RouteTool {
                     });
                 }
                 drop(inputs);
+                if let Some(run) = autonomy_run {
+                    run.settle_child(crate::agent::autonomy::AutonomyChild::Worker(worker_id));
+                }
 
                 // Worker is idle but has no input channel — shouldn't happen
                 // for interactive workers, but fall through to injection.
@@ -131,11 +148,31 @@ impl Tool for RouteTool {
                 if let Some(inject_tx) = injections.get(&worker_id).cloned() {
                     drop(injections);
 
-                    inject_tx.send(args.message).await.map_err(|_| {
-                        RouteError(format!(
+                    let autonomy_run = self.state.autonomy_run();
+                    let child = crate::agent::autonomy::AutonomyChild::Worker(worker_id);
+                    let registered_here = if let Some(run) = &autonomy_run {
+                        if run.owns_child(child) {
+                            false
+                        } else if run.register_child(child) {
+                            true
+                        } else {
+                            return Err(RouteError(
+                                "The autonomy epoch is finishing and cannot route more work"
+                                    .to_string(),
+                            ));
+                        }
+                    } else {
+                        false
+                    };
+
+                    if inject_tx.send(args.message).await.is_err() {
+                        if registered_here && let Some(run) = autonomy_run {
+                            run.settle_child(child);
+                        }
+                        return Err(RouteError(format!(
                             "Worker {worker_id} has stopped running (injection channel closed)"
-                        ))
-                    })?;
+                        )));
+                    }
 
                     tracing::info!(
                         worker_id = %worker_id,

--- a/src/tools/task_update.rs
+++ b/src/tools/task_update.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub enum TaskUpdateScope {
     Branch,
+    Autonomy(crate::config::AutonomyLevel),
     Worker(WorkerId),
 }
 
@@ -43,6 +44,19 @@ impl TaskUpdateTool {
         }
     }
 
+    pub fn for_autonomy(
+        task_store: Arc<TaskStore>,
+        agent_id: AgentId,
+        level: crate::config::AutonomyLevel,
+    ) -> Self {
+        Self {
+            task_store,
+            agent_id,
+            scope: TaskUpdateScope::Autonomy(level),
+            working_memory: None,
+        }
+    }
+
     pub fn with_working_memory(mut self, store: Arc<crate::memory::WorkingMemoryStore>) -> Self {
         self.working_memory = Some(store);
         self
@@ -53,7 +67,7 @@ impl TaskUpdateTool {
 #[error("task_update failed: {0}")]
 pub struct TaskUpdateError(String);
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct TaskUpdateArgs {
     pub task_number: i32,
     pub title: Option<String>,
@@ -209,6 +223,30 @@ impl Tool for TaskUpdateTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let task_number = i64::from(args.task_number);
+        if matches!(self.scope, TaskUpdateScope::Autonomy(_))
+            && (args.approved_by.is_some() || args.status.as_deref() == Some("ready"))
+        {
+            return Err(TaskUpdateError(
+                "autonomy cannot approve tasks or move them to ready".to_string(),
+            ));
+        }
+        if matches!(
+            self.scope,
+            TaskUpdateScope::Autonomy(crate::config::AutonomyLevel::Suggest)
+        ) && (args.status.is_some()
+            || args.worker_id.is_some()
+            || args.approved_by.is_some()
+            || args.complete_subtask.is_some()
+            || args
+                .subtasks
+                .as_ref()
+                .is_some_and(|subtasks| subtasks.iter().any(|subtask| subtask.completed)))
+        {
+            return Err(TaskUpdateError(
+                "suggest autonomy may enrich task content and execution plans, but cannot approve, execute, bind, or complete task work"
+                    .to_string(),
+            ));
+        }
         if matches!(self.scope, TaskUpdateScope::Worker(_))
             && (args.title.is_some()
                 || args.description.is_some()
@@ -267,7 +305,7 @@ impl Tool for TaskUpdateTool {
         };
 
         let (author_type, author_id, source) = match &self.scope {
-            TaskUpdateScope::Branch => (
+            TaskUpdateScope::Branch | TaskUpdateScope::Autonomy(_) => (
                 crate::tasks::TaskAuthorKind::Agent,
                 self.agent_id.to_string(),
                 crate::tasks::TaskMutationSource::Tool,
@@ -312,7 +350,7 @@ impl Tool for TaskUpdateTool {
             .map_err(TaskUpdateError)?;
 
         let update_result = match &self.scope {
-            TaskUpdateScope::Branch => self
+            TaskUpdateScope::Branch | TaskUpdateScope::Autonomy(_) => self
                 .task_store
                 .update_with_dependencies_and_status_transition(
                     task_number,
@@ -553,6 +591,101 @@ mod tests {
             event.summary,
             format!("Task #{} updated to done", created.task_number)
         );
+    }
+
+    #[tokio::test]
+    async fn suggest_autonomy_cannot_approve_or_execute_tasks() {
+        let task_store = Arc::new(setup_test_store().await);
+        let created = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: Some("agent-test".to_string()),
+                title: "Needs approval".to_string(),
+                status: TaskStatus::PendingApproval,
+                priority: TaskPriority::Medium,
+                created_by: "autonomy".to_string(),
+                ..Default::default()
+            })
+            .await
+            .expect("task should be created");
+        let tool = TaskUpdateTool::for_autonomy(
+            task_store,
+            AgentId::from("agent-test"),
+            crate::config::AutonomyLevel::Suggest,
+        );
+
+        let error = tool
+            .call(TaskUpdateArgs {
+                task_number: created.task_number as i32,
+                title: None,
+                description: None,
+                status: Some("ready".to_string()),
+                priority: None,
+                subtasks: None,
+                metadata: None,
+                complete_subtask: None,
+                worker_id: None,
+                approved_by: Some("autonomy".to_string()),
+                worker_type: None,
+                project_id: None,
+                repo_id: None,
+                worktree_mode: None,
+                worktree_id: None,
+                required_skills: None,
+                depends_on: None,
+                edit_summary: Some("self approve".to_string()),
+                expected_revision: None,
+            })
+            .await
+            .expect_err("suggest autonomy must not approve tasks");
+
+        assert!(error.to_string().contains("cannot approve"));
+
+        let error = tool
+            .call(TaskUpdateArgs {
+                task_number: created.task_number as i32,
+                subtasks: Some(vec![crate::tasks::TaskSubtask {
+                    title: "implementation".to_string(),
+                    completed: true,
+                }]),
+                ..Default::default()
+            })
+            .await
+            .expect_err("suggest autonomy must not complete subtasks");
+        assert!(error.to_string().contains("cannot approve, execute"));
+    }
+
+    #[tokio::test]
+    async fn act_autonomy_cannot_self_approve_tasks() {
+        let task_store = Arc::new(setup_test_store().await);
+        let created = task_store
+            .create(crate::tasks::CreateTaskInput {
+                owner_agent_id: "agent-test".to_string(),
+                assigned_agent_id: Some("agent-test".to_string()),
+                title: "Needs human approval".to_string(),
+                status: TaskStatus::PendingApproval,
+                priority: TaskPriority::Medium,
+                created_by: "autonomy".to_string(),
+                ..Default::default()
+            })
+            .await
+            .expect("task should be created");
+        let tool = TaskUpdateTool::for_autonomy(
+            task_store,
+            AgentId::from("agent-test"),
+            crate::config::AutonomyLevel::Act,
+        );
+
+        let error = tool
+            .call(TaskUpdateArgs {
+                task_number: created.task_number as i32,
+                status: Some("ready".to_string()),
+                approved_by: Some("autonomy".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("act autonomy must not self approve");
+        assert!(error.to_string().contains("cannot approve"));
     }
 
     #[tokio::test]

--- a/src/wakes/runs.rs
+++ b/src/wakes/runs.rs
@@ -100,6 +100,35 @@ impl AutonomyRunStore {
         Ok(id)
     }
 
+    /// Atomically begin a run when no other run is active.
+    pub async fn try_begin_run(&self) -> Result<Option<String>> {
+        let mut tx = self
+            .pool
+            .begin_with("BEGIN IMMEDIATE")
+            .await
+            .context("failed to open autonomy run transaction")?;
+        let active: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM autonomy_runs WHERE status = 'running'")
+                .fetch_one(&mut *tx)
+                .await
+                .context("failed to count active autonomy runs")?;
+        if active > 0 {
+            tx.commit()
+                .await
+                .context("failed to close autonomy run transaction")?;
+            return Ok(None);
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query("INSERT INTO autonomy_runs (id) VALUES (?)")
+            .bind(&id)
+            .execute(&mut *tx)
+            .await
+            .context("failed to insert autonomy run")?;
+        tx.commit().await.context("failed to commit autonomy run")?;
+        Ok(Some(id))
+    }
+
     /// Record the wake events this run consumed ("woken by" provenance).
     pub async fn set_wake_events(&self, run_id: &str, wake_event_ids: &[String]) -> Result<()> {
         let ids_json =
@@ -267,6 +296,22 @@ impl AutonomyRunStore {
         Ok(count > 0)
     }
 
+    /// Close running rows left behind by a previous process before the
+    /// resident supervisor starts accepting heartbeats.
+    pub async fn reconcile_running_runs(&self, summary: &str) -> Result<u64> {
+        let result = sqlx::query(
+            "UPDATE autonomy_runs SET status = 'failed', summary = COALESCE(summary, ?), \
+             finished_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), \
+             duration_secs = CAST((julianday('now') - julianday(started_at)) * 86400 AS INTEGER) \
+             WHERE status = 'running'",
+        )
+        .bind(summary)
+        .execute(&self.pool)
+        .await
+        .context("failed to reconcile interrupted autonomy runs")?;
+        Ok(result.rows_affected())
+    }
+
     /// When the most recent run started, if any. Tracked from the table (not
     /// in-memory) so restarts keep the interval anchored.
     pub async fn last_run_started_at(&self) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
@@ -276,6 +321,17 @@ impl AutonomyRunStore {
             .context("failed to read last autonomy run start")?;
 
         Ok(value.as_deref().and_then(parse_run_timestamp))
+    }
+
+    pub async fn run_is_active(&self, run_id: &str) -> Result<bool> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM autonomy_runs WHERE id = ? AND status = 'running'",
+        )
+        .bind(run_id)
+        .fetch_one(&self.pool)
+        .await
+        .context("failed to read autonomy run status")?;
+        Ok(count > 0)
     }
 }
 
@@ -556,6 +612,55 @@ mod tests {
         let recent = store.recent(1).await.expect("recent");
         assert_eq!(recent[0].status, AutonomyRunStatus::Failed);
         assert!(recent[0].summary.as_deref().unwrap_or("").contains("dead"));
+    }
+
+    #[tokio::test]
+    async fn try_begin_run_is_single_flight() {
+        let store = store().await;
+        let first = store.try_begin_run().await.expect("first admission");
+        let second = store.try_begin_run().await.expect("second admission");
+
+        assert!(first.is_some());
+        assert!(second.is_none());
+        assert_eq!(
+            store
+                .recent(10)
+                .await
+                .expect("runs")
+                .into_iter()
+                .filter(|run| run.status == AutonomyRunStatus::Running)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_reconciliation_closes_only_running_epochs() {
+        let store = store().await;
+        let interrupted = store.begin_run().await.expect("interrupted run");
+        let completed = store.begin_run().await.expect("completed run");
+        store
+            .complete_run(&completed, "already complete", &[])
+            .await
+            .expect("complete run");
+
+        assert_eq!(
+            store
+                .reconcile_running_runs("interrupted by restart")
+                .await
+                .expect("reconcile"),
+            1
+        );
+        let runs = store.recent(10).await.expect("runs");
+        let interrupted = runs.iter().find(|run| run.id == interrupted).unwrap();
+        let completed = runs.iter().find(|run| run.id == completed).unwrap();
+        assert_eq!(interrupted.status, AutonomyRunStatus::Failed);
+        assert_eq!(
+            interrupted.summary.as_deref(),
+            Some("interrupted by restart")
+        );
+        assert_eq!(completed.status, AutonomyRunStatus::Completed);
+        assert_eq!(completed.summary.as_deref(), Some("already complete"));
     }
 
     #[tokio::test]

--- a/tests/behavioral_fixtures.rs
+++ b/tests/behavioral_fixtures.rs
@@ -156,6 +156,7 @@ async fn bootstrap(instance_dir: &Path) -> anyhow::Result<AgentDeps> {
         )),
         wake_def_store: Arc::new(spacebot::wakes::WakeDefStore::new(db.sqlite.clone())),
         autonomy_run_store: Arc::new(spacebot::wakes::AutonomyRunStore::new(db.sqlite.clone())),
+        autonomy_control: spacebot::agent::autonomy::AutonomyControl::default(),
         project_store: Arc::new(spacebot::projects::ProjectStore::new(instance_pool.clone())),
         cron_tool: None,
         runtime_config,

--- a/tests/context_dump.rs
+++ b/tests/context_dump.rs
@@ -128,6 +128,7 @@ async fn bootstrap_deps() -> anyhow::Result<(spacebot::AgentDeps, spacebot::conf
         )),
         wake_def_store: Arc::new(spacebot::wakes::WakeDefStore::new(db.sqlite.clone())),
         autonomy_run_store: Arc::new(spacebot::wakes::AutonomyRunStore::new(db.sqlite.clone())),
+        autonomy_control: spacebot::agent::autonomy::AutonomyControl::default(),
         project_store: Arc::new(spacebot::projects::ProjectStore::new(instance_pool.clone())),
         cron_tool: None,
         runtime_config,
@@ -212,6 +213,7 @@ fn build_channel_system_prompt(rc: &spacebot::config::RuntimeConfig) -> String {
             opencode_enabled,
             &[],
             &spacebot::conversation::settings::WorkerContextMode::default(),
+            true,
         )
         .expect("failed to render worker capabilities");
 


### PR DESCRIPTION
## Summary

- Keep one autonomy channel resident per agent and deliver heartbeats through a coalescing wake doorbell.
- Treat autonomy runs as durable epochs with atomic admission, generation fencing, transactional wake claims, and restart reconciliation.
- Retain interactive workers across heartbeats and restarts while blocking epoch completion until owned work settles.
- Scope autonomy tools by observe, suggest, and act authority. Autonomy cannot self-approve pending work.
- Remove autonomy run timeouts and update the lifecycle, prompt, and worker reliability docs.

## Lifecycle

The resident channel moves between idle, running, and finishing epochs. Atomic run admission prevents overlapping epochs. Child registration and completion share one synchronization boundary, so completion cannot race worker or branch creation. Shutdown closes active epochs and converges retained worker state before database teardown.

This PR is stacked on #649.

## Testing

- `just preflight`
- `just gate-pr`
- `cargo test agent::autonomy`
- `cargo test tools::autonomy_complete`
- `cargo test wakes::runs`
- `cargo test autonomy_cannot`
- `cargo test autonomy_channel_prompt_renders_per_level`