### PR TITLE
Add autonomy toggle commands

### DIFF
--- a/docs/content/docs/(features)/autonomy.mdx
+++ b/docs/content/docs/(features)/autonomy.mdx
@@ -24,7 +24,7 @@ The instance can apply a ceiling that limits every agent regardless of its indiv
 
 ## Commands
 
-`/autonomy` reports the agent's configured level and the effective level after the instance ceiling is applied. `/autonomy-off` remembers the current non-off level and prevents new heartbeats, wake events, and epochs from being admitted. Work already active in the current epoch is allowed to settle. `/autonomy-on` restores the remembered level, or starts at `observe` when the agent has never been enabled.
+`/autonomy` reports the agent's configured level and the effective level after the instance ceiling is applied. `/autonomy-off` remembers the current non-off level and prevents new heartbeats, wake events, and epochs from being admitted. Work already active in the current epoch is allowed to settle. `/autonomy-on` restores the remembered level, or starts at `observe` when the agent has never been enabled. Pass a level to select it explicitly, such as `/autonomy-on act` (Telegram also accepts `/autonomy_on act`).
 
 Changing the configured level does not raise the instance ceiling. Restoring `act` under a `suggest` ceiling leaves the configured level at `act` and reports `suggest` as the effective level. The status command is available to everyone; enabling and disabling autonomy require authority in the current binding.
 

--- a/docs/content/docs/(features)/autonomy.mdx
+++ b/docs/content/docs/(features)/autonomy.mdx
@@ -22,6 +22,12 @@ Each agent has an autonomy level:
 
 The instance can apply a ceiling that limits every agent regardless of its individual setting.
 
+## Commands
+
+`/autonomy` reports the agent's configured level and the effective level after the instance ceiling is applied. `/autonomy-off` remembers the current non-off level and prevents new heartbeats, wake events, and epochs from being admitted. Work already active in the current epoch is allowed to settle. `/autonomy-on` restores the remembered level, or starts at `observe` when the agent has never been enabled.
+
+Changing the configured level does not raise the instance ceiling. Restoring `act` under a `suggest` ceiling leaves the configured level at `act` and reports `suggest` as the effective level. The status command is available to everyone; enabling and disabling autonomy require authority in the current binding.
+
 ## Goals and Tasks
 
 Goals are standing direction. They remain active until an operator closes them. Tasks are the concrete units of work linked to those goals.
@@ -64,13 +70,11 @@ level = "off"
 interval_secs = 1800
 max_turns = 20
 max_tasks_per_run = 2
-timeout_secs = 600
-warn_secs = 480
 run_history_count = 5
 claim_unowned = true
 ```
 
-`interval_secs` must be at least 60 seconds. `timeout_secs` must not exceed the interval. `active_hours`, when configured, uses the agent's cron timezone.
+`interval_secs` must be at least 60 seconds. `active_hours`, when configured, uses the agent's cron timezone.
 
 ## Related Documentation
 

--- a/docs/content/docs/(features)/commands.mdx
+++ b/docs/content/docs/(features)/commands.mdx
@@ -25,7 +25,7 @@ Spacebot handles built-in commands before normal LLM processing. The command set
 | `/pause [reason]` | Authority | Stop new work from starting. |
 | `/pause off` | Authority | Resume new work. |
 | `/autonomy` | Everyone | Show the configured level, effective level, ceiling, and current epoch state. |
-| `/autonomy-on` | Authority | Restore the last non-off autonomy level, defaulting to `observe`. |
+| `/autonomy-on [observe\|suggest\|act]` | Authority | Enable autonomy at an explicit level, or restore the last level when omitted. |
 | `/autonomy-off` | Authority | Stop new autonomy work while the current epoch settles. |
 
 Commands that request task information are sent through the agent after classification. Control commands are applied atomically and do not need an LLM turn.

--- a/docs/content/docs/(features)/commands.mdx
+++ b/docs/content/docs/(features)/commands.mdx
@@ -24,12 +24,15 @@ Spacebot handles built-in commands before normal LLM processing. The command set
 | `/sethome` | Authority | Set the current chat as the agent's home channel. |
 | `/pause [reason]` | Authority | Stop new work from starting. |
 | `/pause off` | Authority | Resume new work. |
+| `/autonomy` | Everyone | Show the configured level, effective level, ceiling, and current epoch state. |
+| `/autonomy-on` | Authority | Restore the last non-off autonomy level, defaulting to `observe`. |
+| `/autonomy-off` | Authority | Stop new autonomy work while the current epoch settles. |
 
 Commands that request task information are sent through the agent after classification. Control commands are applied atomically and do not need an LLM turn.
 
 ## Authority
 
-Authority is configured per binding or adapter. Binding-level authority lists take precedence over adapter defaults. Everyone can use conversational and read-only commands. Only authority members can alter response mode, pause state, or the home channel.
+Authority is configured per binding or adapter. Binding-level authority lists take precedence over adapter defaults. Everyone can use conversational and read-only commands. Only authority members can alter response mode, pause state, autonomy, or the home channel.
 
 Run `/whoami` before using a control command to see the access available in the current chat.
 

--- a/docs/design-docs/autonomy.md
+++ b/docs/design-docs/autonomy.md
@@ -55,6 +55,8 @@ Generation tags fence late messages from older epochs. A bounded doorbell coales
 
 Worker results are also control messages. They continue the intent that spawned or routed the worker. They do not grant permission to start unrelated work.
 
+Changing the effective level to `off` suppresses further heartbeat and wake admission immediately. An active epoch is not cancelled: its current turn and owned children can settle, but the supervisor does not feed it additional work. Once that epoch completes, the resident channel remains idle until autonomy is enabled again.
+
 The transcript holds the current epoch's work. System scaffolding and previous epoch detail do not accumulate.
 
 ## What It Does

--- a/src/agent/autonomy.rs
+++ b/src/agent/autonomy.rs
@@ -254,6 +254,7 @@ pub struct AutonomyControl {
     stopped_notify: Arc<Notify>,
     preserve_idle_workers: Arc<AtomicBool>,
     ready: Arc<AtomicBool>,
+    transition: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl AutonomyControl {
@@ -283,6 +284,10 @@ impl AutonomyControl {
                 }
             }
         }
+    }
+
+    pub async fn lock_transition(&self) -> tokio::sync::OwnedMutexGuard<()> {
+        self.transition.clone().lock_owned().await
     }
 
     pub fn activate(&self) {
@@ -675,6 +680,7 @@ async fn start_epoch_if_due(
     run_slot: &AutonomyRunSlot,
     channel_tx: &mpsc::Sender<InboundMessage>,
 ) -> anyhow::Result<Option<ActiveEpoch>> {
+    let _transition_guard = deps.autonomy_control.lock_transition().await;
     let raw_config = **deps.runtime_config.autonomy.load();
     let config = AutonomyConfig {
         level: raw_config.level.min(**deps.autonomy_ceiling.load()),
@@ -731,7 +737,12 @@ async fn send_heartbeat(
     channel_tx: &mpsc::Sender<InboundMessage>,
     epoch: &mut ActiveEpoch,
 ) -> anyhow::Result<()> {
+    let _transition_guard = deps.autonomy_control.lock_transition().await;
     let config = **deps.runtime_config.autonomy.load();
+    let Some(effective_level) = heartbeat_level(config.level, **deps.autonomy_ceiling.load())
+    else {
+        return Ok(());
+    };
     let pending_count = deps.wake_event_store.pending_count().await?;
     if pending_count == 0
         && epoch.last_heartbeat.elapsed() < Duration::from_secs(config.interval_secs.max(1))
@@ -749,7 +760,7 @@ async fn send_heartbeat(
         }
     };
     epoch.config = AutonomyConfig {
-        level: config.level.min(**deps.autonomy_ceiling.load()),
+        level: effective_level,
         ..config
     };
     let events = deps
@@ -781,6 +792,11 @@ async fn send_heartbeat(
     epoch.wake_event_ids = all_event_ids;
     epoch.last_heartbeat = tokio::time::Instant::now();
     Ok(())
+}
+
+fn heartbeat_level(level: AutonomyLevel, ceiling: AutonomyLevel) -> Option<AutonomyLevel> {
+    let effective = level.min(ceiling);
+    (effective != AutonomyLevel::Off).then_some(effective)
 }
 
 async fn commit_wake_claim(
@@ -1212,6 +1228,40 @@ mod tests {
             12,
             1800
         ));
+    }
+
+    #[test]
+    fn heartbeat_admission_stops_when_dial_or_ceiling_is_off() {
+        assert_eq!(
+            heartbeat_level(AutonomyLevel::Act, AutonomyLevel::Suggest),
+            Some(AutonomyLevel::Suggest)
+        );
+        assert_eq!(
+            heartbeat_level(AutonomyLevel::Off, AutonomyLevel::Act),
+            None
+        );
+        assert_eq!(
+            heartbeat_level(AutonomyLevel::Act, AutonomyLevel::Off),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn autonomy_transitions_serialize_with_admission() {
+        let control = AutonomyControl::default();
+        let guard = control.lock_transition().await;
+        let contender = {
+            let control = control.clone();
+            tokio::spawn(async move { control.lock_transition().await })
+        };
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!contender.is_finished());
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), contender)
+            .await
+            .expect("transition lock should become available")
+            .expect("contender should not panic");
     }
 
     #[test]

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -1940,11 +1940,13 @@ impl Channel {
                 self.send_builtin_text(reply, def.name).await;
             }
             ControlAction::AutonomyOn => {
-                let reply = crate::commands::control::set_autonomy_enabled(&self.deps, true).await;
+                let reply =
+                    crate::commands::control::set_autonomy_enabled(&self.deps, true, args).await;
                 self.send_builtin_text(reply, def.name).await;
             }
             ControlAction::AutonomyOff => {
-                let reply = crate::commands::control::set_autonomy_enabled(&self.deps, false).await;
+                let reply =
+                    crate::commands::control::set_autonomy_enabled(&self.deps, false, args).await;
                 self.send_builtin_text(reply, def.name).await;
             }
         }

--- a/src/agent/channel.rs
+++ b/src/agent/channel.rs
@@ -127,7 +127,11 @@ fn is_control_command(message: &InboundMessage) -> bool {
         crate::MessageContent::Command { .. } => message.content.to_string(),
         _ => return false,
     };
-    match crate::commands::REGISTRY.parse(&text) {
+    let bot_username = message
+        .metadata
+        .get("telegram_bot_username")
+        .and_then(serde_json::Value::as_str);
+    match crate::commands::REGISTRY.parse_addressed(&text, bot_username) {
         crate::commands::ParseResult::Command(command) => matches!(
             command.def.handler,
             crate::commands::CommandHandler::Control(_)
@@ -1931,6 +1935,18 @@ impl Channel {
                 )
                 .await;
             }
+            ControlAction::AutonomyStatus => {
+                let reply = crate::commands::control::autonomy_status(&self.deps).await;
+                self.send_builtin_text(reply, def.name).await;
+            }
+            ControlAction::AutonomyOn => {
+                let reply = crate::commands::control::set_autonomy_enabled(&self.deps, true).await;
+                self.send_builtin_text(reply, def.name).await;
+            }
+            ControlAction::AutonomyOff => {
+                let reply = crate::commands::control::set_autonomy_enabled(&self.deps, false).await;
+                self.send_builtin_text(reply, def.name).await;
+            }
         }
     }
 
@@ -2891,7 +2907,13 @@ impl Channel {
         let parsed_command = if message.source == "system" {
             crate::commands::ParseResult::NotACommand
         } else {
-            crate::commands::REGISTRY.parse(&raw_text)
+            crate::commands::REGISTRY.parse_addressed(
+                &raw_text,
+                message
+                    .metadata
+                    .get("telegram_bot_username")
+                    .and_then(serde_json::Value::as_str),
+            )
         };
         match &parsed_command {
             crate::commands::ParseResult::Command(cmd) => {

--- a/src/api/autonomy.rs
+++ b/src/api/autonomy.rs
@@ -109,7 +109,7 @@ async fn agent_deps(state: &ApiState, agent_id: &str) -> Option<crate::AgentDeps
 }
 
 /// Build a status snapshot for one agent from its stores and live config.
-async fn build_status(
+pub(crate) async fn build_status(
     agent_id: &str,
     deps: &crate::AgentDeps,
     ceiling: AutonomyLevel,

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -494,6 +494,156 @@ pub(super) async fn update_agent_config(
     State(state): State<Arc<ApiState>>,
     axum::Json(request): axum::Json<AgentConfigUpdateRequest>,
 ) -> Result<Json<AgentConfigResponse>, StatusCode> {
+    let _autonomy_guard = if request
+        .autonomy
+        .as_ref()
+        .is_some_and(|autonomy| autonomy.level.is_some())
+    {
+        let key: crate::AgentId = Arc::from(request.agent_id.as_str());
+        let control = state
+            .wake_registry
+            .read()
+            .await
+            .get(&key)
+            .map(|deps| deps.autonomy_control.clone())
+            .ok_or(StatusCode::NOT_FOUND)?;
+        Some(control.lock_transition().await)
+    } else {
+        None
+    };
+    let (new_config, _resume_level) = edit_agent_config(
+        &state,
+        &request.agent_id,
+        |current_config, doc, agent_idx| {
+            if let Some(routing) = &request.routing {
+                update_routing_table(doc, agent_idx, routing)?;
+            }
+            if let Some(tuning) = &request.tuning {
+                update_tuning_table(doc, agent_idx, tuning)?;
+            }
+            if let Some(compaction) = &request.compaction {
+                update_compaction_table(doc, agent_idx, compaction)?;
+            }
+            if let Some(cortex) = &request.cortex {
+                update_cortex_table(doc, agent_idx, cortex)?;
+            }
+            let mut resume_level = None;
+            if let Some(autonomy) = &request.autonomy {
+                if let Some(target) = autonomy.level {
+                    let current = current_config
+                        .agents
+                        .iter()
+                        .find(|agent| agent.id == request.agent_id)
+                        .map(|agent| {
+                            agent
+                                .resolve(&current_config.instance_dir, &current_config.defaults)
+                                .autonomy
+                                .level
+                        });
+                    resume_level = current
+                        .and_then(|current| autonomy_resume_level_for_transition(current, target))
+                }
+                update_autonomy_table(doc, agent_idx, autonomy)?;
+            }
+            if let Some(warmup) = &request.warmup {
+                update_warmup_table(doc, agent_idx, warmup)?;
+            }
+            if let Some(coalesce) = &request.coalesce {
+                update_coalesce_table(doc, agent_idx, coalesce)?;
+            }
+            if let Some(memory_persistence) = &request.memory_persistence {
+                update_memory_persistence_table(doc, agent_idx, memory_persistence)?;
+            }
+            if let Some(browser) = &request.browser {
+                update_browser_table(doc, agent_idx, browser)?;
+            }
+            if let Some(channel) = &request.channel {
+                update_channel_table(doc, agent_idx, channel)?;
+            }
+            if let Some(sandbox) = &request.sandbox {
+                update_sandbox_table(doc, agent_idx, sandbox)?;
+            }
+            if let Some(projects) = &request.projects {
+                update_projects_table(doc, agent_idx, projects)?;
+            }
+            if let Some(discord) = &request.discord {
+                update_discord_table(doc, discord)?;
+            }
+            Ok((resume_level, true))
+        },
+        |resume_level| persist_autonomy_resume_level(&state, &request.agent_id, *resume_level),
+    )
+    .await?;
+
+    tracing::info!(agent_id = %request.agent_id, "config.toml updated via API");
+
+    if request.discord.is_some()
+        && let Some(discord_config) = &new_config.messaging.discord
+    {
+        let new_permissions =
+            crate::config::DiscordPermissions::from_config(discord_config, &new_config.bindings);
+        let permissions = state.discord_permissions.read().await;
+        if let Some(arc_swap) = permissions.as_ref() {
+            arc_swap.store(std::sync::Arc::new(new_permissions));
+        }
+    }
+
+    get_agent_config(
+        State(state),
+        Query(AgentConfigQuery {
+            agent_id: request.agent_id,
+        }),
+    )
+    .await
+}
+
+fn autonomy_resume_level_for_transition(
+    current: crate::config::AutonomyLevel,
+    target: crate::config::AutonomyLevel,
+) -> Option<crate::config::AutonomyLevel> {
+    match (current, target) {
+        (current, crate::config::AutonomyLevel::Off)
+            if current != crate::config::AutonomyLevel::Off =>
+        {
+            Some(current)
+        }
+        (_, target) if target != crate::config::AutonomyLevel::Off => Some(target),
+        _ => None,
+    }
+}
+
+fn persist_autonomy_resume_level(
+    state: &ApiState,
+    agent_id: &str,
+    level: Option<crate::config::AutonomyLevel>,
+) -> Result<(), StatusCode> {
+    let Some(level) = level else {
+        return Ok(());
+    };
+    let settings = state
+        .runtime_configs
+        .load()
+        .get(agent_id)
+        .and_then(|runtime_config| runtime_config.settings.load().as_ref().clone())
+        .ok_or(StatusCode::NOT_FOUND)?;
+    settings.set_autonomy_resume_level(level).map_err(|error| {
+        tracing::warn!(%error, agent_id, "failed to save autonomy resume level");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+/// Apply one serialized agent-config edit and converge the live runtime before
+/// another API or command writer can observe the new file with stale state.
+async fn edit_agent_config<R>(
+    state: &Arc<ApiState>,
+    agent_id: &str,
+    edit: impl FnOnce(
+        &crate::config::Config,
+        &mut toml_edit::DocumentMut,
+        usize,
+    ) -> Result<(R, bool), StatusCode>,
+    before_write: impl FnOnce(&R) -> Result<(), StatusCode>,
+) -> Result<(crate::config::Config, R), StatusCode> {
     let config_path = state.config_path.read().await.clone();
     if config_path.as_os_str().is_empty() {
         tracing::error!("config_path not set in ApiState");
@@ -510,6 +660,10 @@ pub(super) async fn update_agent_config(
             tracing::warn!(%error, "failed to read config.toml");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+    let current_config = crate::config::Config::load_from_path(&config_path).map_err(|error| {
+        tracing::warn!(%error, "failed to load current config.toml");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let mut doc = config_content
         .parse::<toml_edit::DocumentMut>()
@@ -518,46 +672,10 @@ pub(super) async fn update_agent_config(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let agent_idx = find_or_create_agent_table(&mut doc, &request.agent_id)?;
-
-    if let Some(routing) = &request.routing {
-        update_routing_table(&mut doc, agent_idx, routing)?;
-    }
-    if let Some(tuning) = &request.tuning {
-        update_tuning_table(&mut doc, agent_idx, tuning)?;
-    }
-    if let Some(compaction) = &request.compaction {
-        update_compaction_table(&mut doc, agent_idx, compaction)?;
-    }
-    if let Some(cortex) = &request.cortex {
-        update_cortex_table(&mut doc, agent_idx, cortex)?;
-    }
-    if let Some(autonomy) = &request.autonomy {
-        update_autonomy_table(&mut doc, agent_idx, autonomy)?;
-    }
-    if let Some(warmup) = &request.warmup {
-        update_warmup_table(&mut doc, agent_idx, warmup)?;
-    }
-    if let Some(coalesce) = &request.coalesce {
-        update_coalesce_table(&mut doc, agent_idx, coalesce)?;
-    }
-    if let Some(memory_persistence) = &request.memory_persistence {
-        update_memory_persistence_table(&mut doc, agent_idx, memory_persistence)?;
-    }
-    if let Some(browser) = &request.browser {
-        update_browser_table(&mut doc, agent_idx, browser)?;
-    }
-    if let Some(channel) = &request.channel {
-        update_channel_table(&mut doc, agent_idx, channel)?;
-    }
-    if let Some(sandbox) = &request.sandbox {
-        update_sandbox_table(&mut doc, agent_idx, sandbox)?;
-    }
-    if let Some(projects) = &request.projects {
-        update_projects_table(&mut doc, agent_idx, projects)?;
-    }
-    if let Some(discord) = &request.discord {
-        update_discord_table(&mut doc, discord)?;
+    let agent_idx = find_or_create_agent_table(&mut doc, agent_id)?;
+    let (edit_result, changed) = edit(&current_config, &mut doc, agent_idx)?;
+    if !changed {
+        return Ok((current_config, edit_result));
     }
 
     let updated_content = doc.to_string();
@@ -565,6 +683,7 @@ pub(super) async fn update_agent_config(
         tracing::warn!(%error, "rejected config API update due to invalid resulting TOML");
         return Err(StatusCode::BAD_REQUEST);
     }
+    before_write(&edit_result)?;
 
     tokio::fs::write(&config_path, updated_content)
         .await
@@ -573,51 +692,108 @@ pub(super) async fn update_agent_config(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // Release the config write mutex — remaining work is read-only state updates.
+    let new_config = crate::config::Config::load_from_path(&config_path).map_err(|error| {
+        tracing::warn!(%error, "config.toml written but failed to reload immediately");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    state.set_defaults_config(new_config.defaults.clone()).await;
+    let runtime_config = state.runtime_configs.load().get(agent_id).cloned();
+    let mcp_manager = state.mcp_managers.load().get(agent_id).cloned();
+    let mcp_reconciliation = runtime_config
+        .as_ref()
+        .and_then(|runtime_config| runtime_config.publish_config(&new_config, agent_id));
     drop(_config_guard);
-
-    tracing::info!(agent_id = %request.agent_id, "config.toml updated via API");
-
-    match crate::config::Config::load_from_path(&config_path) {
-        Ok(new_config) => {
-            // Keep in-memory defaults fresh so newly created agents inherit
-            // the latest routing values.
-            state.set_defaults_config(new_config.defaults.clone()).await;
-
-            let runtime_configs = state.runtime_configs.load();
-            let mcp_managers = state.mcp_managers.load();
-            if let (Some(rc), Some(mcp_manager)) = (
-                runtime_configs.get(&request.agent_id).cloned(),
-                mcp_managers.get(&request.agent_id).cloned(),
-            ) {
-                rc.reload_config(&new_config, &request.agent_id, &mcp_manager)
-                    .await;
-            }
-            if request.discord.is_some()
-                && let Some(discord_config) = &new_config.messaging.discord
-            {
-                let new_perms = crate::config::DiscordPermissions::from_config(
-                    discord_config,
-                    &new_config.bindings,
-                );
-                let perms = state.discord_permissions.read().await;
-                if let Some(arc_swap) = perms.as_ref() {
-                    arc_swap.store(std::sync::Arc::new(new_perms));
-                }
-            }
-        }
-        Err(error) => {
-            tracing::warn!(%error, "config.toml written but failed to reload immediately");
-        }
+    if let (Some(mcp_manager), Some((old_mcp, new_mcp))) = (mcp_manager, mcp_reconciliation)
+        && old_mcp != new_mcp
+    {
+        mcp_manager.reconcile(&old_mcp, &new_mcp).await;
     }
 
-    get_agent_config(
-        State(state),
-        Query(AgentConfigQuery {
-            agent_id: request.agent_id,
-        }),
+    Ok((new_config, edit_result))
+}
+
+pub(crate) enum AutonomyLevelMutation {
+    Unchanged,
+    Set(crate::config::AutonomyLevel),
+}
+
+pub(crate) struct AutonomyLevelChange {
+    pub previous: crate::config::AutonomyLevel,
+    pub configured: crate::config::AutonomyLevel,
+    pub effective: crate::config::AutonomyLevel,
+}
+
+/// Persist a level selected by an operator command and return both dial and
+/// effective values after the shared ceiling is applied.
+pub(crate) async fn mutate_agent_autonomy_level(
+    state: &Arc<ApiState>,
+    agent_id: &str,
+    mutation: impl FnOnce(crate::config::AutonomyLevel) -> Result<AutonomyLevelMutation, StatusCode>,
+) -> Result<AutonomyLevelChange, StatusCode> {
+    let key: crate::AgentId = Arc::from(agent_id);
+    let control = state
+        .wake_registry
+        .read()
+        .await
+        .get(&key)
+        .map(|deps| deps.autonomy_control.clone())
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let _transition_guard = control.lock_transition().await;
+    if !state.runtime_configs.load().contains_key(agent_id)
+        || !state.mcp_managers.load().contains_key(agent_id)
+    {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let (_new_config, (previous, configured, _resume_level)) = edit_agent_config(
+        state,
+        agent_id,
+        move |current_config, doc, agent_idx| {
+            let agent = current_config
+                .agents
+                .iter()
+                .find(|agent| agent.id == agent_id)
+                .ok_or(StatusCode::NOT_FOUND)?;
+            let current = agent
+                .resolve(&current_config.instance_dir, &current_config.defaults)
+                .autonomy
+                .level;
+            let configured = match mutation(current)? {
+                AutonomyLevelMutation::Unchanged => {
+                    return Ok(((current, current, None), false));
+                }
+                AutonomyLevelMutation::Set(configured) => configured,
+            };
+            update_autonomy_table(
+                doc,
+                agent_idx,
+                &AutonomyUpdate {
+                    level: Some(configured),
+                    interval_secs: None,
+                    active_hours: None,
+                    max_turns: None,
+                    max_tasks_per_run: None,
+                    run_history_count: None,
+                    claim_unowned: None,
+                },
+            )?;
+            Ok((
+                (
+                    current,
+                    configured,
+                    autonomy_resume_level_for_transition(current, configured),
+                ),
+                true,
+            ))
+        },
+        |(_, _, resume_level)| persist_autonomy_resume_level(state, agent_id, *resume_level),
     )
-    .await
+    .await?;
+    Ok(AutonomyLevelChange {
+        previous,
+        configured,
+        effective: configured.min(**state.autonomy_ceiling.load()),
+    })
 }
 
 // -- TOML edit helpers --
@@ -1133,6 +1309,146 @@ fn update_discord_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn test_api_state(config_path: std::path::PathBuf) -> Arc<ApiState> {
+        let (provider_setup_tx, _) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, _) = tokio::sync::mpsc::channel(1);
+        let (agent_remove_tx, _) = tokio::sync::mpsc::channel(1);
+        let (injection_tx, _) = tokio::sync::mpsc::channel(1);
+        let state = Arc::new(ApiState::new_with_provider_sender(
+            provider_setup_tx,
+            agent_tx,
+            agent_remove_tx,
+            injection_tx,
+        ));
+        state.set_config_path(config_path).await;
+        state
+    }
+
+    #[tokio::test]
+    async fn unchanged_edit_preserves_the_config_file_byte_for_byte() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let content = "# keep this comment\n\n[[agents]]\nid = \"main\"\ndefault = true\n";
+        tokio::fs::write(&config_path, content).await.unwrap();
+        let state = test_api_state(config_path.clone()).await;
+
+        edit_agent_config(&state, "main", |_, _, _| Ok(((), false)), |_| Ok(()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            tokio::fs::read_to_string(config_path).await.unwrap(),
+            content
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_edit_does_not_run_prewrite_side_effects() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let content = "[[agents]]\nid = \"main\"\ndefault = true\n";
+        tokio::fs::write(&config_path, content).await.unwrap();
+        let state = test_api_state(config_path.clone()).await;
+        let side_effect_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let side_effect = side_effect_ran.clone();
+
+        let result = edit_agent_config(
+            &state,
+            "main",
+            |_, doc, agent_idx| {
+                update_autonomy_table(
+                    doc,
+                    agent_idx,
+                    &AutonomyUpdate {
+                        level: Some(crate::config::AutonomyLevel::Act),
+                        interval_secs: Some(1),
+                        active_hours: None,
+                        max_turns: None,
+                        max_tasks_per_run: None,
+                        run_history_count: None,
+                        claim_unowned: None,
+                    },
+                )?;
+                Ok((Some(crate::config::AutonomyLevel::Act), true))
+            },
+            move |_| {
+                side_effect.store(true, std::sync::atomic::Ordering::Release);
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
+        assert!(!side_effect_ran.load(std::sync::atomic::Ordering::Acquire));
+        assert_eq!(
+            tokio::fs::read_to_string(config_path).await.unwrap(),
+            content
+        );
+    }
+
+    #[test]
+    fn api_level_changes_keep_the_latest_resume_level() {
+        use crate::config::AutonomyLevel;
+
+        assert_eq!(
+            autonomy_resume_level_for_transition(AutonomyLevel::Act, AutonomyLevel::Off),
+            Some(AutonomyLevel::Act)
+        );
+        assert_eq!(
+            autonomy_resume_level_for_transition(AutonomyLevel::Off, AutonomyLevel::Suggest),
+            Some(AutonomyLevel::Suggest)
+        );
+        assert_eq!(
+            autonomy_resume_level_for_transition(AutonomyLevel::Off, AutonomyLevel::Off),
+            None
+        );
+    }
+
+    #[test]
+    fn autonomy_level_update_preserves_other_tuning() {
+        let mut doc: toml_edit::DocumentMut = r#"
+[defaults.autonomy]
+interval_secs = 900
+
+[[agents]]
+id = "main"
+
+[agents.autonomy]
+level = "act"
+max_tasks_per_run = 4
+claim_unowned = true
+"#
+        .parse()
+        .expect("failed to parse test TOML");
+        let agent_idx = find_or_create_agent_table(&mut doc, "main").unwrap();
+
+        update_autonomy_table(
+            &mut doc,
+            agent_idx,
+            &AutonomyUpdate {
+                level: Some(crate::config::AutonomyLevel::Off),
+                interval_secs: None,
+                active_hours: None,
+                max_turns: None,
+                max_tasks_per_run: None,
+                run_history_count: None,
+                claim_unowned: None,
+            },
+        )
+        .unwrap();
+
+        let autonomy = doc["agents"]
+            .as_array_of_tables()
+            .and_then(|agents| agents.get(agent_idx))
+            .and_then(|agent| agent.get("autonomy"))
+            .and_then(toml_edit::Item::as_table)
+            .unwrap();
+        assert_eq!(autonomy["level"].as_str(), Some("off"));
+        assert_eq!(autonomy["max_tasks_per_run"].as_integer(), Some(4));
+        assert_eq!(autonomy["claim_unowned"].as_bool(), Some(true));
+        assert!(autonomy.get("interval_secs").is_none());
+    }
 
     #[test]
     fn test_update_warmup_table_writes_values() {

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -616,9 +616,9 @@ fn persist_autonomy_resume_level(
     state: &ApiState,
     agent_id: &str,
     level: Option<crate::config::AutonomyLevel>,
-) -> Result<(), StatusCode> {
+) -> Result<Option<AutonomyResumeRollback>, StatusCode> {
     let Some(level) = level else {
-        return Ok(());
+        return Ok(None);
     };
     let settings = state
         .runtime_configs
@@ -626,10 +626,32 @@ fn persist_autonomy_resume_level(
         .get(agent_id)
         .and_then(|runtime_config| runtime_config.settings.load().as_ref().clone())
         .ok_or(StatusCode::NOT_FOUND)?;
+    let previous = settings.autonomy_resume_level().map_err(|error| {
+        tracing::warn!(%error, agent_id, "failed to read autonomy resume level");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    if previous == Some(level) {
+        return Ok(None);
+    }
     settings.set_autonomy_resume_level(level).map_err(|error| {
         tracing::warn!(%error, agent_id, "failed to save autonomy resume level");
         StatusCode::INTERNAL_SERVER_ERROR
-    })
+    })?;
+    Ok(Some(AutonomyResumeRollback { settings, previous }))
+}
+
+struct AutonomyResumeRollback {
+    settings: Arc<crate::settings::SettingsStore>,
+    previous: Option<crate::config::AutonomyLevel>,
+}
+
+impl AutonomyResumeRollback {
+    fn restore(self) -> crate::Result<()> {
+        match self.previous {
+            Some(level) => self.settings.set_autonomy_resume_level(level),
+            None => self.settings.clear_autonomy_resume_level(),
+        }
+    }
 }
 
 /// Apply one serialized agent-config edit and converge the live runtime before
@@ -642,7 +664,7 @@ async fn edit_agent_config<R>(
         &mut toml_edit::DocumentMut,
         usize,
     ) -> Result<(R, bool), StatusCode>,
-    before_write: impl FnOnce(&R) -> Result<(), StatusCode>,
+    before_write: impl FnOnce(&R) -> Result<Option<AutonomyResumeRollback>, StatusCode>,
 ) -> Result<(crate::config::Config, R), StatusCode> {
     let config_path = state.config_path.read().await.clone();
     if config_path.as_os_str().is_empty() {
@@ -683,14 +705,17 @@ async fn edit_agent_config<R>(
         tracing::warn!(%error, "rejected config API update due to invalid resulting TOML");
         return Err(StatusCode::BAD_REQUEST);
     }
-    before_write(&edit_result)?;
+    let rollback = before_write(&edit_result)?;
 
-    tokio::fs::write(&config_path, updated_content)
-        .await
-        .map_err(|error| {
-            tracing::warn!(%error, "failed to write config.toml");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    if let Err(error) = tokio::fs::write(&config_path, updated_content).await {
+        tracing::warn!(%error, "failed to write config.toml");
+        if let Some(rollback) = rollback
+            && let Err(rollback_error) = rollback.restore()
+        {
+            tracing::error!(%rollback_error, "failed to restore autonomy resume level after config write failure");
+        }
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
 
     let new_config = crate::config::Config::load_from_path(&config_path).map_err(|error| {
         tracing::warn!(%error, "config.toml written but failed to reload immediately");
@@ -1333,7 +1358,7 @@ mod tests {
         tokio::fs::write(&config_path, content).await.unwrap();
         let state = test_api_state(config_path.clone()).await;
 
-        edit_agent_config(&state, "main", |_, _, _| Ok(((), false)), |_| Ok(()))
+        edit_agent_config(&state, "main", |_, _, _| Ok(((), false)), |_| Ok(None))
             .await
             .unwrap();
 
@@ -1374,7 +1399,7 @@ mod tests {
             },
             move |_| {
                 side_effect.store(true, std::sync::atomic::Ordering::Release);
-                Ok(())
+                Ok(None)
             },
         )
         .await;

--- a/src/commands/access.rs
+++ b/src/commands/access.rs
@@ -257,24 +257,15 @@ mod authority_gate_tests {
         )])));
     }
 
-    /// The channel re-parses raw text without the receiving bot's username,
-    /// so text the router declined as addressed elsewhere still resolves
-    /// there. That path must gate on the stamped verdict.
     #[test]
-    fn addressed_commands_diverge_between_the_two_parsers() {
+    fn addressed_commands_are_rejected_consistently() {
         let registry = &crate::commands::REGISTRY;
-        assert!(matches!(
+        for parsed in [
             registry.parse_addressed("/sethome@otherbot", Some("spacebot")),
-            crate::commands::ParseResult::NotACommand
-        ));
-        let reparsed = registry.parse("/sethome@otherbot");
-        let crate::commands::ParseResult::Command(parsed) = reparsed else {
-            panic!("channel-side parse should still resolve the command");
-        };
-        assert_eq!(parsed.def.name, "sethome");
-        assert_eq!(parsed.def.access, CommandAccess::Authority);
-        assert!(!access_allows(parsed.def, false));
-        assert!(access_allows(parsed.def, true));
+            registry.parse_addressed("/autonomy_off@otherbot", Some("spacebot")),
+        ] {
+            assert!(matches!(parsed, crate::commands::ParseResult::NotACommand));
+        }
     }
 }
 

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -120,8 +120,8 @@ impl ControlPlane {
             ControlAction::SetPause => set_pause(&self.deps, args),
             ControlAction::WhoAmI => whoami_text(self.is_authority, self.surface),
             ControlAction::AutonomyStatus => autonomy_status(&self.deps).await,
-            ControlAction::AutonomyOn => set_autonomy_enabled(&self.deps, true).await,
-            ControlAction::AutonomyOff => set_autonomy_enabled(&self.deps, false).await,
+            ControlAction::AutonomyOn => set_autonomy_enabled(&self.deps, true, args).await,
+            ControlAction::AutonomyOff => set_autonomy_enabled(&self.deps, false, args).await,
         }
     }
 
@@ -266,12 +266,20 @@ pub async fn autonomy_status(deps: &crate::AgentDeps) -> String {
 }
 
 /// Toggle future autonomy epochs while preserving the last enabled level.
-pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool) -> String {
+pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool, args: &str) -> String {
     let Some(api_state) = deps.api_state.as_ref() else {
         return "autonomy settings aren't available — level unchanged".to_string();
     };
     let Some(settings) = deps.settings() else {
         return "settings storage isn't available — autonomy unchanged".to_string();
+    };
+    let requested_level = if enabled && !args.is_empty() {
+        match crate::config::AutonomyLevel::parse(args) {
+            Some(level) if level != crate::config::AutonomyLevel::Off => Some(level),
+            _ => return "usage: /autonomy-on [observe|suggest|act]".to_string(),
+        }
+    } else {
+        None
     };
 
     let result = crate::api::config::mutate_agent_autonomy_level(
@@ -279,15 +287,21 @@ pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool) -> Str
         &deps.agent_id,
         move |current| {
             if enabled {
-                if current != crate::config::AutonomyLevel::Off {
+                if requested_level == Some(current)
+                    || (requested_level.is_none() && current != crate::config::AutonomyLevel::Off)
+                {
                     return Ok(crate::api::config::AutonomyLevelMutation::Unchanged);
                 }
-                let resume_level = settings.autonomy_resume_level().map_err(|error| {
-                    tracing::warn!(%error, "failed to read autonomy resume level");
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR
-                })?;
+                let resume_level = if requested_level.is_none() {
+                    settings.autonomy_resume_level().map_err(|error| {
+                        tracing::warn!(%error, "failed to read autonomy resume level");
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR
+                    })?
+                } else {
+                    None
+                };
                 Ok(crate::api::config::AutonomyLevelMutation::Set(
-                    autonomy_toggle_target(current, true, resume_level),
+                    autonomy_enable_target(current, requested_level, resume_level),
                 ))
             } else {
                 if current == crate::config::AutonomyLevel::Off {
@@ -313,18 +327,26 @@ pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool) -> Str
         deps.autonomy_control.request_check();
     }
     if enabled {
-        if change.previous != crate::config::AutonomyLevel::Off {
+        if change.previous == change.configured {
             return format!(
                 "autonomy is already enabled at {} (effective: {}).",
                 change.configured, change.effective
             );
         }
-        if change.configured == change.effective {
-            format!("autonomy enabled at {}.", change.configured)
+        let action = if change.previous == crate::config::AutonomyLevel::Off {
+            format!("autonomy enabled at {}", change.configured)
         } else {
             format!(
-                "autonomy enabled at {}; the instance ceiling limits it to {}.",
-                change.configured, change.effective
+                "autonomy changed from {} to {}",
+                change.previous, change.configured
+            )
+        };
+        if change.configured == change.effective {
+            format!("{action}.")
+        } else {
+            format!(
+                "{action}; the instance ceiling limits it to {}.",
+                change.effective
             )
         }
     } else if change.previous == crate::config::AutonomyLevel::Off {
@@ -337,13 +359,13 @@ pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool) -> Str
     }
 }
 
-fn autonomy_toggle_target(
+fn autonomy_enable_target(
     current: crate::config::AutonomyLevel,
-    enabled: bool,
+    requested_level: Option<crate::config::AutonomyLevel>,
     resume_level: Option<crate::config::AutonomyLevel>,
 ) -> crate::config::AutonomyLevel {
-    if !enabled {
-        return crate::config::AutonomyLevel::Off;
+    if let Some(requested_level) = requested_level {
+        return requested_level;
     }
     if current != crate::config::AutonomyLevel::Off {
         return current;
@@ -629,7 +651,7 @@ mod tests {
         use crate::config::AutonomyLevel;
 
         assert_eq!(
-            autonomy_toggle_target(AutonomyLevel::Off, true, None),
+            autonomy_enable_target(AutonomyLevel::Off, None, None),
             AutonomyLevel::Observe
         );
         for level in [
@@ -638,14 +660,14 @@ mod tests {
             AutonomyLevel::Act,
         ] {
             assert_eq!(
-                autonomy_toggle_target(AutonomyLevel::Off, true, Some(level)),
+                autonomy_enable_target(AutonomyLevel::Off, None, Some(level)),
                 level
             );
-            assert_eq!(autonomy_toggle_target(level, true, None), level);
             assert_eq!(
-                autonomy_toggle_target(level, false, Some(level)),
-                AutonomyLevel::Off
+                autonomy_enable_target(AutonomyLevel::Observe, Some(level), None),
+                level
             );
+            assert_eq!(autonomy_enable_target(level, None, None), level);
         }
     }
 

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -119,6 +119,9 @@ impl ControlPlane {
             ControlAction::SetHome => self.set_home().await,
             ControlAction::SetPause => set_pause(&self.deps, args),
             ControlAction::WhoAmI => whoami_text(self.is_authority, self.surface),
+            ControlAction::AutonomyStatus => autonomy_status(&self.deps).await,
+            ControlAction::AutonomyOn => set_autonomy_enabled(&self.deps, true).await,
+            ControlAction::AutonomyOff => set_autonomy_enabled(&self.deps, false).await,
         }
     }
 
@@ -237,6 +240,115 @@ impl ControlPlane {
 
         mode_confirmation(mode).to_string()
     }
+}
+
+/// `/autonomy` reply built from the same status snapshot as the HTTP API.
+pub async fn autonomy_status(deps: &crate::AgentDeps) -> String {
+    let ceiling = **deps.autonomy_ceiling.load();
+    match crate::api::autonomy::build_status(&deps.agent_id, deps, ceiling).await {
+        Ok(status) => {
+            let epoch = if status.current_run.is_some() {
+                "running"
+            } else {
+                "idle"
+            };
+            let next = status.next_run_at.as_deref().unwrap_or("none");
+            format!(
+                "autonomy\n- configured: {}\n- effective: {}\n- ceiling: {}\n- epoch: {epoch}\n- next run: {next}",
+                status.level, status.effective_level, ceiling
+            )
+        }
+        Err(error) => {
+            tracing::warn!(%error, agent = %deps.agent_id, "failed to read autonomy status");
+            "couldn't read autonomy status".to_string()
+        }
+    }
+}
+
+/// Toggle future autonomy epochs while preserving the last enabled level.
+pub async fn set_autonomy_enabled(deps: &crate::AgentDeps, enabled: bool) -> String {
+    let Some(api_state) = deps.api_state.as_ref() else {
+        return "autonomy settings aren't available — level unchanged".to_string();
+    };
+    let Some(settings) = deps.settings() else {
+        return "settings storage isn't available — autonomy unchanged".to_string();
+    };
+
+    let result = crate::api::config::mutate_agent_autonomy_level(
+        api_state,
+        &deps.agent_id,
+        move |current| {
+            if enabled {
+                if current != crate::config::AutonomyLevel::Off {
+                    return Ok(crate::api::config::AutonomyLevelMutation::Unchanged);
+                }
+                let resume_level = settings.autonomy_resume_level().map_err(|error| {
+                    tracing::warn!(%error, "failed to read autonomy resume level");
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR
+                })?;
+                Ok(crate::api::config::AutonomyLevelMutation::Set(
+                    autonomy_toggle_target(current, true, resume_level),
+                ))
+            } else {
+                if current == crate::config::AutonomyLevel::Off {
+                    return Ok(crate::api::config::AutonomyLevelMutation::Unchanged);
+                }
+                Ok(crate::api::config::AutonomyLevelMutation::Set(
+                    crate::config::AutonomyLevel::Off,
+                ))
+            }
+        },
+    )
+    .await;
+
+    let change = match result {
+        Ok(change) => change,
+        Err(error) => {
+            tracing::warn!(status = %error, agent = %deps.agent_id, "failed to persist autonomy toggle");
+            return "couldn't save autonomy setting — level unchanged".to_string();
+        }
+    };
+
+    if change.previous != change.configured {
+        deps.autonomy_control.request_check();
+    }
+    if enabled {
+        if change.previous != crate::config::AutonomyLevel::Off {
+            return format!(
+                "autonomy is already enabled at {} (effective: {}).",
+                change.configured, change.effective
+            );
+        }
+        if change.configured == change.effective {
+            format!("autonomy enabled at {}.", change.configured)
+        } else {
+            format!(
+                "autonomy enabled at {}; the instance ceiling limits it to {}.",
+                change.configured, change.effective
+            )
+        }
+    } else if change.previous == crate::config::AutonomyLevel::Off {
+        "autonomy is already off.".to_string()
+    } else {
+        format!(
+            "autonomy off. new epochs won't start; current autonomy work can finish. /autonomy-on restores {}.",
+            change.previous
+        )
+    }
+}
+
+fn autonomy_toggle_target(
+    current: crate::config::AutonomyLevel,
+    enabled: bool,
+    resume_level: Option<crate::config::AutonomyLevel>,
+) -> crate::config::AutonomyLevel {
+    if !enabled {
+        return crate::config::AutonomyLevel::Off;
+    }
+    if current != crate::config::AutonomyLevel::Off {
+        return current;
+    }
+    resume_level.unwrap_or(crate::config::AutonomyLevel::Observe)
 }
 
 /// Resolve a conversation into the canonical delivery target that reaches it.
@@ -510,6 +622,31 @@ mod tests {
             .count();
         assert!(authority.contains(&restricted.to_string()));
         assert!(everyone.contains(&restricted.to_string()));
+    }
+
+    #[test]
+    fn autonomy_enable_restores_the_last_level_or_observe() {
+        use crate::config::AutonomyLevel;
+
+        assert_eq!(
+            autonomy_toggle_target(AutonomyLevel::Off, true, None),
+            AutonomyLevel::Observe
+        );
+        for level in [
+            AutonomyLevel::Observe,
+            AutonomyLevel::Suggest,
+            AutonomyLevel::Act,
+        ] {
+            assert_eq!(
+                autonomy_toggle_target(AutonomyLevel::Off, true, Some(level)),
+                level
+            );
+            assert_eq!(autonomy_toggle_target(level, true, None), level);
+            assert_eq!(
+                autonomy_toggle_target(level, false, Some(level)),
+                AutonomyLevel::Off
+            );
+        }
     }
 
     #[test]

--- a/src/commands/dispatch.rs
+++ b/src/commands/dispatch.rs
@@ -165,7 +165,9 @@ pub async fn dispatch_inbound(
                 // over the network, and that stays on a spawned task.
                 ControlAction::SetResponseMode(_)
                 | ControlAction::SetHome
-                | ControlAction::SetPause => {
+                | ControlAction::SetPause
+                | ControlAction::AutonomyOn
+                | ControlAction::AutonomyOff => {
                     let reply = plane.execute(action, &parsed.args).await;
                     reply_ephemeral(messaging, deps, message, reply);
                 }
@@ -174,7 +176,8 @@ pub async fn dispatch_inbound(
                 ControlAction::Status
                 | ControlAction::Help
                 | ControlAction::AgentId
-                | ControlAction::WhoAmI => {
+                | ControlAction::WhoAmI
+                | ControlAction::AutonomyStatus => {
                     let messaging = messaging.clone();
                     let deps = deps.clone();
                     let target = message.clone();

--- a/src/commands/native.rs
+++ b/src/commands/native.rs
@@ -252,4 +252,22 @@ mod tests {
         });
         assert!(has_control && has_agent);
     }
+
+    #[test]
+    fn autonomy_controls_are_exposed_on_native_surfaces() {
+        let expected = ["autonomy", "autonomy-on", "autonomy-off"];
+        let (discord, _) = discord_commands();
+        let telegram = telegram_menu();
+        let slack = slack_subcommands();
+
+        for command in expected {
+            assert!(discord.iter().any(|spec| spec.name == command));
+            assert!(
+                telegram
+                    .iter()
+                    .any(|entry| entry.command == command.replace('-', "_"))
+            );
+            assert!(slack.iter().any(|spec| spec.name == command));
+        }
+    }
 }

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -177,6 +177,12 @@ pub enum ControlAction {
     SetPause,
     /// Report the sender's authority in this scope.
     WhoAmI,
+    /// Report the configured and effective autonomy levels.
+    AutonomyStatus,
+    /// Restore the most recently enabled autonomy level.
+    AutonomyOn,
+    /// Disable future autonomy epochs while current work settles.
+    AutonomyOff,
 }
 
 /// Agent-turn commands.
@@ -407,6 +413,39 @@ pub static COMMANDS: &[CommandDef] = &[
         availability: CommandAvailability::ALL,
     },
     CommandDef {
+        name: "autonomy",
+        description: "show configured and effective autonomy",
+        category: CommandCategory::Config,
+        aliases: &[],
+        args: ArgSpec::None,
+        handler: CommandHandler::Control(ControlAction::AutonomyStatus),
+        access: CommandAccess::Everyone,
+        busy: BusyPolicy::Queue,
+        availability: CommandAvailability::ALL,
+    },
+    CommandDef {
+        name: "autonomy-on",
+        description: "restore the last enabled autonomy level",
+        category: CommandCategory::Config,
+        aliases: &[],
+        args: ArgSpec::None,
+        handler: CommandHandler::Control(ControlAction::AutonomyOn),
+        access: CommandAccess::Authority,
+        busy: BusyPolicy::Queue,
+        availability: CommandAvailability::ALL,
+    },
+    CommandDef {
+        name: "autonomy-off",
+        description: "stop new autonomy epochs; current work settles",
+        category: CommandCategory::Config,
+        aliases: &[],
+        args: ArgSpec::None,
+        handler: CommandHandler::Control(ControlAction::AutonomyOff),
+        access: CommandAccess::Authority,
+        busy: BusyPolicy::Queue,
+        availability: CommandAvailability::ALL,
+    },
+    CommandDef {
         name: "active",
         description: "normal reply mode",
         category: CommandCategory::Response,
@@ -540,6 +579,20 @@ mod tests {
     }
 
     #[test]
+    fn autonomy_commands_have_separate_read_and_write_authority() {
+        let status = parsed(REGISTRY.parse("/autonomy"));
+        let enable = parsed(REGISTRY.parse("/autonomy-on"));
+        let disable = parsed(REGISTRY.parse("/autonomy-off"));
+
+        assert_eq!(status.def.access, CommandAccess::Everyone);
+        assert_eq!(enable.def.access, CommandAccess::Authority);
+        assert_eq!(disable.def.access, CommandAccess::Authority);
+        assert!(matches!(status.def.handler, CommandHandler::Control(_)));
+        assert!(matches!(enable.def.handler, CommandHandler::Control(_)));
+        assert!(matches!(disable.def.handler, CommandHandler::Control(_)));
+    }
+
+    #[test]
     fn parses_with_surrounding_whitespace() {
         let cmd = parsed(REGISTRY.parse("  /help  "));
         assert_eq!(cmd.def.name, "help");
@@ -670,13 +723,13 @@ mod tests {
     fn help_lists_every_command_exactly_once() {
         let help = REGISTRY.help_text();
         for def in COMMANDS {
-            let needle = format!("- /{}", def.name);
-            assert_eq!(
-                help.matches(&needle).count(),
-                1,
-                "help must list /{} exactly once",
-                def.name
-            );
+            let count = help
+                .lines()
+                .filter_map(|line| line.strip_prefix("- /"))
+                .filter_map(|line| line.split([' ', ':']).next())
+                .filter(|name| *name == def.name)
+                .count();
+            assert_eq!(count, 1, "help must list /{} exactly once", def.name);
         }
     }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -425,10 +425,10 @@ pub static COMMANDS: &[CommandDef] = &[
     },
     CommandDef {
         name: "autonomy-on",
-        description: "restore the last enabled autonomy level",
+        description: "enable autonomy at a level, or restore the last level",
         category: CommandCategory::Config,
         aliases: &[],
-        args: ArgSpec::None,
+        args: ArgSpec::Choice(&["observe", "suggest", "act"]),
         handler: CommandHandler::Control(ControlAction::AutonomyOn),
         access: CommandAccess::Authority,
         busy: BusyPolicy::Queue,
@@ -582,6 +582,7 @@ mod tests {
     fn autonomy_commands_have_separate_read_and_write_authority() {
         let status = parsed(REGISTRY.parse("/autonomy"));
         let enable = parsed(REGISTRY.parse("/autonomy-on"));
+        let enable_act = parsed(REGISTRY.parse("/autonomy-on ACT"));
         let disable = parsed(REGISTRY.parse("/autonomy-off"));
 
         assert_eq!(status.def.access, CommandAccess::Everyone);
@@ -590,6 +591,11 @@ mod tests {
         assert!(matches!(status.def.handler, CommandHandler::Control(_)));
         assert!(matches!(enable.def.handler, CommandHandler::Control(_)));
         assert!(matches!(disable.def.handler, CommandHandler::Control(_)));
+        assert_eq!(enable_act.args, "act");
+        assert!(matches!(
+            REGISTRY.parse("/autonomy-on unlimited"),
+            ParseResult::Usage(_, _)
+        ));
     }
 
     #[test]

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -219,10 +219,25 @@ impl RuntimeConfig {
         agent_id: &str,
         mcp_manager: &crate::mcp::McpManager,
     ) {
+        let Some((old_mcp, new_mcp)) = self.publish_config(config, agent_id) else {
+            return;
+        };
+        mcp_manager.reconcile(&old_mcp, &new_mcp).await;
+        tracing::info!(agent_id, "runtime config reloaded");
+    }
+
+    /// Publish reloadable local values and return the MCP delta for separate
+    /// reconciliation. Config writers use this while holding their file
+    /// transaction lock, then release it before any network work begins.
+    pub(crate) fn publish_config(
+        &self,
+        config: &Config,
+        agent_id: &str,
+    ) -> Option<(Vec<McpServerConfig>, Vec<McpServerConfig>)> {
         let agent = config.agents.iter().find(|a| a.id == agent_id);
         let Some(agent) = agent else {
             tracing::warn!(agent_id, "agent not found in reloaded config, skipping");
-            return;
+            return None;
         };
 
         let resolved = agent.resolve(&config.instance_dir, &config.defaults);
@@ -301,9 +316,7 @@ impl RuntimeConfig {
             );
         }
 
-        mcp_manager.reconcile(&old_mcp, &new_mcp).await;
-
-        tracing::info!(agent_id, "runtime config reloaded");
+        Some((old_mcp, new_mcp))
     }
 
     /// Reload identity files from disk.

--- a/src/messaging/discord.rs
+++ b/src/messaging/discord.rs
@@ -691,9 +691,9 @@ impl Handler {
             return;
         }
 
-        // Control replies resolve the deferral ephemerally; Agent commands
-        // defer publicly and the real response arrives through the normal
-        // message path.
+        // Acknowledge before resolving thread metadata through Discord's REST
+        // API. Parent lookup can be slow, but interactions must be deferred
+        // within three seconds.
         let is_control = crate::commands::REGISTRY
             .resolve(&command.data.name)
             .is_some_and(|def| matches!(def.handler, crate::commands::CommandHandler::Control(_)));
@@ -707,6 +707,35 @@ impl Handler {
         if let Err(error) = command.create_response(&ctx.http, defer).await {
             tracing::warn!(%error, command = %command.data.name, "failed to defer slash command");
             return;
+        }
+
+        let parent_channel_id = if command.guild_id.is_some() {
+            command
+                .channel_id
+                .to_channel(&ctx.http)
+                .await
+                .ok()
+                .and_then(|channel| channel.guild().and_then(|channel| channel.parent_id))
+                .map(|parent_id| parent_id.get())
+        } else {
+            None
+        };
+        if let Some(guild_id) = command.guild_id
+            && let Some(allowed_channels) = permissions.channel_filter.get(&guild_id.get())
+            && !allowed_channels.is_empty()
+        {
+            let direct_match = allowed_channels.contains(&command.channel_id.get());
+            let parent_match = !direct_match
+                && parent_channel_id.is_some_and(|parent_id| allowed_channels.contains(&parent_id));
+            if !discord_channel_is_allowed(allowed_channels, command.channel_id.get(), parent_match)
+            {
+                let edit = EditInteractionResponse::new()
+                    .content("this command isn't available in this channel");
+                if let Err(error) = command.edit_response(&ctx.http, edit).await {
+                    tracing::warn!(%error, command = %command.data.name, "failed to resolve denied slash command");
+                }
+                return;
+            }
         }
 
         let interaction_id = command.id.to_string();
@@ -748,6 +777,12 @@ impl Handler {
             metadata.insert(
                 "discord_guild_id".into(),
                 serde_json::Value::Number(guild_id.get().into()),
+            );
+        }
+        if let Some(parent_channel_id) = parent_channel_id {
+            metadata.insert(
+                "discord_parent_channel_id".into(),
+                serde_json::Value::Number(parent_channel_id.into()),
             );
         }
         // A command invocation addresses the bot directly.
@@ -861,10 +896,10 @@ impl EventHandler for Handler {
                 .get("discord_parent_channel_id")
                 .and_then(|v| v.as_u64());
 
-            let direct_match = allowed_channels.contains(&message.channel_id.get());
             let parent_match = parent_channel_id.is_some_and(|pid| allowed_channels.contains(&pid));
 
-            if !direct_match && !parent_match {
+            if !discord_channel_is_allowed(allowed_channels, message.channel_id.get(), parent_match)
+            {
                 return;
             }
         }
@@ -1003,6 +1038,14 @@ impl EventHandler for Handler {
             );
         }
     }
+}
+
+fn discord_channel_is_allowed(
+    allowed_channels: &[u64],
+    channel_id: u64,
+    parent_matches: bool,
+) -> bool {
+    allowed_channels.contains(&channel_id) || parent_matches
 }
 
 /// Discord application-command field limits (CHAT_INPUT).
@@ -1759,6 +1802,14 @@ fn build_poll(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn native_commands_share_message_channel_admission() {
+        let allowed = vec![10, 20];
+        assert!(discord_channel_is_allowed(&allowed, 10, false));
+        assert!(discord_channel_is_allowed(&allowed, 30, true));
+        assert!(!discord_channel_is_allowed(&allowed, 30, false));
+    }
     use crate::{Button, ButtonStyle, Card, CardField, InteractiveElements, Poll};
 
     #[test]

--- a/src/messaging/mattermost.rs
+++ b/src/messaging/mattermost.rs
@@ -659,7 +659,7 @@ impl Messaging for MattermostAdapter {
         let channel_id = self.extract_channel_id(message)?;
 
         match response {
-            OutboundResponse::Text(text) => {
+            OutboundResponse::Text(text) | OutboundResponse::Ephemeral { text, .. } => {
                 self.stop_typing(channel_id).await;
                 // Use root_id for threading: prefer mattermost_root_id (when triggered from a
                 // threaded message) or REPLY_TO_MESSAGE_ID (set by channel.rs for branch/worker
@@ -1209,7 +1209,12 @@ fn build_message_from_post(
     // Thread-reply-to-bot detection is handled asynchronously in the WS event
     // handler and may upgrade this to true after this function returns.
     let is_dm = post.channel_type.as_deref() == Some("D");
+    let is_command = matches!(
+        crate::commands::REGISTRY.parse(&post.message),
+        crate::commands::ParseResult::Command(_) | crate::commands::ParseResult::Usage(_, _)
+    );
     let mentions_bot = is_dm
+        || is_command
         || (!context.bot_username.is_empty()
             && post.message.contains(&format!("@{}", context.bot_username)));
     metadata.insert(
@@ -1805,6 +1810,21 @@ mod tests {
                 .get("mattermost_mentions_or_replies_to_bot")
                 .and_then(|v| v.as_bool()),
             Some(false),
+        );
+    }
+
+    #[test]
+    fn recognized_command_counts_as_direct_invocation() {
+        let mut post = post("user1", "chan1", Some("O"));
+        post.message = "/autonomy".into();
+        let message =
+            build_message_from_mattermost_post(&post, "bot", Some("team1"), &no_filters()).unwrap();
+        assert_eq!(
+            message
+                .metadata
+                .get("mattermost_mentions_or_replies_to_bot")
+                .and_then(serde_json::Value::as_bool),
+            Some(true)
         );
     }
 

--- a/src/messaging/slack.rs
+++ b/src/messaging/slack.rs
@@ -430,6 +430,38 @@ fn resolve_slack_subcommand(
         .filter(|def| def.availability.on(crate::commands::Surface::Slack))
 }
 
+fn validate_slack_subcommand_args(
+    command: &str,
+    def: &crate::commands::CommandDef,
+    args: &str,
+) -> Result<String, String> {
+    use crate::commands::ArgSpec;
+
+    let args = args.trim();
+    let usage = || {
+        let suffix = def
+            .args
+            .hint()
+            .map(|hint| format!(" {hint}"))
+            .unwrap_or_default();
+        format!("usage: {command} {}{suffix}", def.name)
+    };
+    match def.args {
+        ArgSpec::None if !args.is_empty() => Err(usage()),
+        ArgSpec::Required(_) if args.is_empty() => Err(usage()),
+        ArgSpec::Choice(options)
+            if !args.is_empty()
+                && !options
+                    .iter()
+                    .any(|option| option.eq_ignore_ascii_case(args)) =>
+        {
+            Err(usage())
+        }
+        ArgSpec::Choice(_) => Ok(args.to_ascii_lowercase()),
+        ArgSpec::None | ArgSpec::Optional(_) | ArgSpec::Required(_) => Ok(args.to_string()),
+    }
+}
+
 /// Handle Slack slash command events (e.g. `/ask What is the weather?`).
 ///
 /// Slack requires an acknowledgement within 3 seconds. This handler acks
@@ -527,6 +559,15 @@ async fn handle_command_event(
             response_type: Some(SlackMessageResponseType::Ephemeral),
         });
     };
+    let args = match validate_slack_subcommand_args(&command_str, def, &args) {
+        Ok(args) => args,
+        Err(usage) => {
+            return Ok(SlackCommandEventResponse {
+                content: SlackMessageContent::new().with_text(usage),
+                response_type: Some(SlackMessageResponseType::Ephemeral),
+            });
+        }
+    };
 
     let base_conversation_id = format!("slack:{}:{}", team_id, channel_id);
     let conversation_id =
@@ -557,6 +598,7 @@ async fn handle_command_event(
         "slack_user_mention".into(),
         serde_json::Value::String(format!("<@{}>", user_id)),
     );
+    metadata.insert("slack_mentions_or_replies_to_bot".into(), true.into());
 
     let content = MessageContent::Command {
         name: def.name.to_string(),
@@ -1736,6 +1778,19 @@ fn resolve_slack_user_identity(user: &SlackUser, user_id: &str) -> SlackUserIden
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn slack_subcommands_validate_no_argument_commands() {
+        let def = crate::commands::REGISTRY.resolve("autonomy-off").unwrap();
+        assert_eq!(
+            validate_slack_subcommand_args("/spacebot", def, "typo"),
+            Err("usage: /spacebot autonomy-off".to_string())
+        );
+        assert_eq!(
+            validate_slack_subcommand_args("/spacebot", def, ""),
+            Ok(String::new())
+        );
+    }
 
     #[test]
     fn slack_subcommands_resolve_only_when_available_on_slack() {

--- a/src/messaging/telegram.rs
+++ b/src/messaging/telegram.rs
@@ -1434,7 +1434,7 @@ mod tests {
             Some("spacebot")
         ));
         assert!(telegram_command_addresses_bot(
-            "/autonomy_on@spacebot",
+            "/autonomy_on@spacebot act",
             Some("spacebot")
         ));
         assert!(!telegram_command_addresses_bot(

--- a/src/messaging/telegram.rs
+++ b/src/messaging/telegram.rs
@@ -987,6 +987,12 @@ fn build_metadata(
     // Matches the pattern used by Discord/Slack/Twitch adapters.
     let mut mentions_or_replies_to_bot = false;
 
+    if let Some(text) = extract_text(message)
+        && telegram_command_addresses_bot(&text, bot_username.as_deref())
+    {
+        mentions_or_replies_to_bot = true;
+    }
+
     // Check text-based @mention in message text/caption.
     // Uses a word-boundary check so "@spacebot" doesn't match "@spacebot_extra".
     if let Some(bot_username) = bot_username {
@@ -1056,6 +1062,13 @@ fn build_metadata(
     );
 
     (metadata, formatted_author)
+}
+
+fn telegram_command_addresses_bot(text: &str, bot_username: Option<&str>) -> bool {
+    matches!(
+        crate::commands::REGISTRY.parse_addressed(text, bot_username),
+        crate::commands::ParseResult::Command(_) | crate::commands::ParseResult::Usage(_, _)
+    )
 }
 
 /// Build a display name from a Telegram user, preferring full name.
@@ -1413,6 +1426,26 @@ async fn send_formatted(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recognized_commands_address_the_receiving_bot() {
+        assert!(telegram_command_addresses_bot(
+            "/autonomy",
+            Some("spacebot")
+        ));
+        assert!(telegram_command_addresses_bot(
+            "/autonomy_on@spacebot",
+            Some("spacebot")
+        ));
+        assert!(!telegram_command_addresses_bot(
+            "/autonomy@other_bot",
+            Some("spacebot")
+        ));
+        assert!(!telegram_command_addresses_bot(
+            "/unknown",
+            Some("spacebot")
+        ));
+    }
 
     #[test]
     fn bold() {

--- a/src/settings/store.rs
+++ b/src/settings/store.rs
@@ -245,6 +245,37 @@ impl SettingsStore {
         Ok(())
     }
 
+    fn remove_raw(&self, key: &str) -> Result<()> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| SettingsError::WriteFailed {
+                key: key.to_string(),
+                details: error.to_string(),
+            })?;
+        {
+            let mut table = write_txn.open_table(SETTINGS_TABLE).map_err(|error| {
+                SettingsError::WriteFailed {
+                    key: key.to_string(),
+                    details: error.to_string(),
+                }
+            })?;
+            table
+                .remove(key)
+                .map_err(|error| SettingsError::WriteFailed {
+                    key: key.to_string(),
+                    details: error.to_string(),
+                })?;
+        }
+        write_txn
+            .commit()
+            .map_err(|error| SettingsError::WriteFailed {
+                key: key.to_string(),
+                details: error.to_string(),
+            })?;
+        Ok(())
+    }
+
     /// Get the worker log mode setting.
     pub fn worker_log_mode(&self) -> WorkerLogMode {
         match self.get_raw(WORKER_LOG_MODE_KEY) {
@@ -395,6 +426,10 @@ impl SettingsStore {
         self.set_raw(AUTONOMY_RESUME_LEVEL_KEY, level.as_str())
     }
 
+    pub(crate) fn clear_autonomy_resume_level(&self) -> Result<()> {
+        self.remove_raw(AUTONOMY_RESUME_LEVEL_KEY)
+    }
+
     /// Drop the home channel, returning the instance to sending nothing on
     /// its own.
     pub fn clear_home_channel(&self) -> Result<()> {
@@ -444,6 +479,8 @@ mod tests {
                 .set_autonomy_resume_level(crate::config::AutonomyLevel::Off)
                 .is_err()
         );
+        store.clear_autonomy_resume_level().unwrap();
+        assert_eq!(store.autonomy_resume_level().unwrap(), None);
     }
 
     #[test]

--- a/src/settings/store.rs
+++ b/src/settings/store.rs
@@ -25,6 +25,8 @@ const HOME_CHANNEL_EXPLICIT_KEY: &str = "home_channel_explicit";
 const PAUSED_KEY: &str = "paused";
 /// Operator-supplied reason shown wherever the pause surfaces.
 const PAUSE_REASON_KEY: &str = "pause_reason";
+/// Last non-off autonomy level selected before autonomy was disabled.
+const AUTONOMY_RESUME_LEVEL_KEY: &str = "autonomy_resume_level";
 
 /// How worker execution logs are stored.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -370,6 +372,29 @@ impl SettingsStore {
         }
     }
 
+    /// The non-off autonomy level restored by `/autonomy-on`.
+    pub fn autonomy_resume_level(&self) -> Result<Option<crate::config::AutonomyLevel>> {
+        let Some(value) = self.get_optional(AUTONOMY_RESUME_LEVEL_KEY)? else {
+            return Ok(None);
+        };
+        match crate::config::AutonomyLevel::parse(&value) {
+            Some(crate::config::AutonomyLevel::Off) | None => {
+                Err(SettingsError::Other(format!("invalid autonomy resume level: {value}")).into())
+            }
+            Some(level) => Ok(Some(level)),
+        }
+    }
+
+    /// Remember a non-off autonomy level for the next enable command.
+    pub fn set_autonomy_resume_level(&self, level: crate::config::AutonomyLevel) -> Result<()> {
+        if level == crate::config::AutonomyLevel::Off {
+            return Err(
+                SettingsError::Other("autonomy resume level cannot be off".to_string()).into(),
+            );
+        }
+        self.set_raw(AUTONOMY_RESUME_LEVEL_KEY, level.as_str())
+    }
+
     /// Drop the home channel, returning the instance to sending nothing on
     /// its own.
     pub fn clear_home_channel(&self) -> Result<()> {
@@ -394,5 +419,41 @@ impl SettingsStore {
 impl std::fmt::Debug for SettingsStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SettingsStore").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn autonomy_resume_level_round_trips_and_rejects_off() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let store = SettingsStore::new(&directory.path().join("settings.redb")).expect("store");
+
+        assert_eq!(store.autonomy_resume_level().unwrap(), None);
+        store
+            .set_autonomy_resume_level(crate::config::AutonomyLevel::Suggest)
+            .unwrap();
+        assert_eq!(
+            store.autonomy_resume_level().unwrap(),
+            Some(crate::config::AutonomyLevel::Suggest)
+        );
+        assert!(
+            store
+                .set_autonomy_resume_level(crate::config::AutonomyLevel::Off)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn invalid_autonomy_resume_level_fails_closed() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let store = SettingsStore::new(&directory.path().join("settings.redb")).expect("store");
+        store
+            .set_raw(AUTONOMY_RESUME_LEVEL_KEY, "unlimited")
+            .unwrap();
+
+        assert!(store.autonomy_resume_level().is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Add `/autonomy` for public status and authority-only `/autonomy-on` and `/autonomy-off` controls.
- Restore the last non-off level when autonomy is enabled, with `observe` as the first-use fallback.
- Serialize level changes with epoch and heartbeat admission so turning autonomy off stops new work while the current epoch settles.
- Keep configured and effective levels distinct when the instance ceiling applies.
- Register the controls across Discord, Telegram, and Slack, with text-command parity for other adapters.
- Align Discord thread admission, Telegram addressing, Slack argument validation, and Mattermost command replies.

## Lifecycle

Autonomy transitions and supervisor admission share one lock. An off transition cannot race a new epoch or heartbeat claim. Existing turns and owned workers are not cancelled, but no additional wake events or heartbeat work enter the active epoch after the transition commits.

This PR is stacked on #650.

## Testing

- `cargo test agent::autonomy::tests`
- `cargo test api::config::tests`
- `cargo test commands::`
- Targeted Discord, Slack, Telegram, Mattermost, and settings tests
- `just preflight`
- `just gate-pr`